### PR TITLE
Updates iOS build settings for bitcode and x86_64

### DIFF
--- a/wscript
+++ b/wscript
@@ -188,12 +188,16 @@ def configure(ctx):
         ctx.env.CXXFLAGS += ['-stdlib=libc++']
         ctx.env.CXXFLAGS += ['-miphoneos-version-min=5.0']    
         ctx.env.CXXFLAGS += [ '-isysroot' , '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
+        ctx.env.CXXFLAGS += [ '-fembed-bitcode']
 
     if ctx.options.CROSS_COMPILE_IOS_SIM:
         print ("→ Cross-compiling for iOS Simulator (i386)")
         ctx.env.CXXFLAGS += [ '-arch' , 'i386']        
         ctx.env.LINKFLAGS += [ '-arch', 'i386']
         ctx.env.LDFLAGS += ['-arch', 'i386']        
+        ctx.env.CXXFLAGS += [ '-arch' , 'x86_64']        
+        ctx.env.LINKFLAGS += [ '-arch', 'x86_64']
+        ctx.env.LDFLAGS += ['-arch', 'x86_64']        
                     
         ctx.env.CXXFLAGS += ['-stdlib=libc++']
         ctx.env.CXXFLAGS += ['-miphoneos-version-min=5.0']    


### PR DESCRIPTION
XCode 7 projects default to using bitcode and require all libraries to also be built with bitcode support. This pull request enables bitcode support via the `-fembed-bitcode` compiler flag.

Additionally on modern systems the iOS simulator uses `x86_64` architecture, which is now added to the build flags.