### PR TITLE
Add option to zero-center windows for EBU R128 loudness estimation

### DIFF
--- a/src/algorithms/temporal/loudnessebur128.cpp
+++ b/src/algorithms/temporal/loudnessebur128.cpp
@@ -131,24 +131,27 @@ inline Real loudness2power(Real loudness) {
 void LoudnessEBUR128::configure() {
 
   Real sampleRate = parameter("sampleRate").toReal();
+  bool startFromZero = !parameter("startAtZero").toBool();
+
+
   _hopSize = int(round(parameter("hopSize").toReal() * sampleRate));
 
   _loudnessEBUR128Filter->configure("sampleRate", sampleRate);
   
   _frameCutterMomentary->configure("frameSize", int(round(0.4 * sampleRate)), // 400ms
                                    "hopSize", _hopSize,
-                                   "startFromZero", true,
+                                   "startFromZero", startFromZero,
                                    "silentFrames", "keep");
   _frameCutterShortTerm->configure("frameSize", int(3 * sampleRate), // 3 seconds
                                    "hopSize", _hopSize,
-                                   "startFromZero", true,
+                                   "startFromZero", startFromZero,
                                    "silentFrames", "keep");
 
   // The measurement input to which the gating threshold is applied is the loudness of the
   // 400 ms blocks with a constant overlap between consecutive gating blocks of 75%. 
   _frameCutterIntegrated->configure("frameSize", int(round(0.4 * sampleRate)),
                                     "hopSize", int(round(0.1 * sampleRate)), 
-                                    "startFromZero", true,
+                                    "startFromZero", startFromZero,
                                     "silentFrames", "keep");
 
   _computeMomentary->configure("type", "log10",
@@ -308,7 +311,7 @@ LoudnessEBUR128::~LoudnessEBUR128() {
 }
 
 void LoudnessEBUR128::configure() {
-  _loudnessEBUR128->configure(INHERIT("sampleRate"), INHERIT("hopSize"));
+  _loudnessEBUR128->configure(INHERIT("sampleRate"), INHERIT("hopSize"), INHERIT("startAtZero"));
 }
 
 

--- a/src/algorithms/temporal/loudnessebur128.h
+++ b/src/algorithms/temporal/loudnessebur128.h
@@ -69,7 +69,9 @@ class LoudnessEBUR128 : public AlgorithmComposite {
   void declareParameters() {
     // EBU R128 specs: the update rate for short-term loudness "live meters" shall be at least 10 Hz
     declareParameter("sampleRate", "the sampling rate of the audio signal [Hz]", "(0,inf)", 44100.);
-    declareParameter("hopSize", "the hop size with which the loudness is computed [s]", "(0,0.1]", 0.1);  
+    declareParameter("hopSize", "the hop size with which the loudness is computed [s]", "(0,0.1]", 0.1);
+    declareParameter("startAtZero", "start momentary/short-term loudness estimation at time 0 (zero-centered loudness estimation windows) if true; otherwise start both windows at time 0 (time positions for momentary and short-term values will not be syncronized)",
+                     "{true,false}", false);
   };
 
   void configure();
@@ -113,7 +115,9 @@ class LoudnessEBUR128 : public Algorithm {
   void declareParameters() {
     // EBU R128 specs: the update rate for short-term loudness 'live meters' shall be at least 10 Hz
     declareParameter("sampleRate", "the sampling rate of the audio signal [Hz]", "(0,inf)", 44100.);
-    declareParameter("hopSize", "the hop size with which the loudness is computed [s]", "(0,0.1]", 0.1);  
+    declareParameter("hopSize", "the hop size with which the loudness is computed [s]", "(0,0.1]", 0.1);
+    declareParameter("startAtZero", "start momentary/short-term loudness estimation at time 0 (zero-centered loudness estimation windows) if true; otherwise start both windows at time 0 (time positions for momentary and short-term values will not be syncronized)",
+                     "{true,false}", false);
   };
 
   void configure();

--- a/test/src/unittests/temporal/test_loudnessebur128.py
+++ b/test/src/unittests/temporal/test_loudnessebur128.py
@@ -119,6 +119,151 @@ class TestLoudnessEBUR128(TestCase):
         _, _, _, r = LoudnessEBUR128(sampleRate=samplerate)(audio)
         self.assertAlmostEqual(r, 15., 1.)
 
+    def testRegressionStartAtZero(self):
+        # The test audio files for loudness are provided in EBU Tech 3341
+        # https://tech.ebu.ch/docs/tech/tech3341.pdf
+
+        # Test zero-centered. When startAtZero=True, the loudness measurement
+        # windows are centered at zero position in time producing the fadein
+        # and fadeout effect at the start and the end of the signal. Estimate
+        # the number of the affected values from windows/hop size
+
+        # Default hopSize = 0.1 s
+        # Momentary loudness window size = 0.4 s
+        # Short-term loudness window size = 3 s
+
+        fade_size_m = round((0.4 / 2) / 0.1)
+        fade_size_s = round((3. / 2) / 0.1)
+
+        # M, S, I = -20 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', '1kHz_sine_-20LUFS-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+
+        m, s, i, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        m = m[fade_size_m:-fade_size_m]
+        s = s[fade_size_s:-fade_size_s]
+        self.assertAlmostEqualVector(m, essentia.array([-20.] * len(m)), 0.1)
+        self.assertAlmostEqualVector(s, essentia.array([-20.] * len(s)), 0.1)
+        self.assertAlmostEqual(i, -20., 0.1)
+
+        # M, S, I = -26 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', '1kHz_sine_-26LUFS-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        m, s, i, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        m = m[fade_size_m:-fade_size_m]
+        s = s[fade_size_s:-fade_size_s]
+        self.assertAlmostEqualVector(m, essentia.array([-26.] * len(m)), 0.1)
+        self.assertAlmostEqualVector(s, essentia.array([-26.] * len(s)), 0.1)
+        self.assertAlmostEqual(i, -26., 0.1)
+
+        # M, S, I = -40 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', '1kHz_sine_-40LUFS-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        m, s, i, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        m = m[fade_size_m:-fade_size_m]
+        s = s[fade_size_s:-fade_size_s]
+        self.assertAlmostEqualVector(m, essentia.array([-40.] * len(m)), 0.1)
+        self.assertAlmostEqualVector(s, essentia.array([-40.] * len(s)), 0.1)
+        self.assertAlmostEqual(i, -40., 0.1)
+
+        # M, S, I = -23 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3341-1-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        m, s, i, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        m = m[fade_size_m:-fade_size_m]
+        s = s[fade_size_s:-fade_size_s]
+        self.assertAlmostEqualVector(m, essentia.array([-23.] * len(m)), 0.1)
+        self.assertAlmostEqualVector(s, essentia.array([-23.] * len(s)), 0.1)
+        self.assertAlmostEqual(i, -23., 0.1)
+
+        # M, S, I = -33 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3341-2-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        m, s, i, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        m = m[fade_size_m:-fade_size_m]
+        s = s[fade_size_s:-fade_size_s]
+        self.assertAlmostEqualVector(m, essentia.array([-33.] * len(m)), 0.1)
+        self.assertAlmostEqualVector(s, essentia.array([-33.] * len(s)), 0.1)
+        self.assertAlmostEqual(i, -33., 0.1)
+
+        # I = -23 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3341-3-16bit-v02.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, i, _ = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(i, -23., 0.1)
+
+        # I = -23 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3341-4-16bit-v02.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, i, _ = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(i, -23., 0.1)
+
+
+        # I = -23 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3341-5-16bit-v02.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, i, _ = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(i, -23., 0.1)
+
+        # I = -23 +- 0.1 LUFS
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3341-7_seq-3342-5-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, i, _ = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(i, -23., 0.1)
+
+        # Test audio files for dynamic range are provided in EBU Tech Doc 3342
+        # https://tech.ebu.ch/docs/tech/tech3342.pdf
+
+        # LRA = 10 +- 1 LU
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3342-1-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, i, _ = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(r, 10., 1.)
+
+        # LRA = 5 +- 1 LU
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3342-2-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, _, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(r, 5., 1.)
+
+        # LRA = 20 +- 1 LU
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3342-3-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, _, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(r, 20., 1.)
+
+        # LRA = 15 +- 1 LU
+        filename = join(testdata.audio_dir, 'generated', 'ebur128', 'seq-3342-4-16bit.flac')
+        audio, samplerate, _, _, _, _ = AudioLoader(filename=filename)()
+        _, _, _, r = LoudnessEBUR128(sampleRate=samplerate,
+                                     hopSize=0.1,
+                                     startAtZero=True)(audio)
+        self.assertAlmostEqual(r, 15., 1.)
+
     def testEmpty(self):
         # empty (0,2) array
         audio = essentia.array([[1., 1.]])[:-1]


### PR DESCRIPTION
This may be useful when one wants to syncronize positons of the values of
instantaneous and short-term loudness. Otherwise the value do not correspond
to the same time positions because of the difference in the size of sliding windows.