### PR TITLE
Changes for Visual Studio compilation

### DIFF
--- a/src/algorithms/rhythm/tempotapdegara.cpp
+++ b/src/algorithms/rhythm/tempotapdegara.cpp
@@ -26,6 +26,11 @@ using namespace std;
 namespace essentia {
 namespace standard {
 
+const Real TempoTapDegara::_alpha = 0.5;
+const Real TempoTapDegara::_sigma_ibi = 0.025;
+
+const int TempoTapDegara::_numberCombs = 4;
+const Real TempoTapDegara::_frameDurationODF = 5.944308390022676;
 
 const char* TempoTapDegara::name = "TempoTapDegara";
 const char* TempoTapDegara::description = DOC("This algorithm estimates beat positions given an onset detection function.  The detection function is partitioned into 6-second frames with a 1.5-second increment, and the autocorrelation is computed for each frame, and is weighted by a tempo preference curve [2]. Periodicity estimations are done frame-wisely, searching for the best match with the Viterbi algorith [3]. The estimated periods are then passed to the probabilistic beat tracking algorithm [1], which computes beat positions.\n"

--- a/src/algorithms/rhythm/tempotapdegara.h
+++ b/src/algorithms/rhythm/tempotapdegara.h
@@ -64,8 +64,8 @@ class TempoTapDegara : public Algorithm {
  private:
   // Davies' beat periods estimation:
   int _smoothingWindowHalfSize;
-  static const int _numberCombs = 4;
-  static const Real _frameDurationODF = 5.944308390022676;
+  static const int _numberCombs;
+  static const Real _frameDurationODF;
   Real _sampleRateODF;
   int _hopSizeODF;
   Real _hopDurationODF;
@@ -92,8 +92,8 @@ class TempoTapDegara : public Algorithm {
   void adaptiveThreshold(std::vector<Real>& array, int smoothingHalfSize);
 
   // Degara's beat tracking from periods:
-  static const Real _alpha = 0.5; // decoding weighting parameter
-  static const Real _sigma_ibi = 0.025; // std of the inter-beat interval pdf,
+  static const Real _alpha;// decoding weighting parameter
+  static const Real _sigma_ibi; // std of the inter-beat interval pdf,
                                        // models potential variations in the
                                        // inter-beat interval in secs.
   int _numberStates;    // number HMM states

--- a/src/algorithms/rhythm/tempotapmaxagreement.cpp
+++ b/src/algorithms/rhythm/tempotapmaxagreement.cpp
@@ -24,6 +24,11 @@ using namespace std;
 using namespace essentia;
 using namespace standard;
 
+const Real TempoTapMaxAgreement::_phaseThreshold = 0.175;
+const Real TempoTapMaxAgreement::_periodThreshold = 0.175;
+const Real TempoTapMaxAgreement::_minTickTime = 5.;
+const int TempoTapMaxAgreement::_numberBins = 40;
+
 const char* TempoTapMaxAgreement::name = "TempoTapMaxAgreement";
 const char* TempoTapMaxAgreement::description = DOC("This algorithm estimates beat positions and confidence of their estimation based on the maximum mutual agreement between given beat postion candidates, estimated by different beat trackers (or using different features) [1,2].\n"
 "\n"

--- a/src/algorithms/rhythm/tempotapmaxagreement.h
+++ b/src/algorithms/rhythm/tempotapmaxagreement.h
@@ -53,8 +53,8 @@ class TempoTapMaxAgreement : public Algorithm {
   static const char* description;
 
  private:
-  static const Real _minTickTime = 5.;  // ignore peaks before this time [s]
-  static const int _numberBins = 40; // number of histogram bins for information gain method
+  static const Real _minTickTime;  // ignore peaks before this time [s]
+  static const int _numberBins; // number of histogram bins for information gain method
                                      // corresponds to Log2(40) = 5.32 maximum
                                      // confidence value
 
@@ -62,8 +62,8 @@ class TempoTapMaxAgreement : public Algorithm {
   std::vector<Real> _binValues;
 
   // parameters for the continuity-based method
-  static const Real _phaseThreshold = 0.175; // size of tolerance window for beat phase
-  static const Real _periodThreshold = 0.175; // size of tolerance window for beat period
+  static const Real _phaseThreshold; // size of tolerance window for beat phase
+  static const Real _periodThreshold; // size of tolerance window for beat period
 
   Real computeBeatInfogain(std::vector<Real>& ticks1, std::vector<Real>& ticks2);
 

--- a/src/algorithms/temporal/loudnessebur128filter.cpp
+++ b/src/algorithms/temporal/loudnessebur128filter.cpp
@@ -19,6 +19,7 @@
 
 #include "loudnessebur128filter.h"
 #include "algorithmfactory.h"
+#include "essentiamath.h"
 
 using namespace std;
 

--- a/src/essentia/algorithmfactory.h
+++ b/src/essentia/algorithmfactory.h
@@ -243,7 +243,7 @@ namespace streaming {
 
 } // namespace essentia
 
-#if ESSENTIA_EXPORTS
+#if (ESSENTIA_EXPORTS == 1 && defined(OS_WIN32)) || !defined(OS_WIN32)
 // include implementation, because the factory is now templated
 #include "algorithmfactory_impl.h"
 

--- a/src/essentia/algorithmfactory.h
+++ b/src/essentia/algorithmfactory.h
@@ -243,8 +243,10 @@ namespace streaming {
 
 } // namespace essentia
 
-
+#if ESSENTIA_EXPORTS
 // include implementation, because the factory is now templated
 #include "algorithmfactory_impl.h"
+
+#endif
 
 #endif // ESSENTIA_ALGORITHMFACTORY_H

--- a/src/essentia/connector.h
+++ b/src/essentia/connector.h
@@ -37,7 +37,7 @@ class Algorithm;
  * and is aware (through TypeProxy) of which type of data is supposed to flow
  * through it.
  */
-class Connector : public TypeProxy, public StreamConnector {
+class ESSENTIA_API Connector : public TypeProxy, public StreamConnector {
  protected:
   Algorithm* _parent;
 

--- a/src/essentia/debugging.h
+++ b/src/essentia/debugging.h
@@ -59,7 +59,7 @@ const char* debugModuleDescription(DebuggingModule module);
 /**
  * A bitmask representing which debug levels are currently activated.
  */
-extern int activatedDebugLevels;
+extern int ESSENTIA_API activatedDebugLevels;
 
 extern bool infoLevelActive;
 extern bool warningLevelActive;
@@ -102,7 +102,7 @@ void setDebugLevelForTimeIndex(int index);
 /**
  * Asynchronous thread-safe logger object. (TODO: implementation is still not thread-safe)
  */
-class Logger {
+class ESSENTIA_API Logger {
  protected:
   std::deque<std::string> _msgQueue;
   bool _addHeader;
@@ -119,7 +119,7 @@ class Logger {
 
 };
 
-extern Logger loggerInstance;
+extern Logger ESSENTIA_API loggerInstance;
 
 } // namespace essentia
 

--- a/src/essentia/essentia.h
+++ b/src/essentia/essentia.h
@@ -43,11 +43,11 @@ extern const char* version_git_sha;
  * "human-readable" representations. You need to call this function before
  * doing anything with essentia.
  */
-void init();
+void ESSENTIA_API init();
 
-bool isInitialized();
+bool ESSENTIA_API isInitialized();
 
-void shutdown();
+void ESSENTIA_API shutdown();
 
 namespace standard {
   /**

--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -24,6 +24,7 @@
 #define _USE_MATH_DEFINES
 #endif
 
+#include <math.h>
 #include <cmath>
 #include <vector>
 #include <numeric>

--- a/src/essentia/parameter.h
+++ b/src/essentia/parameter.h
@@ -279,7 +279,7 @@ class ParameterMap : public EssentiaMap<std::string, Parameter, string_cmp> {
   typedef EssentiaMap<std::string, Parameter, string_cmp> ParameterMapBase;
 
  public:
-  void add(const std::string& name, const Parameter& value);
+  void ESSENTIA_API add(const std::string& name, const Parameter& value);
 
   const Parameter& operator[](const std::string& key) const;
   Parameter& operator[](const std::string& key);

--- a/src/essentia/roguevector.h
+++ b/src/essentia/roguevector.h
@@ -77,7 +77,6 @@ void RogueVector<T>::setSize(size_t size) {
 #elif defined(OS_WIN32)
 
 // TODO probably outdated, as we want to use MINGW
-/*
 template <typename T>
 void RogueVector<T>::setData(T* data) { this->_Myfirst = data; }
 
@@ -86,8 +85,8 @@ void RogueVector<T>::setSize(size_t size) {
   this->_Mylast = this->_Myfirst + size;
   this->_Myend = this->_Myfirst + size;
 }
-*/
 
+/*
 // TODO just a copy-paste from OS_LINUX version
 template <typename T>
 void RogueVector<T>::setData(T* data) { this->_M_impl._M_start = data; }
@@ -97,7 +96,7 @@ void RogueVector<T>::setSize(size_t size) {
   this->_M_impl._M_finish = this->_M_impl._M_start + size;
   this->_M_impl._M_end_of_storage = this->_M_impl._M_start + size;
 }
-
+*/
 
 // Linux implementation
 #elif defined(OS_LINUX)

--- a/src/essentia/scheduler/network.h
+++ b/src/essentia/scheduler/network.h
@@ -95,7 +95,7 @@ typedef std::stack<NetworkNode*> NodeStack;
  * generator node at the root of the Network (an audio loader, usually) and
  * carry the data through all the other algorithms automatically.
  */
-class Network {
+class ESSENTIA_API Network {
 
  public:
   /**

--- a/src/essentia/streaming/algorithms/devnull.h
+++ b/src/essentia/streaming/algorithms/devnull.h
@@ -76,7 +76,7 @@ enum DevNullConnector {
  * Connect a source (eg: the output of an algorithm) to a DevNull, so the data
  * the source outputs does not block the whole processing.
  */
-void connect(SourceBase& source, DevNullConnector devnull);
+void ESSENTIA_API connect(SourceBase& source, DevNullConnector devnull);
 
 inline void operator>>(SourceBase& source, DevNullConnector devnull) {
   connect(source, devnull);
@@ -86,7 +86,7 @@ inline void operator>>(SourceBase& source, DevNullConnector devnull) {
 /**
  * Disconnect a source (eg: the output of an algorithm) from a DevNull.
  */
-void disconnect(SourceBase& source, DevNullConnector devnull);
+void ESSENTIA_API disconnect(SourceBase& source, DevNullConnector devnull);
 
 } // namespace streaming
 } // namespace essentia

--- a/src/essentia/streaming/algorithms/poolstorage.h
+++ b/src/essentia/streaming/algorithms/poolstorage.h
@@ -142,7 +142,7 @@ class PoolStorage : public PoolStorageBase {
  * Connect a source (eg: the output of an algorithm) to a Pool, and use the given
  * name as an identifier in the Pool.
  */
-void connect(SourceBase& source, Pool& pool,
+void ESSENTIA_API connect(SourceBase& source, Pool& pool,
              const std::string& descriptorName);
 
 class PoolConnector {

--- a/src/essentia/streaming/phantombuffer_impl.h
+++ b/src/essentia/streaming/phantombuffer_impl.h
@@ -134,13 +134,13 @@ void PhantomBuffer<T>::releaseForWrite(int released) {
   // replicate from the beginning to the phantom zone if necessary
   if (_writeWindow.begin < _phantomSize) {
     T* first  = &_buffer[_writeWindow.begin];
-    T* last   = &_buffer[std::min(_writeWindow.begin + released, _phantomSize)];
+    T* last   = &_buffer[(std::min)(_writeWindow.begin + released, _phantomSize)];
     T* result = &_buffer[_writeWindow.begin + _bufferSize];
     fastcopy(result, first, last-first);
   }
   // replicate from the phantom zone to the beginning if necessary
   else if (_writeWindow.end > _bufferSize) {
-    int beginIdx = std::max(_writeWindow.begin, (int)_bufferSize);
+    int beginIdx = (std::max)(_writeWindow.begin, (int)_bufferSize);
     T* first  = &_buffer[beginIdx];
     T* last   = &_buffer[_writeWindow.end];
     T* result = &_buffer[beginIdx - _bufferSize];
@@ -234,7 +234,7 @@ int PhantomBuffer<T>::availableForRead(ReaderID id) const {
         << " final: " << min(theoretical, contiguous));
   */
 
-  return std::min(theoretical, contiguous);
+  return (std::min)(theoretical, contiguous);
 }
 
 /**
@@ -259,7 +259,7 @@ int PhantomBuffer<T>::availableForWrite(bool contiguous) const {
   // that the write window should not overtake.
   for (uint i=0; i<_readWindow.size(); i++) {
     const Window& w = _readWindow[i];
-    minTotal = std::min(minTotal, w.total(_bufferSize));
+    minTotal = (std::min)(minTotal, w.total(_bufferSize));
   }
 
   int theoretical = minTotal - _writeWindow.total(_bufferSize) + _bufferSize;
@@ -268,7 +268,7 @@ int PhantomBuffer<T>::availableForWrite(bool contiguous) const {
   }
 
   int ncontiguous = _bufferSize + _phantomSize - _writeWindow.begin;
-  return std::min(theoretical, ncontiguous);
+  return (std::min)(theoretical, ncontiguous);
 }
 
 // reposition pointer if we're in the phantom zone

--- a/src/essentia/streaming/sinkbase.h
+++ b/src/essentia/streaming/sinkbase.h
@@ -32,11 +32,11 @@ class SourceBase;
 class Algorithm;
 
 
-void connect(SourceBase& source, SinkBase& sink);
-void disconnect(SourceBase& source, SinkBase& sink);
+void ESSENTIA_API connect(SourceBase& source, SinkBase& sink);
+void ESSENTIA_API disconnect(SourceBase& source, SinkBase& sink);
 
-void attach(SinkProxyBase& proxy, SinkBase& innerSink);
-void detach(SinkProxyBase& proxy, SinkBase& innerSink);
+void ESSENTIA_API attach(SinkProxyBase& proxy, SinkBase& innerSink);
+void ESSENTIA_API detach(SinkProxyBase& proxy, SinkBase& innerSink);
 
 
 /**
@@ -49,7 +49,7 @@ void detach(SinkProxyBase& proxy, SinkBase& innerSink);
  * the template being the token type). Look at the Sink implementation for more
  * information.
  */
-class SinkBase : public Connector {
+class ESSENTIA_API SinkBase : public Connector {
  protected:
   SourceBase* _source;
   ReaderID _id; // ID to use to identify this reader for the source (to know which reader is requesting tokens, etc...)

--- a/src/essentia/streaming/sinkproxy.h
+++ b/src/essentia/streaming/sinkproxy.h
@@ -27,7 +27,7 @@ namespace essentia {
 namespace streaming {
 
 
-class SinkProxyBase : public SinkBase {
+class ESSENTIA_API SinkProxyBase : public SinkBase {
  protected:
   SinkBase* _proxiedSink;
 

--- a/src/essentia/streaming/sourcebase.h
+++ b/src/essentia/streaming/sourcebase.h
@@ -32,11 +32,11 @@ class SourceProxyBase;
 class SinkBase;
 class Algorithm;
 
-void connect(SourceBase& source, SinkBase& sink);
-void disconnect(SourceBase& source, SinkBase& sink);
+void ESSENTIA_API connect(SourceBase& source, SinkBase& sink);
+void ESSENTIA_API disconnect(SourceBase& source, SinkBase& sink);
 
-void attach(SourceBase& innerSource, SourceProxyBase& proxy);
-void detach(SourceBase& innerSource, SourceProxyBase& proxy);
+void ESSENTIA_API attach(SourceBase& innerSource, SourceProxyBase& proxy);
+void ESSENTIA_API detach(SourceBase& innerSource, SourceProxyBase& proxy);
 
 
 /**
@@ -49,7 +49,7 @@ void detach(SourceBase& innerSource, SourceProxyBase& proxy);
  * the template being the token type). Look at the Source implementation for more
  * information.
  */
-class SourceBase : public Connector {
+class ESSENTIA_API SourceBase : public Connector {
  protected:
   std::vector<SinkBase*> _sinks;
 

--- a/src/essentia/streaming/sourceproxy.h
+++ b/src/essentia/streaming/sourceproxy.h
@@ -34,7 +34,7 @@ namespace streaming {
  * Non template base class for the proxy source, contains a pointer to the actual
  * Source being proxied.
  */
-class SourceProxyBase : public SourceBase {
+class ESSENTIA_API SourceProxyBase : public SourceBase {
  protected:
   SourceBase* _proxiedSource;
 

--- a/src/essentia/types.h
+++ b/src/essentia/types.h
@@ -264,7 +264,7 @@ inline bool sameType(const std::type_info& t1, const std::type_info& t2) {
 
 
 // defined in src/base/essentia.cpp
-std::string nameOfType(const std::type_info& type);
+std::string ESSENTIA_API nameOfType(const std::type_info& type);
 
 /**
  * Subclasses of this interface have the ability to check their type against

--- a/src/essentia/utils/jsonconvert.cpp
+++ b/src/essentia/utils/jsonconvert.cpp
@@ -40,7 +40,7 @@ int JsonConvert::countBackSlashes() {
   while(i >= 0 && _str[i] == '\\') {
     i--;
   }
-  return -_pos - 1 - i;
+  return -((int)_pos) - 1 - i;
 }
 
 


### PR DESCRIPTION
These are some changes to make it possible to compile with Visual Studio:
 - Move the definition of static variables in CPP files for tempo tap algorithms.
 - Added missing include.
 - Casting an unsigned int to int before making it negative.
 - std::min and std::max couldn't be found. By writing (std::min) or (std::max), the symbols are found.
 - Added ESSENTIA_API in front defintions for dllexport or dllimport. The macro was added only to declaration that were needed.

I tested and with these changes I was still able to compile on Mac OSX 10.11 with XCode 7.3, using the waf script. With these changes, I was able to compile Essentia on Windows 8.1 in Visual Studio 2013, with a custom solution.