### PR TITLE
MFCC/GFCC: added a testZero for every `logType`

### DIFF
--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -404,6 +404,7 @@ template <typename T> T instantPower(const std::vector<T>& array) {
 // aproximately -90
 #define SILENCE_CUTOFF 1e-10
 #define DB_SILENCE_CUTOFF -100
+#define LOG_SILENCE_CUTOFF -23.025850929940457
 
 // returns true if the signal average energy is below a cutoff value, here -90dB
 template <typename T> bool isSilent(const std::vector<T>& array) {
@@ -559,6 +560,10 @@ inline Real db2amp(Real amplitude) {
 
 inline Real linear(Real input) {
   return input;
+}
+
+inline Real lin2log(Real value) {
+  return value < SILENCE_CUTOFF ? LOG_SILENCE_CUTOFF : log(value);
 }
 
 inline Real lin2log(Real input, Real silenceCutoff, Real logSilenceCutoff) {

--- a/src/python/essentia/utils.py
+++ b/src/python/essentia/utils.py
@@ -48,6 +48,9 @@ def amp2db(arg):
 def db2amp(arg):
     return _essentia.db2amp( _c.convertData(arg, _c.Edt.REAL) )
 
+def lin2log(arg):
+    return _essentia.lin2log( _c.convertData(arg, _c.Edt.REAL) )
+
 def bark2hz(arg):
     return _essentia.bark2hz( _c.convertData(arg, _c.Edt.REAL) )
 
@@ -85,4 +88,4 @@ __all__ = [ 'isSilent', 'instantPower',
             'mel2hz', 'hz2mel',
             'postProcessTicks',
             'normalize', 'derivative',
-            'equivalentKey']
+            'equivalentKey', 'lin2log']

--- a/src/python/globalfuncs.cpp
+++ b/src/python/globalfuncs.cpp
@@ -333,6 +333,17 @@ ampToDb(PyObject* notUsed, PyObject* arg) {
 }
 
 static PyObject*
+linToLog(PyObject* notUsed, PyObject* arg) {
+  if (!PyFloat_Check(arg)) {
+    PyErr_SetString(PyExc_TypeError, (char*)"argument must be a float");
+    return NULL;
+  }
+
+  Real db = lin2log( Real( PyFloat_AS_DOUBLE(arg) ) );
+  return PyFloat_FromDouble( double(db) );
+}
+
+static PyObject*
 barkToHz(PyObject* notUsed, PyObject* arg) {
   if (!PyFloat_Check(arg)) {
     PyErr_SetString(PyExc_TypeError, (char*)"argument must be a float");
@@ -995,6 +1006,7 @@ static PyMethodDef Essentia__Methods[] = {
   { "db2pow",        dbToPow,          METH_O, "Converts a dB measure of power to a linear measure" },
   { "pow2db",        powToDb,          METH_O, "Converts a linear measure of power to a measure in dB" },
   { "db2amp",        dbToAmp,          METH_O, "Converts a dB measure of amplitude to a linear measure" },
+  { "lin2log",       linToLog,         METH_O, "Converts a linear measure to a logarithmic one" },
   { "amp2db",        ampToDb,          METH_O, "Converts a linear measure of amplitude to a measure in dB" },
   { "equivalentKey", getEquivalentKey, METH_O, "Returns an equivalent key name if exist or itself otherwise. An empty string is returned if the input is not a valid string" },
   { "info",          standard_info,  METH_VARARGS, "returns all the information about a given classic algorithm." },

--- a/test/src/unittests/spectral/test_gfcc.py
+++ b/test/src/unittests/spectral/test_gfcc.py
@@ -53,7 +53,7 @@ class TestGFCC(TestCase):
     def testZerodbAmp(self):
         # zero input should return dct(lin2db(0)). Try with different sizes
         size = 1025
-        val = 2 * 10 * np.log10(1e-9)
+        val = amp2db(0)
         expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
         while (size > 256 ):
             bands, gfcc = GFCC(inputSize=size)(zeros(size))
@@ -79,15 +79,14 @@ class TestGFCC(TestCase):
     def testZeroLog(self):
         # zero input should return dct(lin2db(0)). Try with different sizes
         size = 1025
-        val = -np.inf # this one has to be replaced with lin2log(0) when 
-                      # the branch mfcc_thresholding is merged. 
+        val = lin2log(0)
         expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
         while (size > 256):
             bands, gfcc = GFCC(inputSize=size, logType='log')(zeros(size))
             self.assertEqualVector(gfcc, expected)
 
             # also assess that the thresholding is working
-            self.assertTrue(not np.isnan(gfcc).any() and not np.isinf(gfcc).any())    
+            self.assertTrue(not np.isnan(gfcc).any() and not np.isinf(gfcc).any())
             size = int(size/2)
 
     def testZeroNatural(self):

--- a/test/src/unittests/spectral/test_gfcc.py
+++ b/test/src/unittests/spectral/test_gfcc.py
@@ -50,7 +50,7 @@ class TestGFCC(TestCase):
             size -= 1
 
 
-    def testZero(self):
+    def testZerodbAmp(self):
         # zero input should return dct(lin2db(0)). Try with different sizes
         size = 1025
         val = 2 * 10 * np.log10(1e-9)
@@ -58,8 +58,50 @@ class TestGFCC(TestCase):
         while (size > 256 ):
             bands, gfcc = GFCC(inputSize=size)(zeros(size))
             self.assertEqualVector(gfcc, expected)
+
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(gfcc).any() and not np.isinf(gfcc).any())    
             size = int(size/2)
 
+    def testZerodbPow(self):
+        # zero input should return dct(lin2db(0)). Try with different sizes
+        size = 1025
+        val = pow2db(0)
+        expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
+        while (size > 256):
+            bands, gfcc = GFCC(inputSize=size, logType='dbpow')(zeros(size))
+            self.assertEqualVector(gfcc, expected)
+
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(gfcc).any() and not np.isinf(gfcc).any())    
+            size = int(size/2)
+
+    def testZeroLog(self):
+        # zero input should return dct(lin2db(0)). Try with different sizes
+        size = 1025
+        val = -np.inf # this one has to be replaced with lin2log(0) when 
+                      # the branch mfcc_thresholding is merged. 
+        expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
+        while (size > 256):
+            bands, gfcc = GFCC(inputSize=size, logType='log')(zeros(size))
+            self.assertEqualVector(gfcc, expected)
+
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(gfcc).any() and not np.isinf(gfcc).any())    
+            size = int(size/2)
+
+    def testZeroNatural(self):
+        # zero input should return dct(lin2db(0)). Try with different sizes
+        size = 1025
+        val = 0.
+        expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
+        while (size > 256):
+            bands, gfcc = GFCC(inputSize=size, logType='natural')(zeros(size))
+            self.assertEqualVector(gfcc, expected)
+
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(gfcc).any() and not np.isinf(gfcc).any())    
+            size = int(size/2)
 
     def testInvalidInput(self):
         # mel bands should fail for a spectrum with less than 2 bins

--- a/test/src/unittests/spectral/test_mfcc.py
+++ b/test/src/unittests/spectral/test_mfcc.py
@@ -89,16 +89,58 @@ class TestMFCC(TestCase):
         self.assertAlmostEqualVector( mean(pool['mfcc'], 0), expected ,1e0)    
 
 
-    def testZero(self):
+    def testZerodBamp(self):
         # zero input should return dct(lin2db(0)). Try with different sizes
         size = 1025
         val = amp2db(0)
         expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
         while (size > 256):
-            bands, mfcc = MFCC()(zeros(size))
+            bands, mfcc = MFCC(inputSize=size)(zeros(size))
             self.assertEqualVector(mfcc, expected)
+
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(mfcc).any() and not np.isinf(mfcc).any())    
             size = int(size/2)
 
+    def testZerodbPow(self):
+        # zero input should return dct(lin2db(0)). Try with different sizes
+        size = 1025
+        val = pow2db(0)
+        expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
+        while (size > 256):
+            bands, mfcc = MFCC(inputSize=size, logType='dbpow')(zeros(size))
+            self.assertEqualVector(mfcc, expected)
+
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(mfcc).any() and not np.isinf(mfcc).any())    
+            size = int(size/2)
+
+    def testZeroLog(self):
+        # zero input should return dct(lin2db(0)). Try with different sizes
+        size = 1025
+        val = -np.inf # this one has to be replaced with lin2log(0) when 
+                      # the branch mfcc_thresholding is merged. 
+        expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
+        while (size > 256):
+            bands, mfcc = MFCC(inputSize=size, logType='log')(zeros(size))
+            self.assertEqualVector(mfcc, expected)
+
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(mfcc).any() and not np.isinf(mfcc).any())    
+            size = int(size/2)
+
+    def testZeroNatural(self):
+        # zero input should return dct(lin2db(0)). Try with different sizes
+        size = 1025
+        val = 0.
+        expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
+        while (size > 256):
+            bands, mfcc = MFCC(inputSize=size, logType='natural')(zeros(size))
+            self.assertEqualVector(mfcc, expected)
+            
+            # also assess that the thresholding is working
+            self.assertTrue(not np.isnan(mfcc).any() and not np.isinf(mfcc).any())    
+            size = int(size/2)
 
     def testInvalidInput(self):
         # mel bands should fail for a spectrum with less than 2 bins

