### PR TITLE
NSGConstantQ: Update the default parameters and repeat the last sample in odd signals

### DIFF
--- a/src/algorithms/standard/nsgconstantq.cpp
+++ b/src/algorithms/standard/nsgconstantq.cpp
@@ -279,11 +279,11 @@ void NSGConstantQ::compute() {
   }
 
   // FFT requires an even input, but in order to push back
-  // we needed to copy the data first. When it is alredy
+  // we needed to copy the data first. When it is already
   // even we can just use a reference to the input buffer
   // to avoid the copy.
-  if(originalSignal.size() % 2) {
-    E_INFO("Odd input. Repeating the last Sample.");
+  if (originalSignal.size() % 2) {
+    E_INFO("NSGConstantQ: Odd input. Duplicating the last sample to get even size.");
 
     paddedSignal = originalSignal;
     

--- a/src/algorithms/standard/nsgconstantq.cpp
+++ b/src/algorithms/standard/nsgconstantq.cpp
@@ -47,6 +47,13 @@ void NSGConstantQ::configure() {
   _minimumWindow = parameter("minimumWindow").toInt();
   _windowSizeFactor = parameter("windowSizeFactor").toInt();
 
+  // Force an even inputSize so FFT doesn't throw
+  // an exception. If the input signal is odd it 
+  // will be padded on runtime.
+  if (_inputSize % 2) {
+    _inputSize++;
+  }
+
   designWindow();
   createCoefficients();
   normalize();

--- a/src/algorithms/standard/nsgconstantq.cpp
+++ b/src/algorithms/standard/nsgconstantq.cpp
@@ -258,17 +258,33 @@ void NSGConstantQ::normalize() {
 
 
 void NSGConstantQ::compute() {
-  const std::vector<Real>& signal = _signal.get();
+  const std::vector<Real>& originalSignal = _signal.get();
   std::vector<std::vector<complex<Real> > >& constantQ = _constantQ.get();
   std::vector<complex<Real> >& constantQDC = _constantQDC.get();
   std::vector<complex<Real> >& constantQNF = _constantQNF.get();
 
   std::vector<complex<Real> > fft;
   std::vector<int> posit;
+  std::vector<Real> paddedSignal;
 
-  if (signal.size() <= 1) {
+  if (originalSignal.size() <= 1) {
     throw EssentiaException("NSGConstantQ: the size of the input signal is not greater than one");
   }
+
+  // FFT requires an even input, but in order to push back
+  // we needed to copy the data first. When it is alredy
+  // even we can just use a reference to the input buffer
+  // to avoid the copy.
+  if(originalSignal.size() % 2) {
+    E_INFO("Odd input. Repeating the last Sample.");
+
+    paddedSignal = originalSignal;
+    
+    // Repeat the last sample if the signal is odd.
+    paddedSignal.push_back(originalSignal.back());
+  }
+
+  const vector<Real>& signal = (originalSignal.size() % 2) ? paddedSignal : originalSignal;
 
   // Check input. If different shape reconfigure the algorithm
   if (signal.size() != _inputSize) {

--- a/src/algorithms/standard/nsgconstantq.h
+++ b/src/algorithms/standard/nsgconstantq.h
@@ -53,15 +53,15 @@ class NSGConstantQ : public Algorithm {
   }
 
   void declareParameters() {
-    declareParameter("inputSize", "the size of the input", "(0,inf)", 1024);
+    declareParameter("inputSize", "the size of the input", "(0,inf)", 4096);
     declareParameter("minFrequency", "the minimum frequency", "(0,inf)", 27.5);
-    declareParameter("maxFrequency", "the maximum frequency", "(0,inf)", 55);
-    declareParameter("binsPerOctave", "the number of bins per octave", "[1,inf)", 12);
+    declareParameter("maxFrequency", "the maximum frequency", "(0,inf)", 7040.);
+    declareParameter("binsPerOctave", "the number of bins per octave", "[1,inf)", 48);
     declareParameter("sampleRate", "the desired sampling rate [Hz]", "[0,inf)", 44100.);
     declareParameter("rasterize", "hop sizes for each frequency channel. With 'none' each frequency channel is distinct. 'full' sets the hop sizes of all the channels to the smallest. 'piecewise' rounds down the hop size to a power of two", "{none,full,piecewise}", "full");
     declareParameter("phaseMode", "'local' to use zero-centered filters. 'global' to use a phase mapping function as described in [1]", "{local,global}", "global");
     declareParameter("gamma", "The bandwidth of each filter is given by Bk = 1/Q * fk + gamma", "[0,inf)", 0);
-    declareParameter("normalize", "coefficient normalization", "{sine,impulse,none}", "sine");
+    declareParameter("normalize", "coefficient normalization", "{sine,impulse,none}", "none");
     declareParameter("window","the type of window for the frequency filters. It is not recommended to change the default window.","{hamming,hann,hannnsgcq,triangular,square,blackmanharris62,blackmanharris70,blackmanharris74,blackmanharris92}","hannnsgcq");
     declareParameter("minimumWindow", "minimum size allowed for the windows", "[2,inf)", 4);
     declareParameter("windowSizeFactor", "window sizes are rounded to multiples of this", "[1,inf)", 1);

--- a/src/algorithms/standard/nsgconstantqstreaming.h
+++ b/src/algorithms/standard/nsgconstantqstreaming.h
@@ -43,16 +43,16 @@ class NSGConstantQStreaming : public Algorithm{
  // }
 
   void declareParameters() {
-    declareParameter("inputSize", "the size of the input", "(0,inf)", 1024);
+    declareParameter("inputSize", "the size of the input", "(0,inf)", 4096);
     declareParameter("minFrequency", "the minimum frequency", "(0,inf)", 27.5);
-    declareParameter("maxFrequency", "the maximum frequency", "(0,inf)", 55);
-    declareParameter("binsPerOctave", "the number of bins per octave", "[1,inf)", 12);
+    declareParameter("maxFrequency", "the maximum frequency", "(0,inf)", 7040.);
+    declareParameter("binsPerOctave", "the number of bins per octave", "[1,inf)", 48);
     declareParameter("sampleRate", "the desired sampling rate [Hz]", "[0,inf)", 44100.);
     declareParameter("rasterize", "hop sizes for each frequency channel. With 'none' each frequency channel is distinct. 'full' sets the hop sizes of all the channels to the smallest. 'piecewise' rounds down the hop size to a power of two", "{none,full,piecewise}", "full");
     declareParameter("phaseMode", "'local' to use zero-centered filters. 'global' to use a phase mapping function as described in [1]", "{local,global}", "global");
     declareParameter("gamma", "The bandwidth of each filter is given by Bk = 1/Q * fk + gamma", "[0,inf)", 0);
-    declareParameter("normalize", "coefficient normalization", "{sine,impulse,none}", "sine");
-    declareParameter("window","the type of window for the frequency filter. It is not recommended to change the default window.","{hamming,hann,hannnsgcq,triangular,square,blackmanharris62,blackmanharris70,blackmanharris74,blackmanharris92}","hannnsgcq");
+    declareParameter("normalize", "coefficient normalization", "{sine,impulse,none}", "none");
+    declareParameter("window","the type of window for the frequency filters. It is not recommended to change the default window.","{hamming,hann,hannnsgcq,triangular,square,blackmanharris62,blackmanharris70,blackmanharris74,blackmanharris92}","hannnsgcq");
     declareParameter("minimumWindow", "minimum size allowed for the windows", "[2,inf)", 4);
     declareParameter("windowSizeFactor", "window sizes are rounded to multiples of this", "[1,inf)", 1);
     }

--- a/src/algorithms/standard/nsgiconstantq.cpp
+++ b/src/algorithms/standard/nsgiconstantq.cpp
@@ -47,6 +47,13 @@ void NSGIConstantQ::configure() {
   _minimumWindow = parameter("minimumWindow").toInt();
   _windowSizeFactor = parameter("windowSizeFactor").toInt();
 
+  if (_inputSize % 2) {
+    _oddInput = true;
+    _inputSize++;
+  } else {
+    _oddInput = false;
+  }
+
   designWindow();
   createCoefficients();
   normalize();
@@ -372,6 +379,14 @@ void NSGIConstantQ::compute() {
   signal.resize(_NN);
   for (int i=0; i<_NN; i++){
     signal[i] = std::real(output[i]);
+  }
+
+  // If the algorithm was configured with an odd size
+  // it means that the last sample was added on the
+  // forward pass and should be removed in order to
+  // get the original size.
+  if (_oddInput) {
+    signal.pop_back();
   }
 }
 

--- a/src/algorithms/standard/nsgiconstantq.h
+++ b/src/algorithms/standard/nsgiconstantq.h
@@ -114,6 +114,7 @@ class NSGIConstantQ : public Algorithm {
   std::vector<std::vector<int> > _win_range;
   std::vector<std::vector<int> > _idx;
 
+  bool _oddInput;
 
   void designDualFrame();
 

--- a/src/algorithms/standard/nsgiconstantq.h
+++ b/src/algorithms/standard/nsgiconstantq.h
@@ -53,16 +53,16 @@ class NSGIConstantQ : public Algorithm {
   }
 
   void declareParameters() {
-    declareParameter("inputSize", "the size of the input", "(0,inf)", 1024);
+    declareParameter("inputSize", "the size of the input", "(0,inf)", 4096);
     declareParameter("minFrequency", "the minimum frequency", "(0,inf)", 27.5);
-    declareParameter("maxFrequency", "the maximum frequency", "(0,inf)", 55);
-    declareParameter("binsPerOctave", "the number of bins per octave", "[1,inf)", 12);
+    declareParameter("maxFrequency", "the maximum frequency", "(0,inf)", 7040.);
+    declareParameter("binsPerOctave", "the number of bins per octave", "[1,inf)", 48);
     declareParameter("sampleRate", "the desired sampling rate [Hz]", "[0,inf)", 44100.);
     declareParameter("rasterize", "hop sizes for each frequency channel. With 'none' each frequency channel is distinct. 'full' sets the hop sizes of all the channels to the smallest. 'piecewise' rounds down the hop size to a power of two", "{none,full,piecewise}", "full");
     declareParameter("phaseMode", "'local' to use zero-centered filters. 'global' to use a phase mapping function as described in [1]", "{local,global}", "global");
     declareParameter("gamma", "The bandwidth of each filter is given by Bk = 1/Q * fk + gamma", "[0,inf)", 0);
-    declareParameter("normalize", "coefficient normalization", "{sine,impulse,none}", "sine");
-    declareParameter("window","the type of window for the frequency filter. It is not recommended to change the default window.","{hamming,hann,hannnsgcq,triangular,square,blackmanharris62,blackmanharris70,blackmanharris74,blackmanharris92}","hannnsgcq");
+    declareParameter("normalize", "coefficient normalization", "{sine,impulse,none}", "none");
+    declareParameter("window","the type of window for the frequency filters. It is not recommended to change the default window.","{hamming,hann,hannnsgcq,triangular,square,blackmanharris62,blackmanharris70,blackmanharris74,blackmanharris92}","hannnsgcq");
     declareParameter("minimumWindow", "minimum size allowed for the windows", "[2,inf)", 4);
     declareParameter("windowSizeFactor", "window sizes are rounded to multiples of this", "[1,inf)", 1);
     }

--- a/test/src/unittests/standard/test_nsgconstantq.py
+++ b/test/src/unittests/standard/test_nsgconstantq.py
@@ -109,6 +109,12 @@ class TestNSGConstantQ(TestCase):
         self.assertConfigureFails(self.initNsgconstantq(), {'minimumWindow': 1})
         self.assertConfigureFails(self.initNsgconstantq(), {'windowSizeFactor': 0})
         self.assertConfigureFails(self.initNsgconstantq(), {'minimumWindow': 1})
+
+    def testOddInput(self):
+        # Checks that compute does not fail for even input (former behavior).
+        a = np.ones(4099, dtype='float32')
+        NSGConstantQ()(a)
+
     
 suite = allTests(TestNSGConstantQ)
 

--- a/test/src/unittests/standard/test_nsgiconstantq.py
+++ b/test/src/unittests/standard/test_nsgiconstantq.py
@@ -59,6 +59,16 @@ class TestNSGIConstantQ(TestCase):
 
         self.assertAlmostEqualVectorFixedPrecision(x, y, 3)
 
+    def testSynthetiseSineOddSize(self):
+        # Test the reconstruction capabilities for signals with an odd length.
+        inputSize = 2 ** 12 + 1
+        x = essentia.array(np.sin(2 * np.pi * 1000 * np.arange(inputSize) / 44100))
+
+        CQ, CQDC, DCNF= NSGConstantQ(inputSize=inputSize)(x)
+        y = NSGIConstantQ(inputSize=inputSize)(CQ, CQDC, DCNF)
+
+        self.assertAlmostEqualVectorFixedPrecision(x, y, 5)
+
     def testSynthetiseDC(self):
         x = essentia.array(np.ones(2**12))
 


### PR DESCRIPTION
This PR contains a few small changes to improve the algorithm's performance with the default parameters.
- updated default parameters so they work better in most of the cases.
- repeat the last sample if the input signal is odd so FFT does not throw an exception.
- add a unit test to assert it don't throw exceptions on odd signals as before.