### PR TITLE
Fix cross-compilation for Android

### DIFF
--- a/src/essentia/roguevector.h
+++ b/src/essentia/roguevector.h
@@ -57,7 +57,7 @@ class RogueVector : public std::vector<T> {
 };
 
 // Clang/LLVM implementation
-#if defined (OS_MAC) || defined(OS_FREEBSD) || defined(__EMSCRIPTEN__)
+#if defined(__clang__) || defined(__EMSCRIPTEN__)
 
 // TODO: this is a big hack that relies on clang/libcpp not changing the memory
 //       layout of the std::vector (very dangerous, but works for now...)

--- a/wscript
+++ b/wscript
@@ -220,10 +220,15 @@ def configure(ctx):
 
     if ctx.options.CROSS_COMPILE_ANDROID:
         print ("→ Cross-compiling for Android ARM")
-        ctx.find_program('arm-linux-androideabi-gcc', var='CC')
-        ctx.find_program('arm-linux-androideabi-g++', var='CXX')
-        ctx.find_program('arm-linux-androideabi-ar', var='AR')
-        ctx.env.LINKFLAGS += ['-Wl,-soname,libessentia.so']
+        # GCC is depricated for Android NDK
+        # Use clang with libc++
+        #ctx.find_program('arm-linux-androideabi-gcc', var='CC')
+        #ctx.find_program('arm-linux-androideabi-g++', var='CXX')
+        #ctx.find_program('arm-linux-androideabi-ar', var='AR')
+        ctx.find_program('clang', var='CC')
+        ctx.find_program('clang++', var='CXX')
+        ctx.env.CXXFLAGS += ['-std=c++11']
+        ctx.env.LINKFLAGS += ['-Wl,-soname,libessentia.so', '-latomic']
 
     if ctx.options.CROSS_COMPILE_IOS:
         print ("→ Cross-compiling for iOS (ARMv7 and ARM64)")


### PR DESCRIPTION
Fix cross-compilation for Android (#622). Use clang and libc++ as
they are the ones that will be supported in the future (gcc is
depricated).