### PR TITLE
Make Degara beattracker deterministic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ packaging/win32_3rdparty/bin
 packaging/win32_3rdparty/share
 packaging/win32_3rdparty/lib
 packaging/win32_3rdparty/include
+dist
+essentia.egg-info
+tmp

--- a/src/algorithms/rhythm/beattrackerdegara.cpp
+++ b/src/algorithms/rhythm/beattrackerdegara.cpp
@@ -96,7 +96,7 @@ void BeatTrackerDegara::configure() {
 
   _frameCutter->configure("frameSize", frameSize,
                           "hopSize", hopSize,
-                          "silentFrames", "noise",
+                          "silentFrames", "keep",
                           "startFromZero", true);
 
   _windowing->configure("size", frameSize, "type", "hann");


### PR DESCRIPTION
Make Degara beattracker deterministic by not adding stochastic noise to silent frames