### PR TITLE
Allow only specific examples to be compiled

### DIFF
--- a/src/examples/wscript
+++ b/src/examples/wscript
@@ -5,8 +5,76 @@ import distutils.sysconfig
 import os
 import sys
 
+# This is a list of 1- or 2-tuples. The first element is the name of
+# the source file (less the .cpp extension) and is also used as the
+# binary name. The second element (if it exists) is a list of
+# additional files for the extractor
+example_sources = [
+        ('standard_beatsmarker', ),
+        ('standard_mfcc', ),
+        ('standard_onsetrate', ),
+        ('standard_pitchyinfft', ),
+        ('standard_fadedetection', ),
+        ('standard_spectralcontrast', ),
+        ('standard_rhythmtransform', ),
+
+        ('streaming_extractor',
+                 [ 'streaming_extractorutils',
+                   'streaming_extractortonal',
+                   'streaming_extractorlowlevel',
+                   'streaming_extractorbeattrack',
+                   'streaming_extractorsfx',
+                   'streaming_extractorpanning',
+                   'streaming_extractorpostprocess' ]),
+
+        ('streaming_extractor_short_sounds',
+                 [ 'streaming_extractorutils',
+                   'streaming_extractormetadata',
+                   'streaming_extractortonal',
+                   'streaming_extractorlowlevel',
+                   'streaming_extractorsfx',
+                   'streaming_extractorpanning',
+                   'streaming_extractorpostprocess' ]),
+
+        ('streaming_extractor_music',
+                 [ 'extractor_music/MusicExtractor',
+                   'extractor_music/MusicLowlevelDescriptors',
+                   'extractor_music/MusicRhythmDescriptors',
+                   'extractor_music/MusicTonalDescriptors' ]),
+
+        ('streaming_beatsmarker', ),
+        ('streaming_mfcc', ),
+        ('streaming_gfcc', ),
+        ('streaming_rhythmextractor_multifeature', ),
+        ('streaming_beattracker_multifeature_mirex2013', ),
+        ('streaming_onsetrate', ),
+        ('streaming_panning', ),
+        ('streaming_tuningfrequency', ),
+        ('streaming_key', ),
+        ('streaming_pitchyinfft', ),
+        ('streaming_predominantmelody', ),
+        ('streaming_md5', ),
+
+        ('streaming_extractor_freesound',
+                 [ 'freesound/FreesoundExtractor',
+                   'freesound/FreesoundLowlevelDescriptors',
+                   'freesound/FreesoundRhythmDescriptors',
+                   'freesound/FreesoundTonalDescriptors',
+                   'freesound/FreesoundSfxDescriptors' ])
+]
+
 
 def configure(ctx):
+    example_list = [p[0] for p in example_sources]
+    if ctx.env.WITH_EXAMPLES:
+        ctx.env.EXAMPLE_LIST = example_list
+    if ctx.env.EXAMPLES:
+        for e in ctx.env.EXAMPLES.split(","):
+            e = e.strip()
+            if e not in example_list:
+                raise ctx.errors.ConfigurationError("Specified example [%s] does not exist" % e)
+            ctx.env.EXAMPLE_LIST.append(e)
+
     if ctx.env.WITH_STATIC_EXAMPLES:
         ctx.env.LINKFLAGS = ['-static', '-pthread']
         ctx.env.SHLIB_MARKER = '-Wl,-Bstatic'
@@ -44,92 +112,31 @@ def configure(ctx):
                         'openjpeg', 'mp3lame', 'vpx', 'gsm', 'z', 'bz2' ]
 
 
-def adjust(objs, path):
-    return [ '%s/%s' % (path, obj) for obj in objs ]
-
-
 def build(ctx):
     print('→ building from ' + ctx.path.abspath())
 
-    if ctx.env.WITH_EXAMPLES:
-        def build_example(prefix, prog_name, other=None):
-            files = [ '%s_%s.cpp' % (prefix, f) for f in [prog_name] + (other or []) ]
+    if len(ctx.env.EXAMPLE_LIST):
+        def build_example(prog_name, other=None):
+            files = ['%s.cpp' % f for f in [prog_name] + (other or [])]
 
