### PR TITLE
Cephes iv Bessel function fix

### DIFF
--- a/src/3rdparty/cephes/bessel/bessel.h
+++ b/src/3rdparty/cephes/bessel/bessel.h
@@ -36,11 +36,13 @@ double iv(double v, double x);
 // double kn(int n, double x);
 
 // double gam(double x);
+double gamma(double x);
 double lgam(double x);
 // extern int sgngam;
 
 
 //! \endcond
-}
+
+} // namespace cephes
 
 #endif // #ifndef BESSEL_H

--- a/src/3rdparty/cephes/bessel/bessel.h
+++ b/src/3rdparty/cephes/bessel/bessel.h
@@ -6,14 +6,13 @@
 
 #include <cmath>
 
-#define MAXITER        500
 
-#define EDOM		33
-#define ERANGE	34
-#define MAXNUM 1.79769313486231570815E308    /* 2**1024*(1-MACHEP) */
-#define EULER 0.577215664901532860606512090082402431 /* Euler constant */
+namespace cephes {
 
-#define MACHEP 1.11022302462515654042E-16
+const static int MAXITER = 500;
+const static double MAXNUM = 1.79769313486231570815E308; /* 2**1024*(1-MACHEP) */
+const static double EULER = 0.577215664901532860606512090082402431; /* Euler constant */
+const static double MACHEP = 1.11022302462515654042E-16;
 
 // double chbevl(double x, double array[], int n);
 // double hyperg(double a, double b, double x);
@@ -38,9 +37,10 @@ double iv(double v, double x);
 
 // double gam(double x);
 double lgam(double x);
-extern int sgngam;
+// extern int sgngam;
 
 
 //! \endcond
+}
 
 #endif // #ifndef BESSEL_H

--- a/src/3rdparty/cephes/bessel/bessel.h
+++ b/src/3rdparty/cephes/bessel/bessel.h
@@ -6,7 +6,7 @@
 
 #include <cmath>
 
-#define MAXITER 500
+#define MAXITER        500
 
 #define EDOM		33
 #define ERANGE	34
@@ -14,8 +14,6 @@
 #define EULER 0.577215664901532860606512090082402431 /* Euler constant */
 
 #define MACHEP 1.11022302462515654042E-16
-
-namespace cephes {
 
 // double chbevl(double x, double array[], int n);
 // double hyperg(double a, double b, double x);
@@ -33,32 +31,16 @@ double p1evl(double x, double coef[], int N);
 // double k1(double x);
 // double k1e(double x);
 
-double iv(double nu, double x);
+double iv(double v, double x);
 // double jv(double nu, double x);
 // double yv(double nu, double x);
 // double kn(int n, double x);
 
-double gam(double x);
+// double gam(double x);
 double lgam(double x);
-double stirf(double x);
-
-double iv_asymptotic(double v, double x);
-void ikv_asymptotic_uniform(double v, double x, double *Iv, double *Kv);
-void ikv_temme(double v, double x, double *Iv, double *Kv);
-
-double hyperg( double a, double b, double x);
-double hyp2f0(double, double, double, int, double *);
-double hy1f1p(double, double, double, double *);
-double hy1f1a(double, double, double, double *);
-
-int temme_ik_series(double v, double x, double *K, double *K1);
-int CF1_ik(double v, double x, double *fv);
-int CF2_ik(double v, double x, double *Kv, double *Kv1);
-
-double gam(double x);
+extern int sgngam;
 
 
-  //! \endcond
-}
+//! \endcond
 
 #endif // #ifndef BESSEL_H

--- a/src/3rdparty/cephes/bessel/gamma.cpp
+++ b/src/3rdparty/cephes/bessel/gamma.cpp
@@ -106,7 +106,7 @@ Copyright 1984, 1987, 1989, 1992, 2000 by Stephen L. Moshier
 
 #include "bessel.h"
 
