### PR TITLE
Key updates fixes

### DIFF
--- a/src/algorithms/tonal/chordsdescriptors.cpp
+++ b/src/algorithms/tonal/chordsdescriptors.cpp
@@ -31,7 +31,7 @@ const char* ChordsDescriptors::description = DOC("Given a chord progression this
 "Note:\n"
 "  - chordsHistogram indexes follow the circle of fifths order, while being shifted to the input key and scale\n"
 "  - key and scale are taken from the most frequent chord. In the case where multiple chords are equally frequent, the chord is hierarchically chosen from the circle of fifths.\n"
-"  - valid chords are C, Em, G, Bm, D, F#m, A, C#m, E, G#m, B, D#m, F#, A#m, C#, Fm, G#, Cm, D#, Gm, A#, Dm, F, Am. Chords that not follow this terminology (i.e. Gb) will raise an exception.\n"
+"  - chords should follow this name convention `<A-G>[<#/b><m>]` (i.e. C, C# or C#m are valid chords). Chord names not fitting this convention will throw an exception.\n"
 "\n"
 "Input chords vector may not be empty, otherwise an exception is thrown.\n"
 "\n"
@@ -41,13 +41,14 @@ const char* ChordsDescriptors::description = DOC("Given a chord progression this
 "  [2] Circle of fifths - Wikipedia, the free encyclopedia,\n"
 "  http://en.wikipedia.org/wiki/Circle_of_fifths");
 
-const char* ChordsDescriptors::circleOfFifth[] = { "C", "Em", "G", "Bm", "D", "F#m", "A", "C#m", "E", "G#m", "B", "D#m", "F#", "A#m", "C#", "Fm", "G#", "Cm", "D#", "Gm", "A#", "Dm", "F", "Am"};
+const char* ChordsDescriptors::circleOfFifth[] = { "C", "Em", "G", "Bm", "D", "F#m", "A", "C#m", "E", "Abm", "B", "Ebm", "F#", "Bbm", "C#", "Fm", "Ab", "Cm", "Eb", "Gm", "Bb", "Dm", "F", "Am"};
+const char* ChordsDescriptors::circleOfFifthAlternativeNames[] = { "C", "Em", "G", "Bm", "D", "Gbm", "A", "Dbm", "E", "G#m", "B", "D#m", "Gb", "A#m", "Db", "Fm", "G#", "Cm", "D#", "Gm", "A#", "Dm", "F", "Am"};
 
 
 
 int ChordsDescriptors::chordIndex(const string& chord) {
   for (int i=0; i<int(ARRAY_SIZE(circleOfFifth)); ++i) {
-    if (chord == circleOfFifth[i]) {
+    if (chord == circleOfFifth[i] || chord ==  circleOfFifthAlternativeNames[i]) {
       return i;
     }
   }

--- a/src/algorithms/tonal/chordsdescriptors.h
+++ b/src/algorithms/tonal/chordsdescriptors.h
@@ -39,6 +39,7 @@ class ChordsDescriptors : public Algorithm {
   Output<std::string> _chordsScale;
 
   static const char* circleOfFifth[];
+  static const char* circleOfFifthAlternativeNames[];
   int chordIndex(const std::string& chord);
   std::map<int, Real> chordsHistogram(const std::vector<std::string>& chords);
   std::map<int, Real> chordsHistogramNorm(std::map<int, Real>& histogram,

--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -882,6 +882,61 @@ TNT::Array2D<T> transpose(const TNT::Array2D<T>& m) {
   return result;
 }
 
+inline std::string equivalentKey(const std::string key) {
+  if (key == "C")
+    return "C";
+
+  if (key == "C#")
+    return "Db";
+
+  if (key == "Db")
+    return "C#";
+
+  if (key == "D")
+    return "D";
+
+  if (key == "D#")
+    return "Eb";
+
+  if (key == "Eb")
+    return "D#";
+
+  if (key == "E")
+    return "E";
+
+  if (key == "F")
+    return "F";
+
+  if (key == "F#")
+    return "Gb";
+
+  if (key == "Gb")
+    return "F#";
+
+  if (key == "G")
+    return "G";
+
+  if (key == "G#")
+    return "Ab";
+
+  if (key == "Ab")
+    return "G#";
+
+  if (key == "A")
+    return "A";
+
+  if (key == "A#")
+    return "Bb";
+
+  if (key == "Bb")
+    return "A#";
+
+  if (key == "B")
+    return "B";
+
+  return "";
+}
+
 } // namespace essentia
 
 #endif // ESSENTIA_MATH_H

--- a/src/python/essentia/utils.py
+++ b/src/python/essentia/utils.py
@@ -60,6 +60,9 @@ def mel2hz(arg):
 def hz2mel(arg):
     return _essentia.hz2mel( _c.convertData(arg, _c.Edt.REAL) )
 
+def equivalentKey(arg):
+    return _essentia.equivalentKey( _c.convertData(arg, _c.Edt.STRING) )
+
 def postProcessTicks(arg1, arg2=None, arg3=None):
     if arg2 != None and arg3 != None:
         return _essentia.postProcessTicks(_c.convertData(arg1, _c.Edt.VECTOR_REAL),
@@ -81,4 +84,5 @@ __all__ = [ 'isSilent', 'instantPower',
             'bark2hz', 'hz2bark',
             'mel2hz', 'hz2mel',
             'postProcessTicks',
-            'normalize', 'derivative']
+            'normalize', 'derivative',
+            'equivalentKey']

--- a/src/python/globalfuncs.cpp
+++ b/src/python/globalfuncs.cpp
@@ -378,6 +378,19 @@ hzToMel(PyObject* notUsed, PyObject* arg) {
   return PyFloat_FromDouble( double(mel) );
 }
 
+
+static PyObject*
+getEquivalentKey(PyObject* notUsed, PyObject* arg) {
+  if (!PyString_Check(arg)) {
+    PyErr_SetString(PyExc_TypeError, (char*)"argument must be an string");
+    return NULL;
+  }
+
+  std::string key = equivalentKey( PyString_AS_STRING(arg) );
+  const char *c_key = key.c_str();
+  return PyString_FromString( c_key );
+}
+
 template <typename T>
 PyObject* algorithmInfo(T* algo) {
   PyObject* result = PyDict_New();
@@ -967,24 +980,25 @@ static PyMethodDef Essentia__Methods[] = {
   { "log_warning",     (PyCFunction)log_warning,           METH_O,       "log the string to the warning stream." },
   { "log_error",       (PyCFunction)log_error,             METH_O,       "log the string to the error stream." },
 
-  { "normalize",    normalize,      METH_O,     "returns the normalized array." },
-  { "derivative",   derivative,     METH_O,     "returns the derivative of an array." },
-  { "isSilent",     is_silent,      METH_O, "returns true if the frame is silent." },
-  { "instantPower", instant_power,  METH_O, "returns the instant power of a frame." },
-  { "nextPowerTwo", next_power_two, METH_O, "returns the next power of two." },
-  { "isPowerTwo",   is_power_two,   METH_O, "returns true if argument is a power of two." },
-  { "bark2hz",      barkToHz,       METH_O, "Converts a bark band to frequency in Hz" },
-  { "hz2bark",      hzToBark,       METH_O, "Converts a frequency in Hz to a bark band" },
-  { "mel2hz",       melToHz,        METH_O, "Converts a mel band to frequency in Hz" },
-  { "hz2mel",       hzToMel,        METH_O, "Converts a frequency in Hz to a mel band" },
-  { "lin2db",       linToDb,        METH_O, "Converts a linear measure of power to a measure in dB" },
-  { "db2lin",       dbToLin,        METH_O, "Converts a dB measure of power to a linear measure" },
-  { "db2pow",       dbToPow,        METH_O, "Converts a dB measure of power to a linear measure" },
-  { "pow2db",       powToDb,        METH_O, "Converts a linear measure of power to a measure in dB" },
-  { "db2amp",       dbToAmp,        METH_O, "Converts a dB measure of amplitude to a linear measure" },
-  { "amp2db",       ampToDb,        METH_O, "Converts a linear measure of amplitude to a measure in dB" },
-  { "info",         standard_info,  METH_VARARGS, "returns all the information about a given classic algorithm." },
-  { "sinfo",        streaming_info, METH_VARARGS, "returns all the information about a given streaming algorithm." },
+  { "normalize",     normalize,        METH_O,     "returns the normalized array." },
+  { "derivative",    derivative,       METH_O,     "returns the derivative of an array." },
+  { "isSilent",      is_silent,        METH_O, "returns true if the frame is silent." },
+  { "instantPower",  instant_power,    METH_O, "returns the instant power of a frame." },
+  { "nextPowerTwo",  next_power_two,   METH_O, "returns the next power of two." },
+  { "isPowerTwo",    is_power_two,     METH_O, "returns true if argument is a power of two." },
+  { "bark2hz",       barkToHz,         METH_O, "Converts a bark band to frequency in Hz" },
+  { "hz2bark",       hzToBark,         METH_O, "Converts a frequency in Hz to a bark band" },
+  { "mel2hz",        melToHz,          METH_O, "Converts a mel band to frequency in Hz" },
+  { "hz2mel",        hzToMel,          METH_O, "Converts a frequency in Hz to a mel band" },
+  { "lin2db",        linToDb,          METH_O, "Converts a linear measure of power to a measure in dB" },
+  { "db2lin",        dbToLin,          METH_O, "Converts a dB measure of power to a linear measure" },
+  { "db2pow",        dbToPow,          METH_O, "Converts a dB measure of power to a linear measure" },
+  { "pow2db",        powToDb,          METH_O, "Converts a linear measure of power to a measure in dB" },
+  { "db2amp",        dbToAmp,          METH_O, "Converts a dB measure of amplitude to a linear measure" },
+  { "amp2db",        ampToDb,          METH_O, "Converts a linear measure of amplitude to a measure in dB" },
+  { "equivalentKey", getEquivalentKey, METH_O, "Returns an equivalent key name if exist or itself otherwise. An empty string is returned if the input is not a valid string" },
+  { "info",          standard_info,  METH_VARARGS, "returns all the information about a given classic algorithm." },
+  { "sinfo",         streaming_info, METH_VARARGS, "returns all the information about a given streaming algorithm." },
 
   { "totalProduced",   (PyCFunction)totalProduced,       METH_VARARGS, "returns the number of tokens written by algorithm's source." },
   { "connect",         (PyCFunction)connect,             METH_VARARGS, "Connects an algorithm's source to another algorithm's sink." },

--- a/test/src/unittests/tonal/test_chordsdescriptors.py
+++ b/test/src/unittests/tonal/test_chordsdescriptors.py
@@ -26,105 +26,130 @@ from essentia.streaming import ChordsDescriptors as sChordsDescriptors
 #circleOfFifth : "C", "Em", "G", "Bm", "D", "F#m", "A", "C#m", "E", "G#m", "B", "D#m", "F#", "A#m", "C#", "Fm", "G#", "Cm", "D#", "Gm", "A#", "Dm", "F", "Am";
 
 class TestChordsDescriptors(TestCase):
-      def testRegressionC(self):
-          chords = ['C', 'F', 'C', 'G', 'C', 'Am', 'Dm', 'G']
-          result = ChordsDescriptors()(chords, 'C', 'major')
-          expectedHist = [3./8., 0, 2./8., 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\
-                          0, 0, 0, 0, 0, 0, 1./8., 1./8., 1./8.]
-          self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
-          self.assertEqual(result[1], 5.0/8.0) #chord rate
-          self.assertEqual(result[2], 7.0/8.0) #change rate
-          self.assertEqual(result[3], 'C')     #key
-          self.assertEqual(result[4], 'major') #scale
+    def testRegressionC(self):
+        chords = ['C', 'F', 'C', 'G', 'C', 'Am', 'Dm', 'G']
+        result = ChordsDescriptors()(chords, 'C', 'major')
+        expectedHist = [3./8., 0, 2./8., 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\
+                        0, 0, 0, 0, 0, 0, 1./8., 1./8., 1./8.]
+        self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
+        self.assertEqual(result[1], 5.0/8.0) #chord rate
+        self.assertEqual(result[2], 7.0/8.0) #change rate
+        self.assertEqual(result[3], 'C')     #key
+        self.assertEqual(result[4], 'major') #scale
 
-      def testRegressionG(self):
-          # same test as above, but input key is different which will affect
-          # the output of the histogram:
-          chords = ['C', 'F', 'C', 'G', 'C', 'Am', 'Dm', 'G']
-          result = ChordsDescriptors()(chords, 'G', 'major')
-          expectedHist = [2./8., 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\
-                          0, 0, 0, 1./8., 1./8., 1./8., 3./8., 0]
+    def testRegressionG(self):
+        # same test as above, but input key is different which will affect
+        # the output of the histogram:
+        chords = ['C', 'F', 'C', 'G', 'C', 'Am', 'Dm', 'G']
+        result = ChordsDescriptors()(chords, 'G', 'major')
+        expectedHist = [2./8., 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\
+                        0, 0, 0, 1./8., 1./8., 1./8., 3./8., 0]
 
-          self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
-          self.assertEqual(result[1], 5.0/8.0) #chord rate
-          self.assertEqual(result[2], 7.0/8.0) #change rate
-          self.assertEqual(result[3], 'C')     #key
-          self.assertEqual(result[4], 'major') #scale
+        self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
+        self.assertEqual(result[1], 5.0/8.0) #chord rate
+        self.assertEqual(result[2], 7.0/8.0) #change rate
+        self.assertEqual(result[3], 'C')     #key
+        self.assertEqual(result[4], 'major') #scale
 
-      def testEqualProb(self):
-          chords = [ 'C', 'G', 'C', 'G', 'C', 'G' ]
-          result = ChordsDescriptors()(chords, 'C', 'major')
-          expectedHist = [0.5, 0, 0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          0, 0, 0, 0, 0, 0, 0]
+    def testEqualProb(self):
+        chords = [ 'C', 'G', 'C', 'G', 'C', 'G' ]
+        result = ChordsDescriptors()(chords, 'C', 'major')
+        expectedHist = [0.5, 0, 0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0]
 
-          self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
-          self.assertAlmostEqual(result[1], 2.0/6.0) #chord rate
-          self.assertAlmostEqual(result[2], 5.0/6.0) #change rate
-          self.assertEqual(result[3], 'C')     #key
-          self.assertEqual(result[4], 'major') #scale
+        self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
+        self.assertAlmostEqual(result[1], 2.0/6.0) #chord rate
+        self.assertAlmostEqual(result[2], 5.0/6.0) #change rate
+        self.assertEqual(result[3], 'C')     #key
+        self.assertEqual(result[4], 'major') #scale
 
-      def testCaseSensitivity(self):
-          chords = [ 'C', 'G', 'C', 'G', 'C', 'G' ]
-          result = ChordsDescriptors()(chords, 'c', 'MaJoR')
-          expectedHist = [0.5, 0, 0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          0, 0, 0, 0, 0, 0, 0]
+    def testCaseSensitivity(self):
+        chords = [ 'C', 'G', 'C', 'G', 'C', 'G' ]
+        result = ChordsDescriptors()(chords, 'c', 'MaJoR')
+        expectedHist = [0.5, 0, 0.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0]
 
-          self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
-          self.assertAlmostEqual(result[1], 2.0/6.0)  #chord rate
-          self.assertAlmostEqual(result[2], 5.0/6.0)  #change rate
-          self.assertEqual(result[3], 'C')      #key
-          self.assertEqual(result[4], 'major')  #scale
+        self.assertEqualVector(result[0], [hist*100 for hist in expectedHist])
+        self.assertAlmostEqual(result[1], 2.0/6.0)  #chord rate
+        self.assertAlmostEqual(result[2], 5.0/6.0)  #change rate
+        self.assertEqual(result[3], 'C')      #key
+        self.assertEqual(result[4], 'major')  #scale
 
-      def testUnknownChord(self):
-          chords = ['Cb', 'G', 'C', 'G', 'C', 'G']  # Cb will raise exception
-          self.assertComputeFails(ChordsDescriptors(), chords, 'C', 'major')
+    def testUnknownChord(self):
+        chords = ['Cb', 'G', 'C', 'G', 'C', 'G']  # Cb will raise exception
+        self.assertComputeFails(ChordsDescriptors(), chords, 'C', 'major')
 
-      def testUnknownKey(self):
-          self.assertComputeFails(ChordsDescriptors(), ['C', 'C'], 'Cb', 'major')
+    def testUnknownKey(self):
+        self.assertComputeFails(ChordsDescriptors(), ['C', 'C'], 'Cb', 'major')
 
-      def testEmpty(self):
-          self.assertComputeFails(ChordsDescriptors(), [], 'C', 'major')
+    def testEmpty(self):
+        self.assertComputeFails(ChordsDescriptors(), [], 'C', 'major')
 
-      def testOne(self):
-          result = ChordsDescriptors()(['C'], 'C', 'major')
-          self.assertEqualVector(result[0], [100]+[0]*23)
-          self.assertEqual(result[1], 1.0) #chord rate
-          self.assertEqual(result[2], 0.0) #change rate
-          self.assertEqual(result[3], 'C')     #key
-          self.assertEqual(result[4], 'major') #scale
+    def testOne(self):
+        result = ChordsDescriptors()(['C'], 'C', 'major')
+        self.assertEqualVector(result[0], [100]+[0]*23)
+        self.assertEqual(result[1], 1.0) #chord rate
+        self.assertEqual(result[2], 0.0) #change rate
+        self.assertEqual(result[3], 'C')     #key
+        self.assertEqual(result[4], 'major') #scale
 
-      def testRegressionStreaming(self):
-          chords = ['C', 'F', 'C', 'G', 'C', 'Am', 'Dm', 'G']
+    def testRegressionStreaming(self):
+        chords = ['C', 'F', 'C', 'G', 'C', 'Am', 'Dm', 'G']
 
-          chordsGen = VectorInput(chords)
-          keyGen = VectorInput(['C'])
-          scaleGen = VectorInput(['major'])
+        chordsGen = VectorInput(chords)
+        keyGen = VectorInput(['C'])
+        scaleGen = VectorInput(['major'])
 
-          algo = sChordsDescriptors()
-          pool = Pool()
+        algo = sChordsDescriptors()
+        pool = Pool()
 
-          chordsGen.data >> algo.chords
-          keyGen.data    >> algo.key
-          scaleGen.data   >> algo.scale
-          algo.chordsHistogram >>   (pool, "hist")
-          algo.chordsNumberRate >>  (pool, "rate")
-          algo.chordsChangesRate >> (pool, "change")
-          algo.chordsKey >>         (pool, "key")
-          algo.chordsScale >>       (pool, "scale")
+        chordsGen.data >> algo.chords
+        keyGen.data    >> algo.key
+        scaleGen.data   >> algo.scale
+        algo.chordsHistogram >>   (pool, "hist")
+        algo.chordsNumberRate >>  (pool, "rate")
+        algo.chordsChangesRate >> (pool, "change")
+        algo.chordsKey >>         (pool, "key")
+        algo.chordsScale >>       (pool, "scale")
 
 
-          keyGen.push("data", 'C')
-          scaleGen.push("data", 'major')
-          run(chordsGen)
+        keyGen.push("data", 'C')
+        scaleGen.push("data", 'major')
+        run(chordsGen)
 
-          expectedHist = [3./8., 0, 2./8., 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\
-                          0, 0, 0, 0, 0, 0, 1./8., 1./8., 1./8.]
-          self.assertEqualVector(pool['hist'], [hist*100 for hist in expectedHist])
-          self.assertEqual(pool['rate'], 5.0/8.0) #chord rate
-          self.assertEqual(pool['change'], 7.0/8.0) #change rate
-          self.assertEqual(pool['key'], 'C')     #key
-          self.assertEqual(pool['scale'], 'major') #scale
+        expectedHist = [3./8., 0, 2./8., 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\
+                        0, 0, 0, 0, 0, 0, 1./8., 1./8., 1./8.]
+        self.assertEqualVector(pool['hist'], [hist*100 for hist in expectedHist])
+        self.assertEqual(pool['rate'], 5.0/8.0) #chord rate
+        self.assertEqual(pool['change'], 7.0/8.0) #change rate
+        self.assertEqual(pool['key'], 'C')     #key
+        self.assertEqual(pool['scale'], 'major') #scale
 
+    def testEquivalentChordNames(self):
+        # Equivalent notes (eg. Eb <-> D#) should produce the same result.
+
+        scale = 'minor'
+        key='A'
+
+        a = ["A", "Bb", "B", "C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab"]
+        b = ["A", "A#", "B", "C", "Db", "D", "D#", "E", "F", "Gb", "G", "G#"]
+        
+        # Assert that if the notes are not equivalet the output is actually different
+        # to probe the validity of the test 
+        c = ["A", "D#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#"]
+
+        chordsHistogramA, chordsNumberRateA, _, chordsKeyA, chordsScaleA = ChordsDescriptors()(a, key, scale)
+        chordsHistogramB, chordsNumberRateB, _, chordsKeyB, chordsScaleB = ChordsDescriptors()(b, key, scale)
+        chordsHistogramC, chordsNumberRateC, _, chordsKeyC, chordsScaleC = ChordsDescriptors()(c, key, scale)
+
+        self.assertEqualVector(chordsHistogramA, chordsHistogramB)
+        self.assertEqual(chordsNumberRateA, chordsNumberRateB)
+        self.assertEqual(chordsKeyA, chordsKeyB)
+        self.assertEqualVector(chordsScaleA, chordsScaleB)
+
+        self.assertNotEquals(sum(abs(chordsHistogramA - chordsHistogramC)), 0)
+        self.assertNotEqual(chordsNumberRateA, chordsNumberRateC)
+        self.assertNotEqual(chordsKeyA, chordsKeyC)
 
 
 suite = allTests(TestChordsDescriptors)


### PR DESCRIPTION
This PR complements the recently added key updates (#814):

- updates  [ChordsDescriptors](https://github.com/MTG/essentia/blob/96531284a35ef6142c6e6ed80cad8b82a9751e2e/src/algorithms/tonal/chordsdescriptors.cpp) to accept the new [chord names](https://github.com/MTG/essentia/blob/08f04f61fc5439396871ec2498f28a03eb3b090e/src/algorithms/tonal/key.cpp#L80) used by `Key`.
- adds a function `equivalentKey` that given a chord name provides an equivalent name when available (e.g,  `equivalentKey(C#)` returns `Db`).
- a python wrapper for `equivalentKey`.

