### PR TITLE
compilation fix: don't use deprecatedAVCODEC_MAX_AUDIO_FRAME_SIZE

### DIFF
--- a/src/algorithms/io/audioloader.cpp
+++ b/src/algorithms/io/audioloader.cpp
@@ -148,8 +148,8 @@ void AudioLoader::openAudioFile(const string& filename) {
         _audioConvert = av_audio_convert_alloc(AV_SAMPLE_FMT_S16, 1, _audioCtx->sample_fmt, 1, NULL, 0);
 
         // reserve some more space
-        _buff1 = (int16_t*)av_malloc(AVCODEC_MAX_AUDIO_FRAME_SIZE * 3);
-        _buff2 = (int16_t*)av_malloc(AVCODEC_MAX_AUDIO_FRAME_SIZE * 3);
+        _buff1 = (int16_t*)av_malloc(MAX_AUDIO_FRAME_SIZE * 3);
+        _buff2 = (int16_t*)av_malloc(MAX_AUDIO_FRAME_SIZE * 3);
 
 #endif
 

--- a/src/algorithms/io/audioloader.h
+++ b/src/algorithms/io/audioloader.h
@@ -24,6 +24,7 @@
 #include "network.h"
 #include "ffmpegapi.h"
 
+#define MAX_AUDIO_FRAME_SIZE 192000
 
 namespace essentia {
 namespace streaming {
@@ -35,11 +36,11 @@ class AudioLoader : public Algorithm {
   AbsoluteSource<int> _channels;
   int _nChannels;
 
-  // AVCODEC_MAX_AUDIO_FRAME_SIZE is in bytes, we want FFMPEG_BUFFER_SIZE in sample units
+  // MAX_AUDIO_FRAME_SIZE is in bytes, we want FFMPEG_BUFFER_SIZE in sample units
   // we also multiply by 2 to get some margin, because we might want to decode multiple frames
   // in this buffer (all the frames contained in a packet, which can be more than 1 as in flac),
   // and each time we decode a frame we need to have at least a full buffer of free space.
-  const static int FFMPEG_BUFFER_SIZE = (AVCODEC_MAX_AUDIO_FRAME_SIZE / sizeof(int16_t)) * 2;
+  const static int FFMPEG_BUFFER_SIZE = (MAX_AUDIO_FRAME_SIZE / sizeof(int16_t)) * 2;
 
   int16_t* _buffer;
   int _dataSize;


### PR DESCRIPTION
Hi there,
I came across the following compile error:

```
~essentia/src/algorithms/io/audioloader.h:42:42: error: ‘AVCODEC_MAX_AUDIO_FRAME_SIZE’ was not declared in this scope
```

it seems that the AVCODEC_MAX_AUDIO_FRAME_SIZE macro is deprecated, ffmpeg(ffmpeg 2.0.1) on my platform(may be the latest version) doesn't support it any more.

ref: http://ffmpeg.org/pipermail/ffmpeg-cvslog/2012-August/053785.html
