### PR TITLE
Separated Network::run into runPrepare and runStep

### DIFF
--- a/src/essentia/scheduler/network.h
+++ b/src/essentia/scheduler/network.h
@@ -110,7 +110,26 @@ class Network {
 
   ~Network();
 
+  /**
+   * Executes all the algorithms in the network until all the tokens given by
+   * the source generator are processed by all the algorithms.
+   *
+   * Internally it just calls runPrepare and then runStep repeatedly.
+   */
   void run();
+
+  /**
+   * Does the preparation needed to process the tokens of the network
+   */
+  void runPrepare();
+
+  /**
+   * Processes all tokens generated with one call of process() on the
+   * generator.
+   *
+   * Returns False if there are no more tokens to process.
+   */
+  bool runStep();
 
   /**
    * Rebuilds the visible and execution network.


### PR DESCRIPTION
This way one can only sort the network once, and then run just a step in
the analysis and analyze audio in real time.

It might be useful to include the algorithms I wrote that just generate input from a buffer in memory (so the buffer can change with new audio data and runStep can be called again) and an algorithm that outputs to a given place in memory, for the same reason.