### PR TITLE
MusicExtractor: compute a chromaprint when libchromaprint is available

### DIFF
--- a/doc/sphinxdoc/streaming_extractor_music.rst
+++ b/doc/sphinxdoc/streaming_extractor_music.rst
@@ -245,10 +245,11 @@ Note, that you need to build Essentia with Gaia2 or use our static builds (soon 
 
 
 Chromaprints
-----------------------------
+------------
 
-If `libchromaprint <https://packages.debian.org/sid/libchromaprint-dev>`_ is available, this extractor can be configured to compute `Chromaprints <https://acoustid.org/chromaprint>`_ and store them in the output pools.
-To generate the chromaprints the parameter `chromaprint.compute` has to be explicitly set to `1` in the profile file (it defaults to `0`). Optionally, The `chromaprint.duration` parameter specifies how many seconds from the beginning of the track are used to compute the chromaprints. If set to 0 (by default) the whole track is used.
+If `libchromaprint <https://packages.debian.org/sid/libchromaprint-dev>`_ is available, this extractor can be configured to compute `Chromaprint fingerprints <https://acoustid.org/chromaprint>`_ and store them in the output pools.
+To generate the fingerprints the parameter `chromaprint.compute` has to be explicitly set to `1` in the profile file (it defaults to `0`). Optionally, The `chromaprint.duration` parameter specifies how many seconds from the beginning of the track are used to compute the fingerprints. If set to 0 (by default), the whole track is used. ::
+
   chromaprint:
     compute: 1
     duration: 10.0

--- a/doc/sphinxdoc/streaming_extractor_music.rst
+++ b/doc/sphinxdoc/streaming_extractor_music.rst
@@ -246,6 +246,17 @@ Instead of computing high-level descriptors altogether with lower-level ones, it
 Note, that you need to build Essentia with Gaia2 or use our static builds (soon online) in order to be able to run high-level models. Since Essentia version 2.1 high-level models are distributed apart from Essentia via a `download page <http://essentia.upf.edu/documentation/svm_models/>`_. 
 
 
+Chromaprints
+----------------------------
+
+If `libchromaprint <https://packages.debian.org/sid/libchromaprint-dev>`_ is available, this extractor can be configured to compute `Chromaprints <https://acoustid.org/chromaprint>`_ and store them in the output pools.
+To generate the chromaprints the parameter `chromaprint.compute` has to be explicitly set to `1` in the profile file (it defaults to `0`). Optionally, The `chromaprint.duration` parameter specifies how many seconds from the beginning of the track are used to compute the chromaprints. If set to 0 (by default) the whole track is used.
+  chromaprint:
+    compute: 1
+    duration: 10.0
+
+
+Note that the `chromaprint` namespace is only meaningful when `libchromaprint` is correctly installed and detected.
 
 
 

--- a/src/algorithms/extractor/musicextractor.cpp
+++ b/src/algorithms/extractor/musicextractor.cpp
@@ -84,6 +84,11 @@ void MusicExtractor::configure() {
   rhythmStats = parameter("rhythmStats").toVectorString();
   mfccStats = parameter("mfccStats").toVectorString();
   gfccStats = parameter("gfccStats").toVectorString();
+  
+#if HAVE_LIBCHROMAPRINT
+  chromaprintCompute = parameter("chromaprintCompute").toBool();
+  chromaprintDuration = parameter("chromaprintDuration").toReal();
+#endif
 
 #if HAVE_GAIA2 
   if (parameter("highlevel").isConfigured()) { 
@@ -111,6 +116,11 @@ void MusicExtractor::configure() {
     E_WARNING("MusicExtractor: Gaia library is missing. Skipping configuration of SVM models.");
 #endif
   }
+
+#if HAVE_LIBCHROMAPRINT
+    chromaprintCompute = options.value<Real>("chromaprint.compute");
+    chromaprintDuration = options.value<Real>("chromaprint.duration");
+#endif
 }
 
 
@@ -162,6 +172,12 @@ void MusicExtractor::setExtractorDefaultOptions() {
     options.set("highlevel.compute", true);
   }
 #endif
+
+#if HAVE_LIBCHROMAPRINT
+    options.set("chromaprint.compute", chromaprintCompute);
+    options.set("chromaprint.duration", chromaprintDuration);
+#endif
+  
 }
 
 
@@ -204,7 +220,16 @@ void MusicExtractor::compute() {
   
   E_INFO("MusicExtractor: Replay gain");
   computeReplayGain(audioFilename, results);
-  
+
+  #if HAVE_LIBCHROMAPRINT
+    if (chromaprintCompute) {
+      E_INFO("MusicExtractor: Chromaprint");
+      computeChromaPrint(audioFilename, results);
+    }
+  #else
+    E_WARNING("MusicExtractor: Chromaprint library is missing. Skipping computation of the Chromaprint.");
+  #endif
+    
   E_INFO("MusicExtractor: Compute audio features");
 
   // normalize the audio with replay gain and compute as many lowlevel, rhythm,
@@ -584,6 +609,43 @@ void MusicExtractor::setExtractorOptions(const std::string& filename) {
   delete yaml;
   options.merge(opts, "replace");
 }
+
+#if HAVE_LIBCHROMAPRINT
+void MusicExtractor::computeChromaPrint(const string& audioFilename, Pool& results) {
+  AlgorithmFactory& factory = standard::AlgorithmFactory::instance();
+
+  Algorithm* audio = factory.create("MonoLoader",
+                                    "filename", audioFilename,
+                                    "sampleRate", analysisSampleRate,
+                                    "downmix", downmix);
+  Algorithm* chromaprinter = factory.create("Chromaprinter",
+                                            "sampleRate", analysisSampleRate,
+                                            "maxLength", chromaprintDuration);
+
+  vector<Real> siganl;
+  string chromaprint;
+
+  audio->output("audio").set(siganl);
+  chromaprinter->input("signal").set(siganl);
+
+  chromaprinter->output("fingerprint").set(chromaprint);
+
+  try {
+    audio->compute();
+    chromaprinter->compute();
+
+    results.add("chromaprint.string", chromaprint);
+    if (chromaprintDuration == 0.f)
+      results.add("chromaprint.duration", results.value<Real>("metadata.audio_properties.length"));
+    else
+    results.add("chromaprint.duration", chromaprintDuration);
+  }
+  catch (const EssentiaException&) {
+    throw EssentiaException("File looks like a completely silent file");
+    //exit(4);
+  }
+}
+#endif
 
 } // namespace standard
 } // namespace essentia

