### PR TITLE
Minimum peak distance parameter for PeakDetection

### DIFF
--- a/src/algorithms/standard/peakdetection.cpp
+++ b/src/algorithms/standard/peakdetection.cpp
@@ -174,7 +174,7 @@ void PeakDetection::compute() {
     Real minPos;
     Real maxPos;
     
-    // iterate following an amplitide hierarchy
+    // iterate following an amplitude hierarchy
     std::sort(peaks.begin(), peaks.end(),
           ComparePeakMagnitude<std::greater<Real>, std::less<Real> >());
 

--- a/src/algorithms/standard/peakdetection.h
+++ b/src/algorithms/standard/peakdetection.h
@@ -39,6 +39,7 @@ class PeakDetection : public Algorithm {
   Real _range;
   bool _interpolate;
   std::string _orderBy;
+  Real _minPeakDistance;
 
  public:
   PeakDetection() {
@@ -55,6 +56,7 @@ class PeakDetection : public Algorithm {
     declareParameter("threshold", "peaks below this given threshold are not output", "(-inf,inf)", -1e6);
     declareParameter("orderBy", "the ordering type of the output peaks (ascending by position or descending by value)", "{position,amplitude}", "position");
     declareParameter("interpolate", "boolean flag to enable interpolation", "{true,false}", true);
+    declareParameter("minPeakDistance", "minimum distance between consecutive peaks (0 to bypass this feature)", "[0,inf)", 0.0);
   }
 
   void configure();

--- a/test/src/unittests/standard/test_peakdetection.py
+++ b/test/src/unittests/standard/test_peakdetection.py
@@ -246,7 +246,7 @@ class TestPeakDetection(TestCase):
         input[smallerPeakPos] = 1.0
         inputSize = len(input)
         
-        # default behaviour: 2 peaks expected.
+        # default behaviour: 2 peaks expected
         config = { 'range': inputSize-1,  'maxPosition': inputSize-1, 'orderBy': 'amplitude',
                    'interpolate': False }
         pdetect = PeakDetection(**config)

--- a/test/src/unittests/standard/test_peakdetection.py
+++ b/test/src/unittests/standard/test_peakdetection.py
@@ -238,6 +238,31 @@ class TestPeakDetection(TestCase):
         PeakDetection(threshold=0)
         self.assertConfigureFails(PeakDetection(), {'minPosition': 1.01,  'maxPosition': 1})
 
+    def testMinPeakDistance(self):
+        peakPos = 2
+        smallerPeakPos = 4
+        input=[0,0,0,0,0]
+        input[peakPos] = 2.0
+        input[smallerPeakPos] = 1.0
+        inputSize = len(input)
+        
+        # default behaviour: 2 peaks expected.
+        config = { 'range': inputSize-1,  'maxPosition': inputSize-1, 'orderBy': 'amplitude',
+                   'interpolate': False }
+        pdetect = PeakDetection(**config)
+        (posis, vals) = pdetect(input)
+
+        self.assertEqualVector(posis, [peakPos, smallerPeakPos])
+        self.assertEqualVector(vals, [2.0, 1.0])
+
+        # with 'minPeakDistance': 1 peak expected
+        config = { 'range': inputSize-1,  'maxPosition': inputSize-1, 'orderBy': 'amplitude',
+                   'minPeakDistance': 3.0, 'interpolate': False }
+        pdetect = PeakDetection(**config)
+        (posis, vals) = pdetect(input)
+        self.assertEqualVector(posis, [peakPos])
+        self.assertEqualVector(vals, [2.0])
+
 suite = allTests(TestPeakDetection)
 
 if __name__ == '__main__':

--- a/test/src/unittests/standard/test_peakdetection.py
+++ b/test/src/unittests/standard/test_peakdetection.py
@@ -263,6 +263,42 @@ class TestPeakDetection(TestCase):
         self.assertEqualVector(posis, [peakPos])
         self.assertEqualVector(vals, [2.0])
 
+    def testMinPeakDistanceSorting(self):
+        # Test the sorting options when appliying
+        # some minimum peak distance
+
+        peak1, peak2, peak3 = 1, 3, 5
+        
+        input=[0] * 6
+        input[peak1] = 4.0
+        input[peak2] = 1.0
+        input[peak3] = 5.0
+        
+        inputSize = len(input)
+
+        peakDetection = PeakDetection()
+        
+        # case 1: ordered by magnitude
+        config = { 'range': inputSize-1,  'maxPosition': inputSize-1, 'orderBy': 'amplitude',
+                   'minPeakDistance': 3.0, 'interpolate': False }
+
+        peakDetection.configure(**config)
+        (posis, vals) = peakDetection(input)
+
+        self.assertEqualVector(posis, [peak3, peak1])
+        self.assertEqualVector(vals, [5.0, 4.0])
+        
+        # case 1: ordered by position
+        config = { 'range': inputSize-1,  'maxPosition': inputSize-1, 'orderBy': 'position',
+                   'minPeakDistance': 3.0, 'interpolate': False }
+
+        peakDetection.configure(**config)
+        (posis, vals) = peakDetection(input)
+
+        self.assertEqualVector(posis, [peak1, peak3])
+        self.assertEqualVector(vals, [4.0, 5.0])
+
+
 suite = allTests(TestPeakDetection)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a new parameter `minPeakDistance` that sets the minimum distance between contiguous peaks. A value of `0` (by default) will bypass this feature. The algorithm uses an amplitude criterium to choose which peaks to delete.
![peaks](https://user-images.githubusercontent.com/16823825/40972249-6d242856-68c0-11e8-9336-c802718f8517.png)
 