### PR TITLE
Update MFCC thresholding

### DIFF
--- a/src/algorithms/spectral/gfcc.h
+++ b/src/algorithms/spectral/gfcc.h
@@ -65,7 +65,7 @@ class GFCC : public Algorithm {
     declareParameter("lowFrequencyBound", "the lower bound of the frequency range [Hz]", "[0,inf)", 40.);
     declareParameter("highFrequencyBound", "the upper bound of the frequency range [Hz]", "(0,inf)", 22050.);
     declareParameter("type", "use magnitude or power spectrum","{magnitude,power}", "power");
-    declareParameter("silenceThreshold", "silence threshold for computing log-energy bands", "(0,inf)", 1e-9);
+    declareParameter("silenceThreshold", "silence threshold for computing log-energy bands", "(0,inf)", 1e-10);
     declareParameter("logType","logarithmic compression type. Use 'dbpow' if working with power and 'dbamp' if working with magnitudes","{natural,dbpow,dbamp,log}","dbamp");
     declareParameter("dctType", "the DCT type", "[2,3]", 2);
   }

--- a/src/algorithms/spectral/mfcc.cpp
+++ b/src/algorithms/spectral/mfcc.cpp
@@ -28,7 +28,7 @@ const char* MFCC::name = "MFCC";
 const char* MFCC::category = "Spectral";
 const char* MFCC::description = DOC("This algorithm computes the mel-frequency cepstrum coefficients of a spectrum. As there is no standard implementation, the MFCC-FB40 is used by default:\n"
 "  - filterbank of 40 bands from 0 to 11000Hz\n"
-"  - take the log value of the spectrum energy in each mel band\n"
+"  - take the log value of the spectrum energy in each mel band. Bands energy values below silence threshold will be clipped to its value before computing log-energies\n"
 "  - DCT of the 40 bands down to 13 mel coefficients\n"
 "There is a paper describing various MFCC implementations [1].\n"
 "\n"
@@ -93,9 +93,12 @@ void MFCC::configure() {
                   INHERIT("liftering"));
   _logbands.resize(parameter("numberBands").toInt());
 
-  setCompressor(parameter("logType").toString());
-
+  _logType = parameter("logType").toLower();
+  _silenceThreshold = parameter("silenceThreshold").toReal();
+  _dbSilenceThreshold = 10 * log10(_silenceThreshold);
+  _logSilenceThreshold = log(_silenceThreshold);
 }
