### PR TITLE
NSGConstantQ testNyquist unit test failing in python 3

### DIFF
--- a/test/src/unittests/standard/test_nsgconstantq.py
+++ b/test/src/unittests/standard/test_nsgconstantq.py
@@ -73,9 +73,9 @@ class TestNSGConstantQ(TestCase):
 
     def testNyquist(self):
         inputSize = 2**11
-        signalNyquist = [-1,  1] * (inputSize / 2)
+        signalNyquist = [-1,  1] * int(inputSize / 2)
 
-        CQ, DC, Nyquist = self.initNsgconstantq()(signalNyquist)
+        CQ, DC, Nyquist = self.initNsgconstantq(inputSize=inputSize)(signalNyquist)
 
         # Checks that all the energy is contained in the Nyquist band
         self.assertEqual(np.sum(np.abs(CQ)), 0)


### PR DESCRIPTION
Fixes #749 by casting the result of the division to `int`.