--- a/test/src/unittests/spectral/test_mfcc.py
+++ b/test/src/unittests/spectral/test_mfcc.py
@@ -29,6 +29,7 @@ class TestMFCC(TestCase):
         return MFCC(inputSize = 1025,
                     sampleRate = 44100,
                     numberBands = 40,
+                    silenceThreshold = 1e-9,
                     numberCoefficients = numCoeffs,
                     lowFrequencyBound = 0,
                     highFrequencyBound = 11000)
@@ -89,7 +90,7 @@ class TestMFCC(TestCase):
         self.assertAlmostEqualVector( mean(pool['mfcc'], 0), expected ,1e0)    
 
 
-    def testZerodBamp(self):
+    def testZerodbAmp(self):
         # zero input should return dct(lin2db(0)). Try with different sizes
         size = 1025
         val = amp2db(0)
@@ -118,8 +119,8 @@ class TestMFCC(TestCase):
     def testZeroLog(self):
         # zero input should return dct(lin2db(0)). Try with different sizes
         size = 1025
-        val = -np.inf # this one has to be replaced with lin2log(0) when 
-                      # the branch mfcc_thresholding is merged. 
+        val = lin2log(0)
+
         expected = DCT(inputSize=40, outputSize=13)([val for x in range(40)])
         while (size > 256):
             bands, mfcc = MFCC(inputSize=size, logType='log')(zeros(size))


### PR DESCRIPTION
Added a new `testZero` unit test for each available `logType` as suggested in #731.  Also added a line to test that nans or infs are never returned.  For now, `testZeroLog`  will fail until we merge [mfcc_thresholding](https://github.com/MTG/essentia/tree/mfcc_thresholding).