### PR TITLE
GFCC: Add silenceThreshold parameter #543

### DIFF
--- a/src/algorithms/spectral/gfcc.h
+++ b/src/algorithms/spectral/gfcc.h
@@ -37,11 +37,10 @@ class GFCC : public Algorithm {
 
   std::vector<Real> _logbands;
 
-  typedef  Real (*funcPointer)(Real);
-  funcPointer _compressor;
-
-  void setCompressor(std::string logType);
-
+  std::string _logType;
+  Real _silenceThreshold;
+  Real _dbSilenceThreshold;
+  Real _logSilenceThreshold;
 
  public:
   GFCC() {
@@ -66,6 +65,7 @@ class GFCC : public Algorithm {
     declareParameter("lowFrequencyBound", "the lower bound of the frequency range [Hz]", "[0,inf)", 40.);
     declareParameter("highFrequencyBound", "the upper bound of the frequency range [Hz]", "(0,inf)", 22050.);
     declareParameter("type", "use magnitude or power spectrum","{magnitude,power}", "power");
+    declareParameter("silenceThreshold", "silence threshold for computing log-energy bands", "(0,inf)", 1e-9);
     declareParameter("logType","logarithmic compression type. Use 'dbpow' if working with power and 'dbamp' if working with magnitudes","{natural,dbpow,dbamp,log}","dbamp");
     declareParameter("dctType", "the DCT type", "[2,3]", 2);
   }

--- a/test/src/unittest/spectral/test_gfcc.py
+++ b/test/src/unittest/spectral/test_gfcc.py
@@ -30,6 +30,7 @@ class TestGFCC(TestCase):
                     sampleRate = 44100,
                     numberBands = 40,
                     numberCoefficients = numCoeffs,
+                    silenceThreshold = 1e-9,
                     lowFrequencyBound = 0,
                     highFrequencyBound = 11000,
                     logType = logType)
@@ -52,7 +53,7 @@ class TestGFCC(TestCase):
     def testZero(self):
         # zero input should return dct(lin2db(0)). Try with different sizes
         size = 1025
-        val = amp2db(0)
+        val = 2 * 10 * np.log10(1e-9)
         expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
         while (size > 256 ):
             bands, gfcc = GFCC(inputSize = size)(zeros(size))


### PR DESCRIPTION
Add silenceThreshold parameter default to 1e-9.

Get rid of pointer to compressor function because it is not flexible as soon as one needs to run functions with different number of parameters (amp2db vs linear) or different threshold log values (amb2db db threshold vs log)

Update unit test to the new results for `testZero`