### PR TITLE
Add flag for C++ standard (force C++11 by default)

### DIFF
--- a/src/algorithms/standard/constantq.cpp
+++ b/src/algorithms/standard/constantq.cpp
@@ -100,7 +100,7 @@ void ConstantQ::configure() {
   SparseKernel *sk = new SparseKernel();
 
   // Initialise temporal kernel with zeros, twice length to deal with complex numbers
-  vector<complex<double> > hammingWindow(_FFTLength, 0.0 + 0.0i);
+  vector<complex<double> > hammingWindow(_FFTLength, complex<double>(0, 0));
   vector<complex<Real> > transfHammingWindowR(_FFTLength, complex<Real>(0, 0));
 
   sk->_sparseKernelIs.reserve( _FFTLength*2 );
@@ -116,7 +116,7 @@ void ConstantQ::configure() {
   for (int k=_uK; k--; ) {
 
     // Compute a hamming window
-    hammingWindow.assign(_FFTLength, 0.0 + 0.0i);
+    hammingWindow.assign(_FFTLength, complex<double>(0, 0));
     const int hammingLength = (int) ceil( _dQ * _sampleRate / ( _minFrequency * pow(2,((double)(k))/(double)_binsPerOctave)));
     int origin = _FFTLength/2 - hammingLength/2;
 

--- a/wscript
+++ b/wscript
@@ -46,6 +46,10 @@ def options(ctx):
                    dest='MODE', default="release",
                    help='debug or release')
 
+    ctx.add_option('--std', action='store',
+                   dest='STD', default='c++11',
+                   help='C++ standard to compile for [c++11 c++14 c++17 ...]')
+
     ctx.add_option('--arch', action='store',
                    dest='ARCH', default="x64",
                    help='Target architecture when compiling on OSX: i386, x64 or FAT')
@@ -108,11 +112,13 @@ def configure(ctx):
     ctx.env.WITH_CPPTESTS = ctx.options.WITH_CPPTESTS
 
     # compiler flags
+    ctx.env.CXXFLAGS = ['-std=' + ctx.options.STD]  # c++11 by default
+
     if sys.platform != 'win32':
         # msvc does not support -pipe
-        ctx.env.CXXFLAGS = ['-pipe', '-Wall']
+        ctx.env.CXXFLAGS += ['-pipe', '-Wall']
     else:
-        ctx.env.CXXFLAGS = ['-W2', '-EHsc']
+        ctx.env.CXXFLAGS += ['-W2', '-EHsc']
 
     # force using SSE floating point (default for 64bit in gcc) instead of
     # 387 floating point (used for 32bit in gcc) to avoid numerical differences


### PR DESCRIPTION
- New waf configure flag for the C++ standard (force C++11 by default)
- Fix compìlation error in ConstantQ