### PR TITLE
Corrected overly strict bounds check

### DIFF
--- a/src/essentia/utils/ringbufferimpl.h
+++ b/src/essentia/utils/ringbufferimpl.h
@@ -218,7 +218,7 @@ class RingBufferImpl {
     int size = _available;
     if (size > outputSize) size = outputSize;
 
-    assert(size < _bufferSize);
+    assert(size <= _bufferSize);
     if (_readIndex + size > _bufferSize)
     {
       int n = _bufferSize - _readIndex;


### PR DESCRIPTION
I'm pretty sure this assertion is too strict: it should be possible to read a buffer up to the last sample, no?