### PR TITLE
Replace libav 3rdparty static dependency with ffmpeg

### DIFF
--- a/packaging/build_3rdparty_static_debian.sh
+++ b/packaging/build_3rdparty_static_debian.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
 cd $BASEDIR/debian_3rdparty
-./build_fftw3.sh  
-./build_libav_nomuxers.sh  
-./build_libsamplerate.sh  
-./build_taglib.sh  
+./build_fftw3.sh
+./build_ffmpeg_nomuxers.sh
+./build_libsamplerate.sh
+./build_taglib.sh
 ./build_yaml.sh
 
 if [ "$1" = --with-gaia ];

--- a/packaging/build_3rdparty_static_win32.sh
+++ b/packaging/build_3rdparty_static_win32.sh
@@ -3,8 +3,8 @@ BASEDIR=$(dirname $0)
 cd $BASEDIR/win32_3rdparty
 rm -rf bin dynamic include lib share
 
-./build_fftw3.sh  
-./build_libav_nomuxers.sh  
-./build_libsamplerate.sh  
-./build_taglib.sh  
+./build_fftw3.sh
+./build_ffmpeg_nomuxers.sh
+./build_libsamplerate.sh
+./build_taglib.sh
 ./build_yaml.sh

--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -14,7 +14,7 @@ SHARED_OR_STATIC="
 --enable-static
 "
 
-LIBAV_VERSION=libav-11.2
+FFMPEG_VERSION=ffmpeg-2.8.12
 TAGLIB_VERSION=taglib-1.10
 FFTW_VERSION=fftw-3.3.2
 LIBSAMPLERATE_VERSION=libsamplerate-0.1.8
@@ -22,18 +22,15 @@ LIBYAML_VERSION=yaml-0.1.5
 QT_SOURCE_URL=http://download.qt-project.org/official_releases/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz
 GAIA_VERSION=v2.4.4
 
-LIBAV_AUDIO_FLAGS="
+FFMPEG_AUDIO_FLAGS="
+    --enable-avresample
     --disable-doc
     --disable-debug
-    --disable-avconv
-    --disable-avplay
-    --disable-avprobe 
-    --disable-avserver 
-    --disable-avdevice  
-    --disable-swscale 
-    --disable-avfilter 
-    --disable-network 
-    --disable-indevs 
+    --disable-avdevice
+    --disable-swscale
+    --disable-avfilter
+    --disable-network
+    --disable-indevs
     --disable-outdevs
     --disable-muxers
     --disable-demuxers
@@ -183,12 +180,12 @@ FFTW_FLAGS="
     --enable-float \
     --enable-sse2 \
     --with-incoming-stack-boundary=2 \
-    --with-our-malloc16 
+    --with-our-malloc16
 "
 
 LIBSAMPLERATE_FLAGS="
     --disable-fftw \
-    --disable-sndfile 
+    --disable-sndfile
 "
 
 QT_FLAGS="
@@ -200,9 +197,9 @@ QT_FLAGS="
     -no-fontconfig
     -no-mitshm
     -no-xrender
-    -no-xrandr 
+    -no-xrandr
     -no-xfixes
-    -no-xcursor 
+    -no-xcursor
     -no-xinerama
     -no-xsync
     -no-xvideo

--- a/packaging/debian_3rdparty/build_ffmpeg_nomuxers.sh
+++ b/packaging/debian_3rdparty/build_ffmpeg_nomuxers.sh
@@ -5,12 +5,12 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 
-wget https://libav.org/releases/$LIBAV_VERSION.tar.gz
-tar xf $LIBAV_VERSION.tar.gz
-cd $LIBAV_VERSION
+wget https://ffmpeg.org/releases/$FFMPEG_VERSION.tar.gz
+tar xf $FFMPEG_VERSION.tar.gz
+cd $FFMPEG_VERSION
 
 ./configure \
-    $LIBAV_AUDIO_FLAGS \
+    $FFMPEG_AUDIO_FLAGS \
     --prefix=$PREFIX \
     $SHARED_OR_STATIC
 make

--- a/packaging/win32_3rdparty/build_ffmpeg_nomuxers.sh
+++ b/packaging/win32_3rdparty/build_ffmpeg_nomuxers.sh
@@ -5,12 +5,12 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 
-wget https://libav.org/releases/$LIBAV_VERSION.tar.gz
-tar xf $LIBAV_VERSION.tar.gz
-cd $LIBAV_VERSION
+wget https://ffmpeg.org/releases/$FFMPEG_VERSION.tar.gz
+tar xf $FFMPEG_VERSION.tar.gz
+cd $FFMPEG_VERSION
 
 ./configure \
-    $LIBAV_AUDIO_FLAGS \
+    $FFMPEG_AUDIO_FLAGS \
     --prefix=$PREFIX \
     --enable-cross-compile \
     --cross-prefix=$HOST- \


### PR DESCRIPTION
Essentia requirements had been previously upgraded to require a newer
version of libav. Since then, debian and ubuntu have both moved back
to ffmpeg too.
We switch to the same version of ffmpeg used in Ubuntu 16.04, which
we currently support for essentia