### PR TITLE
fix wrong behaviour of harmonicpeaks 

### DIFF
--- a/src/algorithms/tonal/harmonicpeaks.cpp
+++ b/src/algorithms/tonal/harmonicpeaks.cpp
@@ -104,7 +104,7 @@ void HarmonicPeaks::compute() {
     int harmonicNumber = round(ratio);
 
     Real distance = abs(ratio - harmonicNumber);
-    if (distance <= _ratioTolerance && ratio <= _ratioMax) { 
+    if (distance <= _ratioTolerance && ratio <= _ratioMax && harmonicNumber>0) {
       if (candidates[harmonicNumber-1].first == -1 || 
             distance < candidates[harmonicNumber-1].second) {
         // first occured candidate or a better candidate for harmonic


### PR DESCRIPTION
was accessing to negative array index when if spectralpeaks had frequencies < f0/2

it  concern all key related algorithms (HPCP ...)!
I still don't understand how now error was thrown from this badAccess