### PR TITLE
Improve precision for computation of subband bin intervals

### DIFF
--- a/src/algorithms/spectral/spectralcontrast.cpp
+++ b/src/algorithms/spectral/spectralcontrast.cpp
@@ -62,22 +62,22 @@ void SpectralContrast::configure() {
 
   _numberOfBinsInBands.clear();
   _numberOfBinsInBands.resize(numberBands);
-  lastBins = int(lowerBound / binWidth);
+  lastBins = round(lowerBound / binWidth);
   _startAtBin = lastBins;
 
   // Determine how many bins are in each band to start with.
   // The rest of the bands will be distributed logarithmically.
-  int  totalNumberOfBins = int(upperBound / binWidth);
-       upperBound        = int(partToScale*totalNumberOfBins) * binWidth;
-  int  staticBinsPerBand = int((1-partToScale)*totalNumberOfBins) / numberBands;
+  int  totalNumberOfBins = round(upperBound / binWidth);
+       upperBound        = round(partToScale*totalNumberOfBins) * binWidth;
+  int  staticBinsPerBand = round((1-partToScale)*totalNumberOfBins / numberBands);
   Real ratio             = upperBound / lowerBound;
   Real ratioPerBand      = pow(ratio, Real(1.0/numberBands));
   Real currFreq          = lowerBound;
 
   for (int i=0; i<numberBands; ++i) {
     currFreq = currFreq*ratioPerBand;
-    _numberOfBinsInBands[i] = int(currFreq / binWidth - lastBins+staticBinsPerBand);
-    lastBins = int(currFreq / binWidth);
+    _numberOfBinsInBands[i] = round(currFreq / binWidth - lastBins+staticBinsPerBand);
+    lastBins = round(currFreq / binWidth);
   }
 }
 
@@ -110,6 +110,7 @@ void SpectralContrast::compute() {
          ++i) {
       bandMean += spectrum[specIdx+i];
     }
+
     if (_numberOfBinsInBands[bandIdx] != 0) bandMean /= _numberOfBinsInBands[bandIdx];
     bandMean += minReal;
 
@@ -118,7 +119,9 @@ void SpectralContrast::compute() {
          spectrum.begin()+std::min(specIdx+_numberOfBinsInBands[bandIdx], int(spectrum.size())));
 
     // number of bins to take the mean of
-    int neighbourBins = int(_neighbourRatio * _numberOfBinsInBands[bandIdx]);
+    // TODO: changed from int() to round() as it seems to be more correct. 
+    // Does this affect values a lot?
+    int neighbourBins = round(_neighbourRatio * _numberOfBinsInBands[bandIdx]);
     if (neighbourBins < 1) neighbourBins = 1;
 
     // valley (FLT_MIN prevents log(0))


### PR DESCRIPTION
Use round() instead of int().

Band boundaries according to the paper:
20 Hz, 330 Hz, 704 Hz, 1256 Hz, 2303 Hz, 4729 Hz, and 11 kHz.

Band boundaries in the implementation
(frequencies corresponding to the first and the last bin of each band):

22050Hz samplerate, 2048 framesize
  new -- using round()
    21.53320312 -- 322.9980469
    333.7646484 -- 699.8291016
    710.5957031 -- 1259.692383
    1270.458984 -- 2314.819336
    2325.585938 -- 4748.071289
    4758.837891 -- 11025
  old -- using int()
    10.76660156-- 312.2314453
    322.9980469 -- 678.2958984
    689.0625 -- 1227.392578
    1238.15918 -- 2260.986328
    2271.75293 -- 4683.47168
    4694.238281 -- 10938.86719

44100Hz samplerate, 2048 framesize
  new -- using round()
    21.53320312 -- 322.9980469
    344.53125  -- 689.0625
    710.5957031 -- 1248.925781
    1270.458984 -- 2304.052734
    2325.585938 -- 4737.304688
    4758.837891 -- 11003.4668
  old -- using int()
    0 -- 279.9316406
    301.4648438 -- 645.9960938
    667.5292969 -- 1184.326172
    1205.859375 -- 2196.386719
    2217.919922 -- 4608.105469
    4629.638672 -- 10852.73438