### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/essentia/config.h
+++ b/src/essentia/config.h
@@ -116,6 +116,8 @@
 #else
 #  if defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
 #    define OS_MAC
+#  elif defined(__FreeBSD__)
+#    define OS_FREEBSD
 #  else
 #    define OS_LINUX
 #  endif

--- a/src/essentia/roguevector.h
+++ b/src/essentia/roguevector.h
@@ -98,7 +98,7 @@ void RogueVector<T>::setSize(size_t size) {
 
 
 // Mac implementation
-#elif defined (OS_MAC)
+#elif defined (OS_MAC) || defined(OS_FREEBSD)
 
 // TODO: this is a big hack that relies on clang/libcpp not changing the memory
 //       layout of the std::vector (very dangerous, but works for now...)


### PR DESCRIPTION
This change enables essentia and examples to compile on FreeBSD. Besides roguevector.h, the other sticking point is atomic.h, which compiles fine if you pass in -std=c++11 and bypass the OS specific implementations.