### PR TITLE
Update wscript to work on Python 2.6.6/CentOS 6

### DIFF
--- a/wscript
+++ b/wscript
@@ -264,7 +264,7 @@ def build(ctx):
 
     if ctx.env.WITH_CPPTESTS:
         # missing -lpthread flag on Ubuntu and LinuxMint
-        if platform.dist()[0].lower() in {'debian', 'ubuntu', 'linuxmint'} and not ctx.env.CROSS_COMPILE_MINGW32 and not ctx.env.WITH_STATIC_EXAMPLES:
+        if platform.dist()[0].lower() in ['debian', 'ubuntu', 'linuxmint'] and not ctx.env.CROSS_COMPILE_MINGW32 and not ctx.env.WITH_STATIC_EXAMPLES:
             ext_paths = ['/usr/lib/i386-linux-gnu', '/usr/lib/x86_64-linux-gnu']
             ctx.read_shlib('pthread', paths=ext_paths)
             ctx.env.USES += ' pthread'


### PR DESCRIPTION
Bug-fix to build on CentOS 6, where native Python support only goes up to 2.6.6 and doesn't support the set syntax. 