--- a/src/algorithms/extractor/musicextractor.cpp
+++ b/src/algorithms/extractor/musicextractor.cpp
@@ -640,9 +640,8 @@ void MusicExtractor::computeChromaPrint(const string& audioFilename, Pool& resul
     else
     results.add("chromaprint.duration", chromaprintDuration);
   }
-  catch (const EssentiaException&) {
-    throw EssentiaException("File looks like a completely silent file");
-    //exit(4);
+  catch (const EssentiaException& e) {
+    throw EssentiaException("MusicExtractor: exception thrown while computing the Chromaprint. ", e.what());
   }
 }
 #endif

--- a/src/algorithms/extractor/musicextractor.cpp
+++ b/src/algorithms/extractor/musicextractor.cpp
@@ -636,9 +636,9 @@ void MusicExtractor::computeChromaPrint(const string& audioFilename, Pool& resul
 
     results.add("chromaprint.string", chromaprint);
     if (chromaprintDuration == 0.f)
-      results.add("chromaprint.duration", results.value<Real>("metadata.audio_properties.length"));
+      results.set("chromaprint.duration", results.value<Real>("metadata.audio_properties.length"));
     else
-    results.add("chromaprint.duration", chromaprintDuration);
+    results.set("chromaprint.duration", chromaprintDuration);
   }
   catch (const EssentiaException& e) {
     throw EssentiaException("MusicExtractor: exception thrown while computing the Chromaprint. ", e.what());

--- a/src/algorithms/extractor/musicextractor.h
+++ b/src/algorithms/extractor/musicextractor.h
@@ -69,6 +69,11 @@ class MusicExtractor : public Algorithm {
   std::vector<std::string> mfccStats;
   std::vector<std::string> gfccStats;
 
+#if HAVE_LIBCHROMAPRINT
+  bool chromaprintCompute;
+  Real chromaprintDuration;
+#endif
+
 #if HAVE_GAIA2 
   std::vector<std::string> svmModels;
 #endif
@@ -83,6 +88,10 @@ class MusicExtractor : public Algorithm {
   void readMetadata(const std::string& audioFilename, Pool& results);
   void computeAudioMetadata(const std::string& audioFilename, Pool& results);
   void computeReplayGain(const std::string& audioFilename, Pool& results);
+
+#if HAVE_LIBCHROMAPRINT
+  void computeChromaPrint(const std::string& audioFilename, Pool& results);
+#endif
 
   Pool computeAggregation(Pool& pool);
 
@@ -134,6 +143,11 @@ class MusicExtractor : public Algorithm {
     
     declareParameter("mfccStats", "the statistics to compute for MFCC features", "", cepstrumStats);
     declareParameter("gfccStats", "the statistics to compute for GFCC features", "", cepstrumStats);
+
+#if HAVE_LIBCHROMAPRINT
+    declareParameter("chromaprintCompute", "compute the Chromaprint", "{true,false}", false);
+    declareParameter("chromaprintDuration", "the amount of time from the beginning used to compute the Chromaprint. 0 to use the full audio length [s]", "[0,inf)", 0.);
+#endif
 
 #if HAVE_GAIA2 
     declareParameter("highlevel", "list of high-level classifier models (gaia2 history filenames) to apply using extracted features. Skip classification if not specified (empty list)", "", Parameter::VECTOR_STRING);

--- a/src/examples/standard_chromaprinter.cpp
+++ b/src/examples/standard_chromaprinter.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
 
   if (argc < 2) {
     cout << "Error: incorrect number of arguments." << endl;
-    cout << "Usage: " << argv[0] << " audio_input output_file chromaprint_duration" << endl;
+    cout << "Usage: " << argv[0] << " audio_input chromaprint_duration" << endl;
     creditLibAV();
     exit(1);
   }

--- a/src/examples/standard_chromaprinter.cpp
+++ b/src/examples/standard_chromaprinter.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#include <iostream>
+#include <fstream>
+#include <essentia/algorithmfactory.h>
+#include <essentia/pool.h>
+#include "credit_libav.h"
+using namespace std;
+using namespace essentia;
+using namespace standard;
+
+int main(int argc, char* argv[]) {
+
+  if (argc != 4) {
+    cout << "Error: incorrect number of arguments." << endl;
+    cout << "Usage: " << argv[0] << " audio_input output_file chromaprint_duration" << endl;
+    creditLibAV();
+    exit(1);
+  }
+
+  string audioFilename = argv[1];
+  string outputFilename = argv[2];
+  Real chromaprintDuration = stof(argv[3]);
+
+  // register the algorithms in the factory(ies)
+  essentia::init();
+
+  Pool pool;
+
+  /////// PARAMS //////////////
+  Real sampleRate = 44100.0;
+
+  AlgorithmFactory& factory = AlgorithmFactory::instance();
+
+  Algorithm* audioLoader = factory.create("MonoLoader",
+                                          "filename", audioFilename,
+                                          "sampleRate", sampleRate);
+
+  Algorithm* chromaPrinter = factory.create("Chromaprinter");
+
+  vector<Real> audio;
+  string chromaprint;
+  Real confidence;
+
+  audioLoader->output("audio").set(audio);
+  audioLoader->compute();
+
+  chromaPrinter->input("signal").set(audio);
+  chromaPrinter->output("fingerprint").set(chromaprint);
+  chromaPrinter->compute();
+
+
+  // output to file:
+  Algorithm* yamlOutput = factory.create("YamlOutput",
+                                         "filename", outputFilename);
+
+  pool.add("pool.chromaprint", chromaprint);
+
+  yamlOutput->input("pool").set(pool);
+
+  // run algorithms
+  yamlOutput->compute();
+
+  delete audioLoader;
+  delete chromaPrinter;
+
+  essentia::shutdown();
+
+  return 0;
+}

--- a/src/examples/wscript
+++ b/src/examples/wscript
@@ -32,6 +32,7 @@ example_sources_fileio = [
     ('standard_spsmodel', ),
     ('standard_stft', ),
     ('standard_stochasticmodel', ),
+    ('standard_chromaprinter', ),
 
     ('standard_discontinuitydetector', ),
     ('standard_extractor_la-cupula', ),


### PR DESCRIPTION
This pull request modifies [MusicExtractor](http://essentia.upf.edu/documentation/reference/std_MusicExtractor.html) to compute a Chromaprint  when libchromaprint is installed as demanded on  #718.
In such case two new parameters are added to MusicExtractor:

- **chromaprintCompute** : a flag to compute the Chromaprint. Defaults to `false`.
- **chromaprintDuration** : the amount of time from the beginning used to compute the Chromaprint. 0 to use the full audio length. Defaults to the full audio length.

The parameters can also be configured through the Yaml file with the following lines as explained [here](http://essentia.upf.edu/documentation/streaming_extractor_music.html#configuration):

```
chromaprint:
<tab>duration: 10.0
<tab>compute: true
```