-#define MAXNUM 1.79769313486231570815E308
+using namespace cephes;
 
 static double P[] = {
   1.60119522476751861407E-4,
@@ -144,31 +144,31 @@ static double MAXLGM = 2.556348e305;
 
 int sgngam = 0;
 
-#ifdef ANSIPROT
-extern double pow ( double, double );
-extern double log ( double );
-extern double exp ( double );
-extern double sin ( double );
-extern double polevl ( double, void *, int );
-extern double p1evl ( double, void *, int );
-extern double floor ( double );
-extern double fabs ( double );
-extern int isnan ( double );
-extern int isfinite ( double );
-static double stirf ( double );
-double lgam ( double );
-#else
-double pow(), log(), exp(), sin(), polevl(), p1evl(), floor(), fabs();
-int isnan(), isfinite();
-static double stirf();
-double lgam();
-#endif
-#ifdef INFINITIES
-extern double INFINITY;
-#endif
-#ifdef NANS
-extern double NAN;
-#endif
+// #ifdef ANSIPROT
+// extern double pow ( double, double );
+// extern double log ( double );
+// extern double exp ( double );
+// extern double sin ( double );
+// extern double polevl ( double, void *, int );
+// extern double p1evl ( double, void *, int );
+// extern double floor ( double );
+// extern double fabs ( double );
+// extern int isnan ( double );
+// extern int isfinite ( double );
+// static double stirf ( double );
+// double lgam ( double );
+// #else
+// double pow(), log(), exp(), sin(), polevl(), p1evl(), floor(), fabs();
+// int isnan(), isfinite();
+// static double stirf();
+// double lgam();
+// #endif
+// #ifdef INFINITIES
+// extern double INFINITY;
+// #endif
+// #ifdef NANS
+// extern double NAN;
+// #endif
 
 
 /* Gamma function computed by Stirling's formula.
@@ -478,7 +478,7 @@ static double LS2PI  =  0.91893853320467274178;
 /* Logarithm of gamma function */
 
 
-double lgam(double x)
+double cephes::lgam(double x)
 {
 double p, q, u, w, z;
 int i;
@@ -598,8 +598,11 @@ double gam(double x)
 
   if (std::isinf(x) == 1)
     return(x);
-  if (std::isinf(x) == -1)
-    return(NAN);
+	// These lines do not make sense
+	// therefore we comment them to 
+	// prevent a compilation warning (Pablo A.)
+    // if (std::isinf(x) == -1)
+    // return(NAN);
 
   q = fabs(x);
 

--- a/src/3rdparty/cephes/bessel/gamma.cpp
+++ b/src/3rdparty/cephes/bessel/gamma.cpp
@@ -594,69 +594,69 @@ double gam(double x)
 
   sgngam = 1;
   if (std::isnan(x))
-    return(x);
+	return(x);
 
   if (std::isinf(x) == 1)
-    return(x);
+	return(x);
 	// These lines do not make sense
 	// therefore we comment them to 
 	// prevent a compilation warning (Pablo A.)
-    // if (std::isinf(x) == -1)
-    // return(NAN);
+	// if (std::isinf(x) == -1)
+	// return(NAN);
 
   q = fabs(x);
 
   if (q > 33.0) {
-    if (x < 0.0) {
-      p = floor(q);
-      if (p == q) {
-      gamnan:
-        // it_warning("gam(): argument domain error");
-        return (NAN);
-      }
-      i = int(p);
-      if ((i & 1) == 0)
-        sgngam = -1;
-      z = q - p;
-      if (z > 0.5) {
-        p += 1.0;
-        z = q - p;
-      }
-      z = q * sin(PI * z);
-      if (z == 0.0) {
-        return(sgngam * INFINITY);
-      }
-      z = fabs(z);
-      z = PI / (z * stirf(q));
-    }
-    else {
-      z = stirf(x);
-    }
-    return(sgngam * z);
+	if (x < 0.0) {
+	  p = floor(q);
+	  if (p == q) {
+	  gamnan:
+		// it_warning("gam(): argument domain error");
+		return (NAN);
+	  }
+	  i = int(p);
+	  if ((i & 1) == 0)
+		sgngam = -1;
+	  z = q - p;
+	  if (z > 0.5) {
+		p += 1.0;
+		z = q - p;
+	  }
+	  z = q * sin(PI * z);
+	  if (z == 0.0) {
+		return(sgngam * INFINITY);
+	  }
+	  z = fabs(z);
+	  z = PI / (z * stirf(q));
+	}
+	else {
+	  z = stirf(x);
+	}
+	return(sgngam * z);
   }
 
   z = 1.0;
   while (x >= 3.0) {
-    x -= 1.0;
-    z *= x;
+	x -= 1.0;
+	z *= x;
   }
 
   while (x < 0.0) {
-    if (x > -1.E-9)
-      goto small;
-    z /= x;
-    x += 1.0;
+	if (x > -1.E-9)
+	  goto small;
+	z /= x;
+	x += 1.0;
   }
 
   while (x < 2.0) {
-    if (x < 1.e-9)
-      goto small;
-    z /= x;
-    x += 1.0;
+	if (x < 1.e-9)
+	  goto small;
+	z /= x;
+	x += 1.0;
   }
 
   if (x == 2.0)
-    return(z);
+	return(z);
 
   x -= 2.0;
   p = polevl(x, P, 6);
@@ -665,8 +665,8 @@ double gam(double x)
 
 small:
   if (x == 0.0) {
-    goto gamnan;
+	goto gamnan;
   }
   else
-    return(z / ((1.0 + 0.5772156649015329 * x) * x));
+	return(z / ((1.0 + 0.5772156649015329 * x) * x));
 }

--- a/src/3rdparty/cephes/bessel/gamma.cpp
+++ b/src/3rdparty/cephes/bessel/gamma.cpp
@@ -106,7 +106,7 @@ Copyright 1984, 1987, 1989, 1992, 2000 by Stephen L. Moshier
 
 #include "bessel.h"
 
-using namespace cephes;
+namespace cephes{
 
 static double P[] = {
   1.60119522476751861407E-4,
@@ -478,7 +478,7 @@ static double LS2PI  =  0.91893853320467274178;
 /* Logarithm of gamma function */
 
 
-double cephes::lgam(double x)
+double lgam(double x)
 {
 double p, q, u, w, z;
 int i;
@@ -670,3 +670,5 @@ small:
   else
 	return(z / ((1.0 + 0.5772156649015329 * x) * x));
 }
+
+} // namespace cephes

--- a/src/3rdparty/cephes/bessel/gamma.cpp
+++ b/src/3rdparty/cephes/bessel/gamma.cpp
@@ -108,8 +108,6 @@ Copyright 1984, 1987, 1989, 1992, 2000 by Stephen L. Moshier
 
 #define MAXNUM 1.79769313486231570815E308
 
-using namespace cephes;
-
 static double P[] = {
   1.60119522476751861407E-4,
   1.19135147006586384913E-3,
@@ -162,8 +160,8 @@ double lgam ( double );
 #else
 double pow(), log(), exp(), sin(), polevl(), p1evl(), floor(), fabs();
 int isnan(), isfinite();
-// static double stirf();
-// double lgam();
+static double stirf();
+double lgam();
 #endif
 #ifdef INFINITIES
 extern double INFINITY;
@@ -176,7 +174,7 @@ extern double NAN;
 /* Gamma function computed by Stirling's formula.
  * The polynomial STIR is valid for 33 <= x <= 172.
  */
-double cephes::stirf(double x)
+static double stirf(double x)
 {
 double y, w, v;
 
@@ -198,7 +196,7 @@ return( y );
 
 
 
-/* double gamma(double x)
+double gamma(double x)
 {
 double p, q, z;
 int i;
@@ -314,7 +312,7 @@ if( x == 0.0 )
 else
 	return( z/((1.0 + 0.5772156649015329 * x) * x) );
 }
-*/
+
 
 
 /* A[]: Stirling's formula expansion of log gamma
@@ -480,7 +478,7 @@ static double LS2PI  =  0.91893853320467274178;
 /* Logarithm of gamma function */
 
 
-double cephes::lgam(double x)
+double lgam(double x)
 {
 double p, q, u, w, z;
 int i;
@@ -589,7 +587,7 @@ else
 return( q );
 }
 
-double cephes::gam(double x)
+double gam(double x)
 {
   double p, q, z;
   int i;
@@ -600,11 +598,8 @@ double cephes::gam(double x)
 
   if (std::isinf(x) == 1)
     return(x);
-	// These lines do not make sense
-	// therefore we comment them to 
-	// prevent a compilation warning (Pablo A.)
-  // if (std::isinf(x) == -1)
-    // return(NAN);
+  if (std::isinf(x) == -1)
+    return(NAN);
 
   q = fabs(x);
 

--- a/src/3rdparty/cephes/bessel/hyperg.cpp
+++ b/src/3rdparty/cephes/bessel/hyperg.cpp
@@ -66,7 +66,7 @@ Copyright 1984, 1987, 1988, 2000 by Stephen L. Moshier
 
 #include "bessel.h"
 
-using namespace cephes;
+namespace cephes{
 
 // #ifdef ANSIPROT
 // extern double exp ( double );
@@ -389,3 +389,5 @@ error:
 // mtherr( "hyperg", TLOSS );
 return( sum );
 }
+
+}  // namespace cephes

--- a/src/3rdparty/cephes/bessel/hyperg.cpp
+++ b/src/3rdparty/cephes/bessel/hyperg.cpp
@@ -66,8 +66,6 @@ Copyright 1984, 1987, 1988, 2000 by Stephen L. Moshier
 
 #include "bessel.h"
 
-using namespace cephes;
-
 // #ifdef ANSIPROT
 // extern double exp ( double );
 // extern double log ( double );
@@ -87,10 +85,14 @@ using namespace cephes;
 // extern double MAXNUM, MACHEP;
 
 
+double hyp2f0(double, double, double, int, double *);
+static double hy1f1p(double, double, double, double *);
+static double hy1f1a(double, double, double, double *);
+
 #define MAXNUM 1.79769313486231570815E308    /* 2**1024*(1-MACHEP) */
 #define MACHEP 1.11022302462515654042E-16   /* 2**-53 */
 
-double cephes::hyperg( double a, double b, double x)
+double hyperg( double a, double b, double x)
 {
 double asum, psum, acanc, pcanc, temp;
 
@@ -119,7 +121,7 @@ if( acanc < pcanc )
 	}
 
 done:
-// if( pcanc > 1.0e-12 )
+if( pcanc > 1.0e-12 )
 	// mtherr( "hyperg", PLOSS );
 
 return( psum );
@@ -131,7 +133,7 @@ return( psum );
 /* Power series summation for confluent hypergeometric function		*/
 
 
-double cephes::hy1f1p(double a, double b, double x, double *err)
+static double hy1f1p(double a, double b, double x, double *err)
 {
 double n, a0, sum, t, u, temp;
 double an, bn, maxt, pcanc;
@@ -218,7 +220,7 @@ return( sum );
  *                               |  (a)                        )
  */
 
-double cephes::hy1f1a(double a, double b, double x, double *err)
+static double hy1f1a(double a, double b, double x, double *err)
 {
 double h1, h2, t, u, temp, acanc, asum, err1, err2;
 
@@ -286,7 +288,7 @@ return( asum );
 
 /*							hyp2f0()	*/
 
-double cephes::hyp2f0(double a, double b, double x, int type, double *err)
+double hyp2f0(double a, double b, double x, int type, double *err)
 {
 double a0, alast, t, tlast, maxt;
 double n, an, bn, u, sum, temp;

--- a/src/3rdparty/cephes/bessel/hyperg.cpp
+++ b/src/3rdparty/cephes/bessel/hyperg.cpp
@@ -66,6 +66,8 @@ Copyright 1984, 1987, 1988, 2000 by Stephen L. Moshier
 
 #include "bessel.h"
 
+using namespace cephes;
+
 // #ifdef ANSIPROT
 // extern double exp ( double );
 // extern double log ( double );
@@ -89,12 +91,15 @@ double hyp2f0(double, double, double, int, double *);
 static double hy1f1p(double, double, double, double *);
 static double hy1f1a(double, double, double, double *);
 
-#define MAXNUM 1.79769313486231570815E308    /* 2**1024*(1-MACHEP) */
-#define MACHEP 1.11022302462515654042E-16   /* 2**-53 */
+// #define MAXNUM 1.79769313486231570815E308    /* 2**1024*(1-MACHEP) */
+// #define MACHEP 1.11022302462515654042E-16   /* 2**-53 */
 
 double hyperg( double a, double b, double x)
 {
 double asum, psum, acanc, pcanc, temp;
+
+pcanc = 1.0; // Initialize error to 100% just to prevent a
+			 // compile-time warning. (Pablo A.)
 
 /* See if a Kummer transformation will help */
 temp = b - a;
@@ -121,7 +126,7 @@ if( acanc < pcanc )
 	}
 
 done:
-if( pcanc > 1.0e-12 )
+// if( pcanc > 1.0e-12 )
 	// mtherr( "hyperg", PLOSS );
 
 return( psum );

--- a/src/3rdparty/cephes/bessel/iv.cpp
+++ b/src/3rdparty/cephes/bessel/iv.cpp
@@ -66,14 +66,14 @@ Copyright 1984, 1987, 1988, 2000 by Stephen L. Moshier
 // #endif
 // extern double MACHEP, MAXNUM;
 
-
+using namespace cephes;
 
 static double iv_asymptotic(double v, double x);
 static void ikv_asymptotic_uniform(double v, double x, double *Iv, double *Kv);
 static void ikv_temme(double v, double x, double *Iv, double *Kv);
 
 
-double iv(double v, double x)
+double cephes::iv(double v, double x)
 {
 int sign;
 double t, ax, res;

--- a/src/3rdparty/cephes/bessel/iv.cpp
+++ b/src/3rdparty/cephes/bessel/iv.cpp
@@ -54,8 +54,6 @@ Copyright 1984, 1987, 1988, 2000 by Stephen L. Moshier
 #include <cstddef>
 #include "bessel.h"
 
-using namespace cephes;
-
 // #ifdef ANSIPROT
 // extern double hyperg ( double, double, double );
 // extern double exp ( double );
@@ -69,7 +67,13 @@ using namespace cephes;
 // extern double MACHEP, MAXNUM;
 
 
-double cephes::iv(double v, double x)
+
+static double iv_asymptotic(double v, double x);
+static void ikv_asymptotic_uniform(double v, double x, double *Iv, double *Kv);
+static void ikv_temme(double v, double x, double *Iv, double *Kv);
+
+
+double iv(double v, double x)
 {
 int sign;
 double t, ax, res;
@@ -139,7 +143,7 @@ return res;
  * Compute Iv from (AMS5 9.7.1), asymptotic expansion for large |z|
  * Iv ~ exp(x)/sqrt(2 pi x) ( 1 + (4*v*v-1)/8x + (4*v*v-1)(4*v*v-9)/8x/2! + ...)
  */
-double cephes::iv_asymptotic(double v, double x)
+static double iv_asymptotic(double v, double x)
 {
     double mu;
     double sum, term, prefactor, factor;
@@ -243,7 +247,7 @@ static const double asymptotic_ufactors[N_UFACTORS][N_UFACTOR_TERMS] = {
 /*
  * Compute Iv, Kv from (AMS5 9.7.7 + 9.7.8), asymptotic expansion for large v
  */
-void cephes::ikv_asymptotic_uniform(double v, double x,
+static void ikv_asymptotic_uniform(double v, double x,
 			    double *i_value, double *k_value)
 {
     double i_prefactor, k_prefactor;
@@ -346,7 +350,7 @@ void cephes::ikv_asymptotic_uniform(double v, double x,
  * Calculate K(v, x) and K(v+1, x) by method analogous to
  * Temme, Journal of Computational Physics, vol 21, 343 (1976)
  */
-int cephes::temme_ik_series(double v, double x, double *K, double *K1)
+static int temme_ik_series(double v, double x, double *K, double *K1)
 {
     double f, h, p, q, coef, sum, sum1, tolerance;
     double a, b, c, d, sigma, gamma1, gamma2;
@@ -408,7 +412,7 @@ int cephes::temme_ik_series(double v, double x, double *K, double *K1)
 
 /* Evaluate continued fraction fv = I_(v+1) / I_v, derived from
  * Abramowitz and Stegun, Handbook of Mathematical Functions, 1972, 9.1.73 */
-int cephes::CF1_ik(double v, double x, double *fv)
+static int CF1_ik(double v, double x, double *fv)
 {
     double C, D, f, a, b, delta, tiny, tolerance;
     unsigned long k;
@@ -459,7 +463,7 @@ int cephes::CF1_ik(double v, double x, double *fv)
  * z1 / z0 = U(v+1.5, 2v+1, 2x) / U(v+0.5, 2v+1, 2x), see
  * Thompson and Barnett, Computer Physics Communications, vol 47, 245 (1987)
  */
-int cephes::CF2_ik(double v, double x, double *Kv, double *Kv1)
+static int CF2_ik(double v, double x, double *Kv, double *Kv1)
 {
 
     double S, C, Q, D, f, a, b, q, delta, tolerance, current, prev;
@@ -526,7 +530,7 @@ enum {
  * Compute I(v, x) and K(v, x) simultaneously by Temme's method, see
  * Temme, Journal of Computational Physics, vol 19, 324 (1975)
  */
-void cephes::ikv_temme(double v, double x, double *Iv_p, double *Kv_p)
+static void ikv_temme(double v, double x, double *Iv_p, double *Kv_p)
 {
     /* Kv1 = K_(v+1), fv = I_(v+1) / I_v */
     /* Ku1 = K_(u+1), fu = I_(u+1) / I_u */

--- a/src/3rdparty/cephes/bessel/iv.cpp
+++ b/src/3rdparty/cephes/bessel/iv.cpp
@@ -66,14 +66,14 @@ Copyright 1984, 1987, 1988, 2000 by Stephen L. Moshier
 // #endif
 // extern double MACHEP, MAXNUM;
 
-using namespace cephes;
+namespace cephes {
 
 static double iv_asymptotic(double v, double x);
 static void ikv_asymptotic_uniform(double v, double x, double *Iv, double *Kv);
 static void ikv_temme(double v, double x, double *Iv, double *Kv);
 
 
-double cephes::iv(double v, double x)
+double iv(double v, double x)
 {
 int sign;
 double t, ax, res;
@@ -653,3 +653,5 @@ static void ikv_temme(double v, double x, double *Iv_p, double *Kv_p)
     }
     return;
 }
+
+} // namespace cephes

--- a/src/3rdparty/cephes/bessel/polevl.cpp
+++ b/src/3rdparty/cephes/bessel/polevl.cpp
@@ -51,9 +51,7 @@ Direct inquiries to 30 Frost Street, Cambridge, MA 02140
 
 #include "bessel.h"
 
-using namespace cephes;
-
-double cephes::polevl(double x, double coef[], int N )
+double polevl(double x, double coef[], int N )
 {
 double ans;
 int i;
@@ -76,7 +74,7 @@ return( ans );
  * Otherwise same as polevl.
  */
 
-double cephes::p1evl(double x, double coef[], int N )
+double p1evl(double x, double coef[], int N )
 {
 double ans;
 double *p;

--- a/src/3rdparty/cephes/bessel/polevl.cpp
+++ b/src/3rdparty/cephes/bessel/polevl.cpp
@@ -51,7 +51,9 @@ Direct inquiries to 30 Frost Street, Cambridge, MA 02140
 
 #include "bessel.h"
 
-double polevl(double x, double coef[], int N )
+using namespace cephes;
+
+double cephes::polevl(double x, double coef[], int N )
 {
 double ans;
 int i;
@@ -74,7 +76,7 @@ return( ans );
  * Otherwise same as polevl.
  */
 
-double p1evl(double x, double coef[], int N )
+double cephes::p1evl(double x, double coef[], int N )
 {
 double ans;
 double *p;

--- a/src/3rdparty/cephes/bessel/polevl.cpp
+++ b/src/3rdparty/cephes/bessel/polevl.cpp
@@ -51,9 +51,9 @@ Direct inquiries to 30 Frost Street, Cambridge, MA 02140
 
 #include "bessel.h"
 
-using namespace cephes;
+namespace cephes {
 
-double cephes::polevl(double x, double coef[], int N )
+double polevl(double x, double coef[], int N )
 {
 double ans;
 int i;
@@ -76,7 +76,7 @@ return( ans );
  * Otherwise same as polevl.
  */
 
-double cephes::p1evl(double x, double coef[], int N )
+double p1evl(double x, double coef[], int N )
 {
 double ans;
 double *p;
@@ -92,3 +92,5 @@ while( --i );
 
 return( ans );
 }
+
+}  // namespace cephes


### PR DESCRIPTION
Closes #878 

As the 3rd party library is only compiled when the algorithms that need it are required it would be not direct to create python bindings and units tests that depend on the `INCLUDE_ALGOS` list. For now, I will just left here some values for the `iv` Bessel function obtained with Scipy and Essentia so they can be checked again if any further modification of this dependancy is produced.

**Scipy values**
iv(0, 0):     1.0
iv(0, -0.9):  1.21298516573
iv(0, 0.9):   1.21298516573
iv(1, 0):     0.0
iv(1, -0.9): -0.497126448161
iv(1, 0.9):   0.497126448161

**Essentia values**
[   INFO   ] iv(0, 0.0): 1
[   INFO   ] iv(0, -0.9): 1.21299
[   INFO   ] iv(0, 0.9): 1.21299
[   INFO   ] iv(1, 0.0): 0
[   INFO   ] iv(1, -0.9): -0.497126
[   INFO   ] iv(1, 0.9): 0.497126