### PR TITLE
Remove error thrown when replayGain is higher than threshold

### DIFF
--- a/src/algorithms/extractor/musicextractor.cpp
+++ b/src/algorithms/extractor/musicextractor.cpp
@@ -566,8 +566,8 @@ void MusicExtractor::computeReplayGain(const string& audioFilename, Pool& result
       results.remove("metadata.audio_properties.replay_gain");
     }
     else {
-      throw EssentiaException("File looks like a completely silent file... Aborting...");
       //exit(5);
+      break;
     }
   }
 }


### PR DESCRIPTION
When using the musicextractor algorithm, an error is thrown when the computed replayGain is higher than a threshold (40dB), and the extraction fails (see #722).
Such behaviour is not ideal (a warning should be thrown instead), so here it was removed.