+
 
 void MFCC::compute() {
 
@@ -111,30 +114,25 @@ void MFCC::compute() {
 
   // take the dB amplitude of the spectrum
   for (int i=0; i<int(bands.size()); ++i) {
-    _logbands[i] = (*_compressor)(bands[i]);
+    if (_logType == "dbpow") {
+      _logbands[i] = pow2db(bands[i], _silenceThreshold, _dbSilenceThreshold);
+    }
+    else if (_logType == "dbamp") {
+      _logbands[i] = amp2db(bands[i], _silenceThreshold, _dbSilenceThreshold);
+    }
+    else if (_logType == "log") {
+      _logbands[i] = lin2log(bands[i], _silenceThreshold, _logSilenceThreshold);
+    }
+    else if (_logType == "natural") {
+      _logbands[i] = bands[i]; 
+    }
+    else {
+      throw EssentiaException("MFCC: Bad 'logType' parameter");
+    }
   }
 
   // compute the DCT of these bands
   _dct->input("array").set(_logbands);
   _dct->output("dct").set(mfcc);
   _dct->compute();
-}
-
-void MFCC::setCompressor(std::string logType){
-  if (logType == "natural"){
-    _compressor = linear;
-  }
-  else if (logType == "dbpow"){
-    _compressor = pow2db;
-  }
-  else if (logType == "dbamp"){
-    _compressor = amp2db;
-  }
-  else if (logType == "log"){
-    _compressor = log;
-  }
-  else{
-    throw EssentiaException("MFCC: Bad 'logType' parameter");
-  }
-
 }

--- a/src/algorithms/spectral/mfcc.h
+++ b/src/algorithms/spectral/mfcc.h
@@ -36,11 +36,10 @@ class MFCC : public Algorithm {
   Algorithm* _dct;
 
   std::vector<Real> _logbands;
-
-  typedef  Real (*funcPointer)(Real);
-  funcPointer _compressor;
-
-  void setCompressor(std::string logType);
+  std::string _logType;
+  Real _silenceThreshold;
+  Real _dbSilenceThreshold;
+  Real _logSilenceThreshold;
 
  public:
   MFCC() {
@@ -68,6 +67,7 @@ class MFCC : public Algorithm {
     declareParameter("weighting", "type of weighting function for determining triangle area","{warping,linear}","warping");
     declareParameter("normalize", "'unit_max' makes the vertex of all the triangles equal to 1, 'unit_sum' makes the area of all the triangles equal to 1","{unit_sum,unit_max}", "unit_sum");
     declareParameter("type", "use magnitude or power spectrum","{magnitude,power}", "power");
+    declareParameter("silenceThreshold", "silence threshold for computing log-energy bands", "(0,inf)", 1e-9);
     declareParameter("dctType", "the DCT type", "[2,3]", 2);
     declareParameter("liftering", "the liftering coefficient. Use '0' to bypass it", "[0,inf)", 0);
     declareParameter("logType","logarithmic compression type. Use 'dbpow' if working with power and 'dbamp' if working with magnitudes","{natural,dbpow,dbamp,log}","dbamp");

--- a/src/algorithms/spectral/mfcc.h
+++ b/src/algorithms/spectral/mfcc.h
@@ -67,7 +67,7 @@ class MFCC : public Algorithm {
     declareParameter("weighting", "type of weighting function for determining triangle area","{warping,linear}","warping");
     declareParameter("normalize", "'unit_max' makes the vertex of all the triangles equal to 1, 'unit_sum' makes the area of all the triangles equal to 1","{unit_sum,unit_max}", "unit_sum");
     declareParameter("type", "use magnitude or power spectrum","{magnitude,power}", "power");
-    declareParameter("silenceThreshold", "silence threshold for computing log-energy bands", "(0,inf)", 1e-9);
+    declareParameter("silenceThreshold", "silence threshold for computing log-energy bands", "(0,inf)", 1e-10);
     declareParameter("dctType", "the DCT type", "[2,3]", 2);
     declareParameter("liftering", "the liftering coefficient. Use '0' to bypass it", "[0,inf)", 0);
     declareParameter("logType","logarithmic compression type. Use 'dbpow' if working with power and 'dbamp' if working with magnitudes","{natural,dbpow,dbamp,log}","dbamp");

--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -386,12 +386,12 @@ template <typename T> T instantPower(const std::vector<T>& array) {
 // first. For this reason we set the silence cutoff as what should be silence
 // on a 16bit pcm file, that is (16bit - 1bit)*6.02 which yields -90.3 dB thus
 // aproximately -90
-#define silenceCutoff 1e-9
-#define dbSilenceCutoff -90
+#define SILENCE_CUTOFF 1e-10
+#define DB_SILENCE_CUTOFF -100
 
 // returns true if the signal average energy is below a cutoff value, here -90dB
 template <typename T> bool isSilent(const std::vector<T>& array) {
-  return instantPower(array) < silenceCutoff;
+  return instantPower(array) < SILENCE_CUTOFF;
 }
 
 // returns the variance of an array of TNT::Array2D<T> elements
@@ -501,9 +501,12 @@ template <typename T> T round(const T value) {
 
 
 inline Real lin2db(Real value) {
-  return value < silenceCutoff ? dbSilenceCutoff : (Real)10.0 * log10(value);
+  return value < SILENCE_CUTOFF ? DB_SILENCE_CUTOFF : (Real)10.0 * log10(value);
 }
 
+inline Real lin2db(Real value, Real silenceCutoff, Real dbSilenceCutoff) {
+  return value < silenceCutoff ? dbSilenceCutoff : (Real)10.0 * log10(value);
+}
 
 inline Real db2lin(Real value) {
   return pow((Real)10.0, value/(Real)10.0);
@@ -511,6 +514,10 @@ inline Real db2lin(Real value) {
 
 inline Real pow2db(Real power) {
   return lin2db(power);
+}
+
+inline Real pow2db(Real power, Real silenceCutoff, Real dbSilenceCutoff) {
+  return lin2db(power, silenceCutoff, dbSilenceCutoff);  
 }
 
 inline Real db2pow(Real power) {
@@ -521,6 +528,10 @@ inline Real amp2db(Real amplitude) {
   return Real(2.0)*lin2db(amplitude);
 }
 
+inline Real amp2db(Real amplitude, Real silenceCutoff, Real dbSilenceCutoff) {
+  return Real(2.0)*lin2db(amplitude, silenceCutoff, dbSilenceCutoff);  
+}
+
 inline Real db2amp(Real amplitude) {
   return db2lin(0.5*amplitude);
 }
@@ -528,6 +539,11 @@ inline Real db2amp(Real amplitude) {
 inline Real linear(Real input) {
   return input;
 }
+
+inline Real lin2log(Real input, Real silenceCutoff, Real logSilenceCutoff) {
+  return input < silenceCutoff ? logSilenceCutoff : log(input);
+}
+
 
 #ifdef OS_WIN32
 // The following function hz2bark needs the function asinh,

--- a/src/python/globalfuncs.cpp
+++ b/src/python/globalfuncs.cpp
@@ -17,7 +17,7 @@
  * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
  */
 
-#include "essentiamath.h" // for silenceCutoff
+#include "essentiamath.h" // for SILENCE_CUTOFF
 #include "streamingalgorithm.h"
 #include "poolstorage.h" // connecting pools
 #include "../algorithms/io/fileoutputproxy.h" // connecting FileOutput algorithm
@@ -238,8 +238,8 @@ is_silent(PyObject* self, PyObject* arg) {
 
   double p = internal_instant_power(arg);
 
-  if (p < silenceCutoff) Py_RETURN_TRUE;
-  else                   Py_RETURN_FALSE;
+  if (p < SILENCE_CUTOFF) Py_RETURN_TRUE;
+  else                    Py_RETURN_FALSE;
 }
 
 static PyObject*

--- a/test/src/unittest/spectral/test_hpcp.py
+++ b/test/src/unittest/spectral/test_hpcp.py
@@ -114,10 +114,10 @@ class TestHPCP(TestCase):
         self.assertEqualVector(hpcp, [0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.])
 
     def testSmallMinRange(self):
-        self.assertConfigureFails(HPCP(), {'minFrequency':1, 'splitFrequency':200})
+        self.assertConfigureFails(HPCP(), {'minFrequency':1, 'bandSplitFrequency':200})
 
     def testSmallMaxRange(self):
-        self.assertConfigureFails(HPCP(), {'maxFrequency':1199, 'splitFrequency':1000})
+        self.assertConfigureFails(HPCP(), {'maxFrequency':1199, 'bandSplitFrequency':1000})
 
     def testSmallMinMaxRange(self):
         self.assertConfigureFails(HPCP(), {'bandPreset':False, 'maxFrequency':200, 'minFrequency':1})


### PR DESCRIPTION
- Add silenceThreshold parameter to MFCC and GFCC
- Add configurable thresholding to lib2db, pow2db, amp2db
- Change silence threshold to 1e-10

This is a big change for MFCC/GFCC values, therefore, this PR should be tested in terms of the resulting performance of classifier models based on MFCCs/GFCCs (does the accuracy improve?).
