### PR TITLE
Make waf use ${PREFIX} to install examples

### DIFF
--- a/src/examples/wscript
+++ b/src/examples/wscript
@@ -163,7 +163,7 @@ def build(ctx):
         if sys.platform == 'darwin':
             install_path = os.environ['HOME'] + '/Library/Audio/Plug-Ins/Vamp'
         elif sys.platform.startswith('linux'):
-            install_path = '/usr/local/lib/vamp'
+            install_path = '${PREFIX}/lib/vamp'
         else:
             install_path = None
 


### PR DESCRIPTION
Otherwise, build fails for users without root permissions.