### PR TITLE
RT mode and 32/64/FAT added

### DIFF
--- a/src/wscript
+++ b/src/wscript
@@ -24,7 +24,9 @@ def options(ctx):
     ctx.add_option('--with-gaia', action='store_true',
                    dest='WITH_GAIA', default=False,
                    help='build with Gaia support')
-
+    ctx.add_option('--realtime-libs', action='store_true',
+                   dest='WITH_RT', default=False,
+                   help='include only fftw and taglib for lighter realtime environement')
 
 def debian_version():
     try:
@@ -46,6 +48,7 @@ def configure(ctx):
     ctx.env.WITH_VAMP     = ctx.options.WITH_VAMP
     ctx.env.WITH_STATIC_EXAMPLES = ctx.options.WITH_STATIC_EXAMPLES
     ctx.env.WITH_GAIA     = ctx.options.WITH_GAIA
+    ctx.env.WITH_RT       = ctx.options.WITH_RT    
     ctx.env.EXAMPLES       = ctx.options.EXAMPLES
     ctx.env.EXAMPLE_LIST   = []
     ctx.env.ALGOIGNORE = []
@@ -53,30 +56,35 @@ def configure(ctx):
     if ctx.env.WITH_STATIC_EXAMPLES and not ctx.env.EXAMPLES:
         ctx.env.WITH_EXAMPLES = True
 
-    ctx.check_cfg(package='libavcodec', uselib_store='AVCODEC',
-                  args=['libavcodec >= 53.25.0', '--cflags', '--libs', '--modversion'],
-                  msg='Checking for \'libavcodec\' >= 53.25.0',
-                  mandatory=False)
-    
-    ctx.check_cfg(package='libavformat', uselib_store='AVFORMAT',
-                  args=['--cflags', '--libs', '--modversion'], mandatory=False)
+    if ctx.env.WITH_RT :
+        print("")
+        print("=======================RealTime Mode : Ignoring ALL libraries except FFTW =======================")
+        print("")
+    else :
+        ctx.check_cfg(package='libavcodec', uselib_store='AVCODEC',
+                      args=['libavcodec >= 53.25.0', '--cflags', '--libs', '--modversion'],
+                      msg='Checking for \'libavcodec\' >= 53.25.0',
+                      mandatory=False)
+        
+        ctx.check_cfg(package='libavformat', uselib_store='AVFORMAT',
+                      args=['--cflags', '--libs', '--modversion'], mandatory=False)
 
-    ctx.check_cfg(package='libavutil', uselib_store='AVUTIL',
-                  args=['--cflags', '--libs', '--modversion'], mandatory=False)
+        ctx.check_cfg(package='libavutil', uselib_store='AVUTIL',
+                      args=['--cflags', '--libs', '--modversion'], mandatory=False)
 
