### PR TITLE
Fix memory leak in RhythmExtractor2013

### DIFF
--- a/src/algorithms/rhythm/onsetdetectionglobal.h
+++ b/src/algorithms/rhythm/onsetdetectionglobal.h
@@ -82,6 +82,11 @@ class OnsetDetectionGlobal : public Algorithm {
     if (_frameCutter) delete _frameCutter;
     if (_windowing) delete _windowing;
     if (_spectrum) delete _spectrum;
+    if (_fft) delete _fft;
+    if (_cartesian2polar) delete _cartesian2polar;
+    if (_movingAverage) delete _movingAverage;
+    if (_erbbands) delete _erbbands;
+    if (_autocorrelation) delete _autocorrelation;
   }
 
   void declareParameters() {


### PR DESCRIPTION
I found a big memory leak for the RhythmExtractor2013 which was related with the missing deletion of referenced algorithms in OnsetDetectionGlobal. Also RhythmExtractor2013 and BeatTrackerMultiFeature do not apply correctly the network->clear() principles.