### PR TITLE
Fix for algorithm composites that slow down after first compute() #696 

### DIFF
--- a/src/essentia/streaming/algorithms/vectorinput.h
+++ b/src/essentia/streaming/algorithms/vectorinput.h
@@ -103,7 +103,7 @@ class VectorInput : public Algorithm {
     _ownVector = own;
   }
 
-  void setAcqireSize(const int size) {
+  void setAcquireSize(const int size) {
     _acquireSize = size;
     
     _output.setAcquireSize(_acquireSize);
@@ -171,7 +171,7 @@ void connect(VectorInput<T>& v, SinkBase& sink) {
   int size = sink.acquireSize();
   SourceBase& visource = v.output("data");
   if (visource.acquireSize() < size) {
-    v.setAcqireSize(size);
+    v.setAcquireSize(size);
   }
   connect(v.output("data"), sink);
 

--- a/src/essentia/streaming/algorithms/vectorinput.h
+++ b/src/essentia/streaming/algorithms/vectorinput.h
@@ -172,6 +172,8 @@ void connect(VectorInput<T>& v, SinkBase& sink) {
     visource.setReleaseSize(size);
   }
   connect(v.output("data"), sink);
+
+  v.setAcqireSize(size);
 }
 
 template <typename T>

--- a/src/essentia/streaming/algorithms/vectorinput.h
+++ b/src/essentia/streaming/algorithms/vectorinput.h
@@ -34,20 +34,21 @@ class VectorInput : public Algorithm {
   const std::vector<TokenType>* _inputVector;
   bool _ownVector;
   int _idx;
+  int _acquireSize = acquireSize;
 
  public:
 
   VectorInput(const std::vector<TokenType>* input=0, bool own = false)
     : _inputVector(input), _ownVector(own) {
     setName("VectorInput");
-    declareOutput(_output, acquireSize, "data", "the values read from the vector");
+    declareOutput(_output, _acquireSize, "data", "the values read from the vector");
     reset();
   }
 
   VectorInput(std::vector<TokenType>* input, bool own = false)
     : _inputVector(input), _ownVector(own) {
     setName("VectorInput");
-    declareOutput(_output, acquireSize, "data", "the values read from the vector");
+    declareOutput(_output, _acquireSize, "data", "the values read from the vector");
     reset();
   }
 
@@ -56,7 +57,7 @@ class VectorInput : public Algorithm {
     setName("VectorInput");
     _inputVector = new std::vector<TokenType>(arrayToVector<TokenType>(inputArray));
     _ownVector = true;
-    declareOutput(_output, acquireSize, "data", "the values read from the vector");
+    declareOutput(_output, _acquireSize, "data", "the values read from the vector");
     reset();
   }
 
@@ -102,11 +103,15 @@ class VectorInput : public Algorithm {
     _ownVector = own;
   }
 
+  void setAcqireSize(const int size) {
+    _acquireSize = size;
+  }
+
   void reset() {
     Algorithm::reset();
     _idx = 0;
-    _output.setAcquireSize(acquireSize);
-    _output.setReleaseSize(acquireSize);
+    _output.setAcquireSize(_acquireSize);
+    _output.setReleaseSize(_acquireSize);
   }
 
   bool shouldStop() const {

--- a/src/essentia/streaming/algorithms/vectorinput.h
+++ b/src/essentia/streaming/algorithms/vectorinput.h
@@ -171,12 +171,11 @@ void connect(VectorInput<T>& v, SinkBase& sink) {
   int size = sink.acquireSize();
   SourceBase& visource = v.output("data");
   if (visource.acquireSize() < size) {
-    visource.setAcquireSize(size);
-    visource.setReleaseSize(size);
+    v.setAcqireSize(size);
   }
   connect(v.output("data"), sink);
 
-  v.setAcqireSize(size);
+  
 }
 
 template <typename T>

--- a/src/essentia/streaming/algorithms/vectorinput.h
+++ b/src/essentia/streaming/algorithms/vectorinput.h
@@ -105,6 +105,9 @@ class VectorInput : public Algorithm {
 
   void setAcqireSize(const int size) {
     _acquireSize = size;
+    
+    _output.setAcquireSize(_acquireSize);
+    _output.setReleaseSize(_acquireSize);
   }
 
   void reset() {


### PR DESCRIPTION
Looking to the issue #696  I've found that on the first iteration the network operates with a frame size of 4096. This size is set as [prefered frame size](https://github.com/MTG/essentia/blob/365564840e1242888f1cebfaf2dcdbd0f9783634/src/algorithms/standard/stereodemuxer.h#L39) by the `StereoDemuxer` when connecting the algorithms. However, LoudnesEBUR128 [doesn't specify](https://github.com/MTG/essentia/blob/9574c4e566ac946918ad424bb9bdb875cfa4c66e/src/algorithms/temporal/loudnessebur128.h#L95) a preferred `acquireSize` and it's reset to the default (i.e. 1) after each `compute()` generating this bottleneck. Furthermore, this bug would appear for every algorithm composite featuring `Input<std::vector<StereoSample> >` (Currently only [LoudnesEBUR128](http://essentia.upf.edu/documentation/reference/std_LoudnessEBUR128.html)) 

As a solution, I propose that `VectorInput` should replicate the behaviour of other generators as `FrameGenerator` (i.e. internally store the acquire size and preserve it after resetting). This change supposes a speedup of 30 to 50X in the successive `compute()` calls according to my tests. On the unit tests of LoudnesEBUR128, the `compute` part is now completed in 22.530s and the `compute\reset\compute` in 43.821s as expected.
 