-    ctx.check_cfg(package='libswresample', uselib_store='SWRESAMPLE',
-                  args=['--cflags', '--libs', '--modversion'], mandatory=False)
+        ctx.check_cfg(package='libswresample', uselib_store='SWRESAMPLE',
+                      args=['--cflags', '--libs', '--modversion'], mandatory=False)
+
+        ctx.check_cfg(package='samplerate', uselib_store='SAMPLERATE',
+                      args=['--cflags', '--libs', '--modversion'])
+
+        ctx.check_cfg(package='taglib', uselib_store='TAGLIB',
+                      args=['taglib >= 1.9', '--cflags', '--libs', '--modversion'],
+                      msg='Checking for \'taglib\' >= 1.9',
+                      mandatory=False)
 
     ctx.check_cfg(package='fftw3f', uselib_store='FFTW',
-                  args=['--cflags', '--libs', '--modversion'])
-
-    ctx.check_cfg(package='samplerate', uselib_store='SAMPLERATE',
-                  args=['--cflags', '--libs', '--modversion'])
-
-    ctx.check_cfg(package='taglib', uselib_store='TAGLIB',
-                  args=['taglib >= 1.9', '--cflags', '--libs', '--modversion'],
-                  msg='Checking for \'taglib\' >= 1.9',
-                  mandatory=False)
+                  args=['--cflags', '--libs', '--modversion'])    
 
     if ctx.env.WITH_GAIA:
         ctx.check_cfg(package='gaia2', uselib_store='GAIA2',
@@ -90,11 +98,12 @@ def configure(ctx):
     debver = debian_version()
     is_squeeze = (debver and debver[0] < 7)
 
-    if is_squeeze:
-        ctx.env.LINKFLAGS += [ '-lyaml' ]
-    else:
-        ctx.check_cfg(package='yaml-0.1', uselib_store='YAML',
-                      args=['--cflags', '--libs', '--modversion'])
+    if not ctx.env.WITH_RT :
+        if is_squeeze:
+            ctx.env.LINKFLAGS += [ '-lyaml' ]
+        else:
+            ctx.check_cfg(package='yaml-0.1', uselib_store='YAML',
+                          args=['--cflags', '--libs', '--modversion'])
 
     if ctx.env.WITH_EXAMPLES or ctx.env.EXAMPLES or ctx.env.WITH_VAMP:
         ctx.recurse('examples')
@@ -112,7 +121,10 @@ def configure(ctx):
         return ('HAVE_%s' % name.upper()) in ctx.env['define_key']
 
     # these are mandatory dependencies
-    ctx.env.USES = 'FFTW YAML'
+    if ctx.env.WITH_RT:
+        ctx.env.USES = 'FFTW'
+    else:
+        ctx.env.USES = 'FFTW YAML'
 
     algos = [ 'AudioLoader', 'MonoLoader', 'EqloudLoader', 'EasyLoader', 'MonoWriter', 'AudioWriter' ]
     if has('avcodec') and has('avformat') and has('avutil'):
@@ -171,7 +183,10 @@ def configure(ctx):
 
     print('=======================================================================================')
 
-
+    #The ignore list for RT mode
+    if ctx.env.WITH_RT:
+        ctx.env.ALGOIGNORE = [ 'AudioLoader', 'MonoLoader', 'EqloudLoader', 'EasyLoader', 'MonoWriter', 'AudioWriter', 'Resample', 'MetadataReader', 'GaiaTransform', 'YamlInput', 'YamlOutput']
+        
 from waflib.Task import Task
 class BuildAlgoReg(Task):
     def run(self):
@@ -205,7 +220,6 @@ def build(ctx):
     # create version.h header file
     create_version_h('src/version.h', ctx.env.VERSION, ctx.env.GIT_SHA)
 
-
     # create algorithms registration file
     algoreg_path = 'src/algorithms/essentia_algorithms_reg.cpp'
     create_registration_cpp(algos, algoreg_path, use_streaming=True)
@@ -215,6 +229,12 @@ def build(ctx):
     # do not compile audiocontext.cpp if we're not compiling ffmpeg
     if 'AVCODEC' not in ctx.env.USES:
         sources = [ s for s in sources if 'audiocontext' not in str(s) ]
+
+    # do not compile anything with yaml if it's realtime
+    if ctx.env.WITH_RT:
+        sources = [ s for s in sources if 'yaml' not in str(s) ]
+        sources = [ s for s in sources if 'jsonconvert' not in str(s) ]
+        print sources
 
     # add all algorithms found in the algorithms/ folder
     sources += [ ctx.path.find_resource('algorithms/essentia_algorithms_reg.cpp') ]
@@ -226,9 +246,13 @@ def build(ctx):
                          'essentia/streaming/algorithms', 'essentia/utils',
                          '3rdparty' ]
 
+    if ctx.env.WITH_RT:
+        targetName = 'essentia_rt'
+    else:
+        targetName = 'essentia'
     ctx.stlib(
         source   = sources,
-        target   = 'essentia',
+        target   = targetName,
         use      = ctx.env.USES,
         install_path = '${PREFIX}/lib',
         #includes = ctx.env.includes

--- a/wscript
+++ b/wscript
@@ -36,6 +36,10 @@ def options(ctx):
                    dest='MODE', default="release",
                    help='debug or release')
 
+    ctx.add_option('--arch', action='store',
+                   dest='ARCH', default="x64",
+                   help='i386, x64 or FAT')
+                                      
     ctx.add_option('--cross-compile-mingw32', action='store_true',
                    dest='CROSS_COMPILE_MINGW32', default=False,
                    help='cross-compile for windows using mingw32 on linux')
@@ -92,6 +96,15 @@ def configure(ctx):
         # add /usr/local/include as the brew formula for yaml doesn't have
         # the cflags properly set
         #ctx.env.CXXFLAGS += [ '-I/usr/local/include' ]
+
+        if ctx.options.ARCH == 'i386':
+            ctx.env.CXXFLAGS += [ '-arch' , 'i386']
+            ctx.env.LINKFLAGS += [ '-arch', 'i386']
+            ctx.env.LDFLAGS = ['-arch', 'i386']
+        if ctx.options.ARCH == 'FAT':
+            ctx.env.CXXFLAGS += [ '-arch' , 'i386', '-arch', 'x86_64']
+            ctx.env.LINKFLAGS += [ '-arch' , 'i386', '-arch', 'x86_64']
+            ctx.env.LDFLAGS = [ '-arch' , 'i386', '-arch', 'x86_64']        
 
     #elif sys.platform == 'win32':
     #    # compile libgcc and libstd statically when using MinGW


### PR DESCRIPTION
This adds a --realtime-libs option which enables the installation of a "lightweight" version of Essentia with everything omitted except for FFTW. It outputs the library name "libessentia_rt.a" so the user can have the full version installed also.

Another option --arch=i386, x86_64, FAT allows Mac users to install the 32-bit/64-bit and universal versions of the library provided the dependencies are appropriate. This is useful as some applications like Pd-Extended and plugin formats like VST still exist as 32-bit.
