### PR TITLE
Fix syntax error on using libswresample

### DIFF
--- a/src/essentia/utils/audiocontext.cpp
+++ b/src/essentia/utils/audiocontext.cpp
@@ -31,7 +31,7 @@ AudioContext::AudioContext()
 #if HAVE_AVRESAMPLE
     , _convertCtxAv(0)
 #elif HAVE_SWRESAMPLE
-    , _convertCtx(0),
+    , _convertCtx(0)
 #endif
               {
   //av_log_set_level(AV_LOG_VERBOSE);


### PR DESCRIPTION
Ubuntu 14.04
libswresample 1.1.100

Hi
src/essentia/utils/audiocontext.cpp has syntax error if using libswresample.