-            ctx.program(source = ctx.path.ant_glob(' '.join(files)),
-                        target = '%s_%s' % (prefix, prog_name),
-                        includes = [ '.', '..' ],
+            # If an `other` program has files in a directory we need
+            # to add an aditional includes
+            includes = [ '.', '..' ]
+            if any((len(x.split("/")) > 1 for x in other or [])):
+                includes.append("../..")
+
+            ctx.program(source  = ctx.path.ant_glob(' '.join(files)),
+                        target  = prog_name,
+                        includes = includes,
                         use      = 'essentia ' + ctx.env.USES,
                         install_path = None)
 
-
-        build_example('standard', 'beatsmarker')
-        build_example('standard', 'mfcc')
-        build_example('standard', 'onsetrate')
-        build_example('standard', 'pitchyinfft')
-        build_example('standard', 'fadedetection')
-        build_example('standard', 'spectralcontrast')
-        build_example('standard', 'rhythmtransform')
-
-        build_example('streaming', 'extractor',
-                                 [ 'extractorutils',
-                                   'extractortonal',
-                                   'extractorlowlevel',
-                                   'extractorbeattrack',
-                                   'extractorsfx',
-                                   'extractorpanning',
-                                   'extractorpostprocess' ])
-
-        build_example('streaming', 'extractor_short_sounds',
-                                 [ 'extractorutils',
-                                   'extractormetadata',
-                                   'extractortonal',
-                                   'extractorlowlevel',
-                                   'extractorsfx',
-                                   'extractorpanning',
-                                   'extractorpostprocess' ])
-
-        
-        music_files = [ 'streaming_extractor_music.cpp',
-                            'extractor_music/MusicExtractor.cpp',
-                            'extractor_music/MusicLowlevelDescriptors.cpp',
-                            'extractor_music/MusicRhythmDescriptors.cpp',
-                            'extractor_music/MusicTonalDescriptors.cpp'
-        ]
-        
-        ctx.program(source = ctx.path.ant_glob(' '.join(music_files)),
-                        target = 'streaming_extractor_music',
-                        includes = [ '.', '..' ,'../..'],
-                        use      = 'essentia ' + ctx.env.USES,
-                        install_path = None)
-
-        build_example('streaming', 'beatsmarker')
-        build_example('streaming', 'mfcc')
-        build_example('streaming', 'gfcc')
-        build_example('streaming', 'rhythmextractor_multifeature')
-        build_example('streaming', 'beattracker_multifeature_mirex2013')
-        build_example('streaming', 'onsetrate')
-        build_example('streaming', 'panning')
-        build_example('streaming', 'tuningfrequency')
-        build_example('streaming', 'key')
-        build_example('streaming', 'pitchyinfft')
-        build_example('streaming', 'predominantmelody')
-        build_example('streaming', 'md5')
-        
-        freesound_files = [ 'streaming_extractor_freesound.cpp',
-			     'freesound/FreesoundExtractor.cpp',
-			     'freesound/FreesoundLowlevelDescriptors.cpp',
-			     'freesound/FreesoundRhythmDescriptors.cpp',
-			     'freesound/FreesoundTonalDescriptors.cpp',
-			     'freesound/FreesoundSfxDescriptors.cpp'
-	    ]
-
-        ctx.program(source = ctx.path.ant_glob(' '.join(freesound_files)),
-                        target = 'streaming_extractor_freesound',
-                        includes = [ '.', '..' ,'../..'],
-                        use      = 'essentia ' + ctx.env.USES,
-                        install_path = None)
-
-
+        for e in example_sources:
+            if e[0] in ctx.env.EXAMPLE_LIST:
+                if len(e) == 1:
+                    build_example(e[0])
+                elif len(e) == 2:
+                    build_example(e[0], e[1])
 
     if ctx.env.WITH_VAMP:
         ctx.env.INCLUDES += [ '3rdparty/vamp-plugin-sdk-2.4' ]

--- a/src/wscript
+++ b/src/wscript
@@ -12,6 +12,9 @@ def options(ctx):
     ctx.add_option('--with-examples', action='store_true',
                    dest='WITH_EXAMPLES', default=False,
                    help='build the example programs')
+    ctx.add_option('--with-example', action='store',
+                   dest='EXAMPLES', default=False,
+                   help='example programs to build (comma separated, without .cpp)')
     ctx.add_option('--with-static-examples', action='store_true',
                    dest='WITH_STATIC_EXAMPLES', default=False,
                    help='build the example programs as static executables (WARNING: only works on debian wheezy with custom-compiled ffmpeg)')
@@ -41,8 +44,10 @@ def configure(ctx):
     ctx.env.WITH_PYTHON   = ctx.options.WITH_PYTHON
     ctx.env.WITH_VAMP     = ctx.options.WITH_VAMP
     ctx.env.WITH_STATIC_EXAMPLES = ctx.options.WITH_STATIC_EXAMPLES
+    ctx.env.EXAMPLES       = ctx.options.EXAMPLES
+    ctx.env.EXAMPLE_LIST   = []
 
-    if ctx.env.WITH_STATIC_EXAMPLES:
+    if ctx.env.WITH_STATIC_EXAMPLES and not ctx.env.EXAMPLES:
         ctx.env.WITH_EXAMPLES = True
 
     ctx.env.ALGOIGNORE = []
@@ -50,7 +55,7 @@ def configure(ctx):
 
 
     ctx.check_cfg(package='libavcodec', uselib_store='AVCODEC',
-                  args=['libavcodec >= 53.25.0', '--cflags', '--libs'], 
+                  args=['libavcodec >= 53.25.0', '--cflags', '--libs'],
                   msg='Checking for \'libavcodec\' >= 53.25.0',
                   mandatory=False)
 
@@ -65,17 +70,17 @@ def configure(ctx):
 
     if ctx.env.WITH_STATIC_EXAMPLES:
         #print('Static examples incompatible with TagLib, skipping TagLib detection...')
-        print('Static examples incompatible with Gaia, skipping Gaia detection...')   
+        print('Static examples incompatible with Gaia, skipping Gaia detection...')
     else:
         #ctx.check_cfg(package='taglib', uselib_store='TAGLIB',
-        #              args=['taglib >= 1.9', '--cflags', '--libs'], 
+        #              args=['taglib >= 1.9', '--cflags', '--libs'],
         #              msg='Checking for \'taglib\' >= 1.9',
         #              mandatory=False)
         ctx.check_cfg(package='gaia2', uselib_store='GAIA2',
                       args=['--cflags', '--libs'], mandatory=False)
 
     ctx.check_cfg(package='taglib', uselib_store='TAGLIB',
-                  args=['taglib >= 1.9', '--cflags', '--libs'], 
+                  args=['taglib >= 1.9', '--cflags', '--libs'],
                   msg='Checking for \'taglib\' >= 1.9',
                   mandatory=False)
 
@@ -99,7 +104,7 @@ def configure(ctx):
     ctx.check_cfg(package='samplerate', uselib_store='SAMPLERATE',
                   args=['--cflags', '--libs'])
 
-    if ctx.env.WITH_EXAMPLES or ctx.env.WITH_VAMP:
+    if ctx.env.WITH_EXAMPLES or ctx.env.EXAMPLES or ctx.env.WITH_VAMP:
         ctx.recurse('examples')
 
     if ctx.env.WITH_PYTHON:
@@ -165,6 +170,11 @@ def configure(ctx):
         print('  The following algorithms will be ignored: %s\n' % algos)
         ctx.env.ALGOIGNORE += algos
 
+    lel = len(ctx.env.EXAMPLE_LIST)
+    if lel:
+        print('- Compiling %s example%s' % (lel, "" if lel == 1 else "s"))
+        print('  %s' % ", ".join(ctx.env.EXAMPLE_LIST))
+
 
     print('=======================================================================================')
 
@@ -185,7 +195,7 @@ def build(ctx):
 
     # get list of available algorithms
     from utils.algorithms_info import get_all_algorithms, create_registration_cpp, create_version_h
-    
+
     algos = get_all_algorithms(ctx.path.find_dir('algorithms').abspath(),
                                root_dir = ctx.path.abspath())
 
@@ -251,7 +261,7 @@ def build(ctx):
     ctx.install_files('${PREFIX}/lib/pkgconfig', '../essentia.pc')
 
 
-    if ctx.env.WITH_EXAMPLES or ctx.env.WITH_VAMP:
+    if ctx.env.EXAMPLE_LIST or ctx.env.WITH_VAMP:
         ctx.recurse('examples')
 
     if ctx.env.WITH_PYTHON:


### PR DESCRIPTION
In order to not change the existing behaviour of --with-examples,
this adds a new option that you can use instead:

  ./waf configure --with-example standard_mfcc,streaming_gfcc

Will build only the specified examples. You can specify one or more.
To compile all examples, use

  ./waf configure --with-examples

as before. If we are happy to change the behaviour of this option we
could require an argument such as 'all' to compile all examples.
optparse does not support an option that can have an optional argument,
so we cannot keep the existing behaviour.
