### PR TITLE
Only link against libessentia in the pc file. Fixes #340

### DIFF
--- a/wscript
+++ b/wscript
@@ -243,7 +243,7 @@ def configure(ctx):
     Name: libessentia
     Description: audio analysis library -- development files
     Version: %(version)s
-    Libs: -L${libdir} -lessentia -lgaia2 -lfftw3 -lyaml -lavcodec -lavformat -lavutil -lavresample -lsamplerate -ltag -lfftw3f
+    Libs: -L${libdir} -lessentia
     Cflags: -I${includedir}/essentia -I${includedir}/essentia/scheduler -I${includedir}/essentia/streaming -I${includedir}/essentia/utils
     ''' % opts
 


### PR DESCRIPTION
When we want to link libessentia.so into a program we only need to
specify -lessentia. Other dependencies of essentia are already
correctly linked against the .so. If a user wants to also link
their program against the same dependency (e.g. libav) then they
should explicitly link against that themselves.