### PR TITLE
Modify the oddtoevenharminicenergyratio algorithm

### DIFF
--- a/src/algorithms/tonal/oddtoevenharmonicenergyratio.cpp
+++ b/src/algorithms/tonal/oddtoevenharmonicenergyratio.cpp
@@ -68,14 +68,18 @@ void OddToEvenHarmonicEnergyRatio::compute() {
     else           odd_energy += magnitudes[i] * magnitudes[i];
   }
 
-  if (even_energy == 0.0) {
-     oddtoevenharmonicenergyratio = numeric_limits<Real>::max();
+  if (even_energy == 0.0 && odd_energy > 0.01) {
+     // oddtoevenharmonicenergyratio = numeric_limits<Real>::max();
+     oddtoevenharmonicenergyratio = 1000.;
+  }
+  else if (even_energy == 0.0 && odd_energy < 0.01 ) {
+     oddtoevenharmonicenergyratio = 1;
   }
   else {
      oddtoevenharmonicenergyratio = odd_energy / even_energy;
   }
   if (oddtoevenharmonicenergyratio >= 1000.) {
-    cerr << "DEBUG: clipping oddtoevenharmonicenergyratio to max value" << endl;
+    cerr << "DEBUG: clipping oddtoevenharmonicenergyratio to max value threshold" << endl;
     oddtoevenharmonicenergyratio = 1000.;
   }
 }


### PR DESCRIPTION
Set the maximum value for the ratio to 1000(arbitrary value)
Set the ratio to 1 when the even energy is zero and the odd is less than 0.01(arbitrary value)
