### PR TITLE
Remove FFTWComplex from Accelerate and KISS FFTs for now

### DIFF
--- a/src/wscript
+++ b/src/wscript
@@ -170,10 +170,10 @@ def configure(ctx):
     if 'ACCELERATE' in ctx.env.FFT:
         print('- using Accelerate Framework for FFT\n')
         ctx.env.LINKFLAGS += [ '-framework', 'Accelerate']
-        ctx.env.ALGOIGNORE += ['FFTK', 'IFFTK', 'FFTW', 'IFFTW']
+        ctx.env.ALGOIGNORE += ['FFTWComplex', 'FFTK', 'IFFTK', 'FFTW', 'IFFTW']
     elif 'KISS' in ctx.env.FFT:
         print('- using KISS for FFT\n')  
-        ctx.env.ALGOIGNORE += ['FFTA', 'IFFTA', 'FFTW', 'IFFTW']      
+        ctx.env.ALGOIGNORE += ['FFTWComplex', 'FFTA', 'IFFTA', 'FFTW', 'IFFTW']      
     else:
         print('- using FFTW for FFT\n') 
         if has('fftw'):


### PR DESCRIPTION
This new FFTWComplex algorithm needs to be adapted as FFTAComplex (for Accelerate) and FFTKComplex for (KISS) otherwise it'll throw errors.

This pull request will remove the algorithm when you use these FFTs for now.