### PR TITLE
Android build

### DIFF
--- a/build_android.sh
+++ b/build_android.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+export PATH=~/Dev/android/toolchain/bin:$PATH
+./waf clean
+./waf configure --cross-compile-android --lightweight= --fft=KISS --ignore-algos=LPC;
+./waf

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-export PATH=~/Dev/android/toolchain/bin:$PATH
-./waf clean
-./waf configure --cross-compile-android --lightweight= --fft=KISS --ignore-algos=LPC;
-./waf
+export PATH=~/Dev/android/toolchain/bin:$PATH;
+./waf clean;
+./waf configure --cross-compile-android --lightweight= --fft=KISS --ignore-algos=LPC --prefix=/Users/carthach/Dev/android/modules/essentia;
+./waf;
+./waf install;

--- a/src/algorithms/temporal/lpc.cpp
+++ b/src/algorithms/temporal/lpc.cpp
@@ -39,12 +39,12 @@ const char* LPC::description = DOC("This algorithm computes the Linear Predictiv
 
 
 void LPC::configure() {
-  _P = parameter("order").toInt();
+  _p = parameter("order").toInt();
 
   delete _correlation;
   if (parameter("type").toString() == "warped") {
     _correlation = AlgorithmFactory::create("WarpedAutoCorrelation",
-                                            "maxLag", _P+1);
+                                            "maxLag", _p+1);
     _correlation->output("warpedAutoCorrelation").set(_r);
   }
   else {
@@ -59,30 +59,30 @@ void LPC::compute() {
   vector<Real>& lpc = _lpc.get();
   vector<Real>& reflection = _reflection.get();
 
-  if (_P > (int)signal.size()) {
+  if (_p > (int)signal.size()) {
     throw EssentiaException("LPC: you can't compute more coefficients than the size of your input");
   }
 
   if (isSilent(signal)) {
-    lpc = vector<Real>(_P+1, 0.0);
-    reflection = vector<Real>(_P, 0.0);
+    lpc = vector<Real>(_p+1, 0.0);
+    reflection = vector<Real>(_p, 0.0);
     return;
   }
 
-  lpc.resize(_P+1);
-  reflection.resize(_P);
+  lpc.resize(_p+1);
+  reflection.resize(_p);
 
   _correlation->input("array").set(signal);
   _correlation->compute();
 
   // Levinson-Durbin algorithm
-  vector<Real> temp(_P);
+  vector<Real> temp(_p);
 
   Real k;
   Real E = _r[0];
   lpc[0] = 1;
 
-  for (int i=1; i<(_P+1); i++) {
+  for (int i=1; i<(_p+1); i++) {
     k = _r[i];
 
     for (int j=1; j<i; j++) {

--- a/src/algorithms/temporal/lpc.h
+++ b/src/algorithms/temporal/lpc.h
@@ -33,7 +33,7 @@ class LPC : public Algorithm {
   Output<std::vector<Real> > _reflection;
   Algorithm* _correlation;
   std::vector<Real> _r;
-  int _P;
+  int _p;
 
  public:
   LPC() : _correlation(0) {

--- a/wscript
+++ b/wscript
@@ -44,6 +44,10 @@ def options(ctx):
                    dest='CROSS_COMPILE_MINGW32', default=False,
                    help='cross-compile for windows using mingw32 on linux')
 
+    ctx.add_option('--cross-compile-android', action='store_true',
+                   dest='CROSS_COMPILE_ANDROID', default=False,
+                   help='cross-compile for Android using toolchain')    
+
 
 def configure(ctx):
     print('→ configuring the project in ' + ctx.path.abspath())
@@ -59,7 +63,8 @@ def configure(ctx):
     # force using SSE floating point (default for 64bit in gcc) instead of
     # 387 floating point (used for 32bit in gcc) to avoid numerical differences
     # between 32 and 64bit builds (see https://github.com/MTG/essentia/issues/179)
-    ctx.env.CXXFLAGS += [ '-msse', '-msse2', '-mfpmath=sse' ]
+    if not ctx.options.CROSS_COMPILE_ANDROID:
+        ctx.env.CXXFLAGS += [ '-msse', '-msse2', '-mfpmath=sse' ]
 
     # define this to be stricter, but sometimes some libraries can give problems...
     #ctx.env.CXXFLAGS += [ '-Werror' ]
@@ -148,6 +153,12 @@ def configure(ctx):
             distutils.dir_util.copy_tree(win_path + "/" + lib + "/include", tdm_include)
             distutils.dir_util.copy_tree(win_path + "/" + lib + "/lib", tdm_lib)
 
+    if ctx.options.CROSS_COMPILE_ANDROID:
+        ctx.find_program('arm-linux-androideabi-gcc', var='CC')
+        ctx.find_program('arm-linux-androideabi-g++', var='CXX')
+        ctx.find_program('arm-linux-androideabi-ar', var='AR')
+
+        print ("→ Cross-compiling for Android ARM")
 
     # use manually prebuilt dependencies in the case of static examples or mingw cross-build
     if ctx.options.CROSS_COMPILE_MINGW32:


### PR DESCRIPTION
This adds support for compiling on android.

An example of how to build using a lightweight version of Android (with the KISS FFT) is in the 
./build_android.sh

Update the PATH to point to where you have your Android Standalone Toolchain:-
https://developer.android.com/ndk/guides/standalone_toolchain.html

I would suggest creating a customised toolchain (as suggested in on that webpage) using the make-standalone-toolchain.sh script.