### PR TITLE
Fix build on GCC 6.3.0

### DIFF
--- a/wscript
+++ b/wscript
@@ -73,7 +73,7 @@ def configure(ctx):
     ctx.env.WITH_CPPTESTS = ctx.options.WITH_CPPTESTS
 
     # compiler flags
-    ctx.env.CXXFLAGS = ['-pipe', '-Wall']
+    ctx.env.CXXFLAGS = ['-pipe', '-Wall', '-std=c++03']
 
     # force using SSE floating point (default for 64bit in gcc) instead of
     # 387 floating point (used for 32bit in gcc) to avoid numerical differences


### PR DESCRIPTION
This fixes build on GCC 6.3.0 with enabled gaia2. 
Same fix from MTG/gaia#64
Eigen that is included in Essentia, is not ready for C++11, which forced by GCC 6.3.0 by default.