### PR TITLE
Fix issue #122: compilation with --with-cpptests fails on Linux Mint

### DIFF
--- a/wscript
+++ b/wscript
@@ -121,7 +121,7 @@ def build(ctx):
 
     if ctx.env.WITH_CPPTESTS:
         # missing -lpthread flag on Ubuntu
-        if platform.dist()[0] == 'Ubuntu':
+        if platform.dist()[0] in ['Ubuntu', 'LinuxMint']:
             ext_paths = ['/usr/lib/i386-linux-gnu', '/usr/lib/x86_64-linux-gnu']
             ctx.read_shlib('pthread', paths=ext_paths)
             ctx.env.USES += ' pthread'


### PR DESCRIPTION
wscript detects Ubuntu and add 'pthread' to libs, but the test didn't include Linux Mint (which is heavily based on Ubuntu).

https://github.com/MTG/essentia/issues/122