### PR TITLE
Prevent the accidental (b or #) from being capitalized in ChordsDescriptors

### DIFF
--- a/src/algorithms/tonal/chordsdescriptors.cpp
+++ b/src/algorithms/tonal/chordsdescriptors.cpp
@@ -102,7 +102,8 @@ void ChordsDescriptors::compute() {
     throw EssentiaException("ChordsDescriptors: Chords input empty");
   }
 
-  string key = toUpper(_key.get());
+  string key = _key.get();
+  key[0] = toUpper(string(1, key[0]))[0];
   string scale = toLower(_scale.get());
 
   if (_scale.get() == "minor") {

--- a/src/algorithms/tonal/chordsdescriptors.cpp
+++ b/src/algorithms/tonal/chordsdescriptors.cpp
@@ -103,8 +103,18 @@ void ChordsDescriptors::compute() {
   }
 
   string key = _key.get();
+  
+  if (key.empty()) {
+    throw EssentiaException("ChordsDescriptors: Key input empty");
+  }
+
   key[0] = toUpper(string(1, key[0]))[0];
+  
   string scale = toLower(_scale.get());
+
+  if (scale.empty()) {
+    throw EssentiaException("ChordsDescriptors: Scale input empty");
+  }
 
   if (_scale.get() == "minor") {
     key += "m";

--- a/test/src/unittests/tonal/test_chordsdescriptors.py
+++ b/test/src/unittests/tonal/test_chordsdescriptors.py
@@ -149,11 +149,11 @@ class TestChordsDescriptors(TestCase):
         # Equivalent notes (eg. Eb <-> D#) should produce the same result.
 
         scale = 'minor'
-        key='A'
+        key = 'A'
 
         a = ["A", "Bb", "B", "C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab"]
         b = ["A", "A#", "B", "C", "Db", "D", "D#", "E", "F", "Gb", "G", "G#"]
-        
+
         # Assert that if the notes are not equivalet the output is actually different
         # to probe the validity of the test 
         c = ["A", "D#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#"]
@@ -170,6 +170,16 @@ class TestChordsDescriptors(TestCase):
         self.assertNotEquals(sum(abs(chordsHistogramA - chordsHistogramC)), 0)
         self.assertNotEqual(chordsNumberRateA, chordsNumberRateC)
         self.assertNotEqual(chordsKeyA, chordsKeyC)
+
+    # Checks whether an empty input yields an exception
+    def testEmptyChords(self):
+        self.assertComputeFails(ChordsDescriptors(),  [], 'A', 'minor')
+
+    def testEmptyKey(self):
+        self.assertComputeFails(ChordsDescriptors(),  ['A'], '', 'minor')
+
+    def testEmptyScale(self):
+        self.assertComputeFails(ChordsDescriptors(),  ['A'], 'A', '')
 
 
 suite = allTests(TestChordsDescriptors)

--- a/test/src/unittests/tonal/test_chordsdescriptors.py
+++ b/test/src/unittests/tonal/test_chordsdescriptors.py
@@ -75,9 +75,29 @@ class TestChordsDescriptors(TestCase):
         self.assertEqual(result[3], 'C')      #key
         self.assertEqual(result[4], 'major')  #scale
 
+    def testCaseSensitivityFlatKey(self):
+        # Checks that key is case-insensitive in presence of the flat sign.
+        upperCase = 'Db'
+        lowerCase = 'db'
+        chords = ['Db', 'Ab', 'Db', 'Ab', 'Db', 'Ab']
+
+        resultUpper = ChordsDescriptors()(chords, upperCase, 'MaJoR')
+        resultLower = ChordsDescriptors()(chords, lowerCase, 'MaJoR')
+
+        self.assertEqualVector(resultUpper[0], resultLower[0])
+        self.assertAlmostEqual(resultUpper[1], resultLower[1])  #chord rate
+        self.assertAlmostEqual(resultUpper[2], resultLower[2])  #change rate
+        self.assertEqual(resultUpper[3], resultLower[3])      #key
+        self.assertEqual(resultUpper[4], resultLower[4])  #scale
+
+
     def testUnknownChord(self):
         chords = ['Cb', 'G', 'C', 'G', 'C', 'G']  # Cb will raise exception
         self.assertComputeFails(ChordsDescriptors(), chords, 'C', 'major')
+
+    def testIncorrectFlatSign(self):
+        chords = ['DB', 'AB', 'DB', 'AB', 'DB', 'AB']  # "B" is not accepted for flat.
+        self.assertComputeFails(ChordsDescriptors(), chords, 'DB', 'major')
 
     def testUnknownKey(self):
         self.assertComputeFails(ChordsDescriptors(), ['C', 'C'], 'Cb', 'major')


### PR DESCRIPTION
In the previous note naming convention sharp ("#") was used to name every not natural note and it was safe to capitalize the whole key string as "#" is not affected by `toUpper`.
Now the `Key` algorithm also outputs some flats ("b") so `toUpper` cannot be applied to the accidental anymore as "B" is not accepted for flat.