### PR TITLE
don't force SSE instructions on ARM

### DIFF
--- a/wscript
+++ b/wscript
@@ -59,7 +59,9 @@ def configure(ctx):
     # force using SSE floating point (default for 64bit in gcc) instead of
     # 387 floating point (used for 32bit in gcc) to avoid numerical differences
     # between 32 and 64bit builds (see https://github.com/MTG/essentia/issues/179)
-    ctx.env.CXXFLAGS += [ '-msse', '-msse2', '-mfpmath=sse' ]
+    # Don't force SSE on ARM platforms, though
+    if not 'arm' in platform.machine().lower():
+        ctx.env.CXXFLAGS += [ '-msse', '-msse2', '-mfpmath=sse' ]
 
     # define this to be stricter, but sometimes some libraries can give problems...
     #ctx.env.CXXFLAGS += [ '-Werror' ]


### PR DESCRIPTION
The fix for https://github.com/MTG/essentia/issues/179 forces SSE instructions to make sure outputs on i386 and x86_64 are the same. However, this breaks compilation on ARM platforms, as SSE is an intel-specific instruction set.

This patch only forces SSE instructions when not on ARM. Theoretically, the correct way would probably be to check whether one is on an intel platform (rather than not on ARM), but there are multiple possibilities for intel hardware, and I don't have hardware to test them all. Furthermore, it seems like the result of platform.machine() can be i386, x86, x86_64, AMD64, and maybe something I've missed, so it's probably to check if it is not ARM.