### PR TITLE
Support Eigen3 as a required external dependency

### DIFF
--- a/Essentia Licensing.txt
+++ b/Essentia Licensing.txt
@@ -124,6 +124,26 @@ Digital Music; Queen Mary, University of London; and Chris Cannam
 shall not be used in advertising or otherwise to promote the sale,
 use or other dealings in this Software without prior written authorization.
 
+Eigen 3
+Eigen is primarily MPL2 licensed. See COPYING.MPL2 and these links:
+  http://www.mozilla.org/MPL/2.0/
+  http://www.mozilla.org/MPL/2.0/FAQ.html
+
+Some files contain third-party code under BSD or LGPL licenses, whence the other
+COPYING.* files here.
+
+All the LGPL code is either LGPL 2.1-only, or LGPL 2.1-or-later.
+For this reason, the COPYING.LGPL file contains the LGPL 2.1 text.
+
+If you want to guarantee that the Eigen code that you are #including is licensed
+under the MPL2 and possibly more permissive licenses (like BSD), #define this
+preprocessor symbol:
+  EIGEN_MPL2_ONLY
+For example, with most compilers, you could add this to your project CXXFLAGS:
+  -DEIGEN_MPL2_ONLY
+This will cause a compilation error to be generated if you #include any code that is
+LGPL licensed.
+
 
 GNU GENERAL PUBLIC LICENSE
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -64,7 +64,7 @@ build_yaml.sh
 ...
 cd ../../
 ```
-Note that the dependency needs may change relying on the set of required algorithms.
+Note that you can selectively build dependencies depending on the required Essentia algorithms."
 
 Build Essentia:
 ```

--- a/FAQ.md
+++ b/FAQ.md
@@ -55,7 +55,8 @@ Use ```--with-gaia``` flag to include Gaia.
 Alternatively, you can build each dependency apart running corresponding scripts inside ```packaging/debian_3rdparty``` folder:
 ```
 cd packaging/debian_3rdparty
-build_libav_nomuxers.sh
+build_eigen3.sh
+build_ffmpeg.sh
 build_taglib.sh
 build_fftw3.sh
 build_libsamplerate.sh
@@ -63,6 +64,7 @@ build_yaml.sh
 ...
 cd ../../
 ```
+Note that the dependency needs may change relying on the set of required algorithms.
 
 Build Essentia:
 ```

--- a/doc/sphinxdoc/installing.rst
+++ b/doc/sphinxdoc/installing.rst
@@ -44,6 +44,7 @@ Compiling Essentia from source
 ==============================
 
 Essentia depends on (at least) the following libraries:
+ - `Eigen <http://eigen.tuxfamily.org/`_: for linear algebra
  - `FFTW <http://www.fftw.org>`_: for the FFT implementation *(optional)*
  - `libavcodec/libavformat/libavutil/libavresample <http://ffmpeg.org/>`_ (from the FFmpeg/LibAv project): for loading/saving any type of audio files *(optional)*
  - `libsamplerate <http://www.mega-nerd.com/SRC/>`_: for resampling audio *(optional)*
@@ -59,7 +60,7 @@ Installing dependencies on Linux
 
 You can install those dependencies on a Debian/Ubuntu system from official repositories using the command below::
 
-  sudo apt-get install build-essential libyaml-dev libfftw3-dev libavcodec-dev libavformat-dev libavutil-dev libavresample-dev python-dev libsamplerate0-dev libtag1-dev libchromaprint-dev python-six
+  sudo apt-get install build-essential libeigen3-dev libyaml-dev libfftw3-dev libavcodec-dev libavformat-dev libavutil-dev libavresample-dev python-dev libsamplerate0-dev libtag1-dev libchromaprint-dev python-six
 
 In order to use Python 2 bindings for the library, you might also need to install python-dev, python-numpy-dev (or python-numpy on Ubuntu) and python-yaml for YAML support in python::
 

--- a/doc/sphinxdoc/licensing_information.rst
+++ b/doc/sphinxdoc/licensing_information.rst
@@ -55,6 +55,7 @@ This is the set of libraries which can be used within Essentia:
    * LibYAML - http://pyyaml.org/wiki/LibYAML (`MIT license`_)
    * Kiss FFT - https://sourceforge.net/projects/kissfft/ (`BSD-style license`_)
    * Accelerate - https://developer.apple.com/reference/accelerate
+   * Eigen - http://eigen.tuxfamily.org/ (`MPL2`_)
 
 
 .. _GPL: http://www.gnu.org/licenses/gpl.html
@@ -65,4 +66,5 @@ This is the set of libraries which can be used within Essentia:
 .. _MIT license: http://www.opensource.org/licenses/mit-license.php
 .. _Public domain: http://en.wikipedia.org/wiki/Public_domain
 .. _BSD-2-Clause: https://opensource.org/licenses/BSD-2-Clause
+.. _MPL2: https://www.mozilla.org/en-US/MPL/2.0/
 

--- a/packaging/build_3rdparty_static_debian.sh
+++ b/packaging/build_3rdparty_static_debian.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
 cd $BASEDIR/debian_3rdparty
+./build_eigen3.sh
 ./build_fftw3.sh
 ./build_ffmpeg.sh
 ./build_libsamplerate.sh

--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -16,6 +16,7 @@ SHARED_OR_STATIC="
 --enable-static
 "
 
+EIGEN_VERSION=3.3.4
 FFMPEG_VERSION=ffmpeg-2.8.12
 TAGLIB_VERSION=taglib-1.11.1
 ZLIB_VERSION=zlib-1.2.11
@@ -24,7 +25,7 @@ LIBSAMPLERATE_VERSION=libsamplerate-0.1.8
 LIBYAML_VERSION=yaml-0.1.5
 CHROMAPRINT_VERSION=1.4.3
 QT_SOURCE_URL=http://download.qt-project.org/archive/qt/4.8/4.8.6/qt-everywhere-opensource-src-4.8.6.tar.gz
-GAIA_VERSION=2.4.5
+GAIA_VERSION=2.4.6
 
 FFMPEG_AUDIO_FLAGS="
     --disable-programs

--- a/packaging/debian_3rdparty/build_eigen3.sh
+++ b/packaging/debian_3rdparty/build_eigen3.sh
@@ -16,7 +16,7 @@ cd build
 
 cmake ../ -DCMAKE_INSTALL_PREFIX=$PREFIX
 make install
+cp "$PREFIX"/share/pkgconfig/eigen3.pc "$PREFIX"/lib/pkgconfig/
 
 cd ../../..
-cp share/pkgconfig/eigen3.pc lib/pkgconfig/
 rm -rf tmp

--- a/packaging/debian_3rdparty/build_eigen3.sh
+++ b/packaging/debian_3rdparty/build_eigen3.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+. ../build_config.sh
+
+rm -rf tmp
+mkdir tmp
+cd tmp
+
+echo "Building gaia $EIGEN_VERSION"
+
+curl -SLO https://bitbucket.org/eigen/eigen/get/$EIGEN_VERSION.tar.gz
+tar -xf $EIGEN_VERSION.tar.gz
+cd eigen-eigen*
+
+mkdir build
+cd build
+
+cmake ../ -DCMAKE_INSTALL_PREFIX=$PREFIX
+make install
+
+cd ../../..
+cp share/pkgconfig/eigen3.pc lib/pkgconfig/
+rm -rf tmp

--- a/packaging/debian_3rdparty/build_eigen3.sh
+++ b/packaging/debian_3rdparty/build_eigen3.sh
@@ -5,7 +5,7 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 
-echo "Building gaia $EIGEN_VERSION"
+echo "Installing headers for Eigen $EIGEN_VERSION"
 
 curl -SLO https://bitbucket.org/eigen/eigen/get/$EIGEN_VERSION.tar.gz
 tar -xf $EIGEN_VERSION.tar.gz

--- a/src/algorithms/io/yamloutput.cpp
+++ b/src/algorithms/io/yamloutput.cpp
@@ -233,7 +233,7 @@ void fillYamlTree (const Pool& p, YamlNode* root) {
 
   if (p.getSingleTensorRealPool().begin() != p.getSingleTensorRealPool().end() ||
       p.getTensorRealPool().begin() != p.getTensorRealPool().end() ) {
-    E_WARNING("YamlOuput: Tensors are not supported by YamlOuput. "
+    E_WARNING("YamlOuput: Tensors are not supported by YamlOutput. "
               "The tensors contained in this pool will be ignored.");
   }
 

--- a/src/algorithms/io/yamloutput.cpp
+++ b/src/algorithms/io/yamloutput.cpp
@@ -231,6 +231,12 @@ void fillYamlTree (const Pool& p, YamlNode* root) {
   FILL_YAML_TREE_MACRO(vector<TNT::Array2D<Real> >, Array2DReal);
   FILL_YAML_TREE_MACRO(vector<StereoSample>, StereoSample);
 
+  if (p.getSingleTensorRealPool().begin() != p.getSingleTensorRealPool().end() ||
+      p.getTensorRealPool().begin() != p.getTensorRealPool().end() ) {
+    E_WARNING("YamlOuput: Tensors are not supported by YamlOuput. "
+              "The tensors contained in this pool will be ignored.");
+  }
+
   #undef FILL_YAML_TREE_MACRO
 }
 

--- a/src/essentia/essentiautil.h
+++ b/src/essentia/essentiautil.h
@@ -157,6 +157,14 @@ inline bool isValid(const TNT::Array2D<T> & mat) {
   return true;
 }
 
+template <typename T>
+inline bool isValid(const Tensor<T>& tensor) {
+  for (const T* i = tensor.data(); i < (tensor.data() + tensor.size()); ++i){
+    if (!isValid(*i)) return false;
+  }
+  return true;
+}
+
 #ifdef OS_WIN32
 int mkstemp(char *tmpl);
 #endif // OS_WIN32

--- a/src/essentia/pool.cpp
+++ b/src/essentia/pool.cpp
@@ -303,7 +303,7 @@ void Pool::add(const string& name, const Tensor<Real>& value, bool validityCheck
   {
     MutexLocker lock(mutexTensorReal);
     if (validityCheck && !isValid(value)) {
-      throw EssentiaException("Pool::add array contains invalid numbers (NaN or inf)");
+      throw EssentiaException("Pool::add tensor contains invalid numbers (NaN or inf)");
     }
     if (_poolTensorReal.find(name) != _poolTensorReal.end()) {
       _poolTensorReal[name].push_back(Tensor<Real>(value));
@@ -368,7 +368,7 @@ void Pool::set(const string& name, const Tensor<Real>& value, bool validityCheck
   {
     MutexLocker lock(mutexSingleTensorReal);
     if (validityCheck && !isValid(value)) {
-      throw EssentiaException("Pool::set array contains invalid numbers (NaN or inf)");
+      throw EssentiaException("Pool::set tensor contains invalid numbers (NaN or inf)");
     }
     if (_poolSingleTensorReal.find(name) != _poolSingleTensorReal.end()) {
       _poolSingleTensorReal[name].resize(value.dimensions());

--- a/src/essentia/pool.cpp
+++ b/src/essentia/pool.cpp
@@ -35,11 +35,13 @@ void Pool::clear() {
   _poolString.clear();
   _poolVectorString.clear();
   _poolArray2DReal.clear();
+  _poolTensorReal.clear();
   _poolStereoSample.clear();
   _poolSingleReal.clear();
   _poolSingleString.clear();
   _poolSingleVectorReal.clear();
-  _poolSingleVectorString.clear();  
+  _poolSingleVectorString.clear();
+  _poolSingleTensorReal.clear();
 }
 
 void Pool::checkIntegrity() const {
@@ -85,6 +87,7 @@ void Pool::remove(const string& name) {
   SEARCH_AND_DESTROY(vector<vector<string> >, VectorString);
 
   SEARCH_AND_DESTROY(vector<TNT::Array2D<Real> >, Array2DReal);
+  SEARCH_AND_DESTROY(vector<Tensor<Real> >, TensorReal);
   SEARCH_AND_DESTROY(vector<StereoSample>, StereoSample);
 
   #undef SEARCH_AND_DESTROY
@@ -125,6 +128,7 @@ void Pool::removeNamespace(const string& ns) {
   SEARCH_AND_DESTROY(vector<string>, SingleVectorString);  
   SEARCH_AND_DESTROY(vector<vector<string> >, VectorString);
 
+  SEARCH_AND_DESTROY(vector<Tensor<Real> >, TensorReal);
   SEARCH_AND_DESTROY(vector<TNT::Array2D<Real> >, Array2DReal);
   SEARCH_AND_DESTROY(vector<StereoSample>, StereoSample);
 
@@ -156,6 +160,8 @@ vector<string> Pool::descriptorNames() const {
   ADD_DESC_NAMES(vector<string>, SingleVectorString);  
   ADD_DESC_NAMES(vector<vector<string> >, VectorString);
   ADD_DESC_NAMES(vector<TNT::Array2D<Real> >, Array2DReal);
+  ADD_DESC_NAMES(vector<Tensor<Real> >, TensorReal);
+  ADD_DESC_NAMES(Tensor<Real>, SingleTensorReal);
   ADD_DESC_NAMES(vector<StereoSample>, StereoSample);
 
   #undef ADD_DESC_NAMES
@@ -185,6 +191,8 @@ vector<string> Pool::descriptorNames(const std::string& ns) const {
   ADD_DESC_NAMES(vector<string>, SingleVectorString);
   ADD_DESC_NAMES(vector<vector<string> >, VectorString);
   ADD_DESC_NAMES(vector<TNT::Array2D<Real> >, Array2DReal);
+  ADD_DESC_NAMES(vector<Tensor<Real> >, TensorReal);
+  ADD_DESC_NAMES(Tensor<Real>, SingleTensorReal);
   ADD_DESC_NAMES(vector<StereoSample>, StereoSample);
 
   #undef ADD_DESC_NAMES
@@ -200,11 +208,13 @@ vector<string> Pool::descriptorNamesNoLocking() const {
                            _poolString.size()       +
                            _poolVectorString.size() +
                            _poolArray2DReal.size()  +
+                           _poolTensorReal.size()  +
                            _poolStereoSample.size() +
                            _poolSingleReal.size()   +
                            _poolSingleString.size() +
                            _poolSingleVectorReal.size() + 
-                           _poolSingleVectorString.size());
+                           _poolSingleVectorString.size() +
+                           _poolSingleTensorReal.size());
   int i=0;
 
   #define ADD_DESC_NAMES(type, tname)                                          \
@@ -223,6 +233,7 @@ vector<string> Pool::descriptorNamesNoLocking() const {
   ADD_DESC_NAMES(vector<string>, SingleVectorString);
   ADD_DESC_NAMES(vector<vector<string> >, VectorString);
   ADD_DESC_NAMES(vector<TNT::Array2D<Real> >, Array2DReal);
+  ADD_DESC_NAMES(vector<Tensor<Real> >, TensorReal);
   ADD_DESC_NAMES(vector<StereoSample>, StereoSample);
 
 
@@ -285,6 +296,25 @@ SPECIALIZE_ADD_IMPL(string, String);
 SPECIALIZE_ADD_IMPL(vector<string>, VectorString);
 SPECIALIZE_ADD_IMPL(StereoSample, StereoSample);
 
+
+void Pool::add(const string& name, const Tensor<Real>& value, bool validityCheck) {
+  /* first check if the pool has ever seen this key before, if it has, we can
+   * just add it, if not, we need to run some validation tests */
+  {
+    MutexLocker lock(mutexTensorReal);
+    if (validityCheck && !isValid(value)) {
+      throw EssentiaException("Pool::add array contains invalid numbers (NaN or inf)");
+    }
+    if (_poolTensorReal.find(name) != _poolTensorReal.end()) {
+      _poolTensorReal[name].push_back(Tensor<Real>(value));
+      return;
+    }
+  }
+  GLOBAL_LOCK
+  validateKey(name);
+  _poolTensorReal[name].push_back(Tensor<Real>(value));
+}
+
 // special add for Array2d<Real>
 // Array2D needs a special add that cannot be implemented in the macro because
 // we need to call the function copy(), or otherwise we only get references
@@ -331,6 +361,28 @@ SPECIALIZE_SET_IMPL(string, String)
 SPECIALIZE_SET_IMPL(vector<Real>, VectorReal)
 SPECIALIZE_SET_IMPL(vector<string>, VectorString)
 
+// special set for Tensor<Real>
+void Pool::set(const string& name, const Tensor<Real>& value, bool validityCheck) {
+  /* first check if the pool has ever seen this key before, if it has, we can
+   * just add it, if not, we need to run some validation tests */
+  {
+    MutexLocker lock(mutexSingleTensorReal);
+    if (validityCheck && !isValid(value)) {
+      throw EssentiaException("Pool::set array contains invalid numbers (NaN or inf)");
+    }
+    if (_poolSingleTensorReal.find(name) != _poolSingleTensorReal.end()) {
+      _poolSingleTensorReal[name].resize(value.dimensions());
+      _poolSingleTensorReal[name] = value;
+      return;
+    }
+  }
+  GLOBAL_LOCK
+  validateKey(name);
+
+  _poolSingleTensorReal[name].resize(value.dimensions());
+  _poolSingleTensorReal[name] = value;
+}
+
 
 void Pool::merge(Pool& p, const string& mergeType) {
 
@@ -371,6 +423,7 @@ void Pool::merge(Pool& p, const string& mergeType) {
   MERGE_SINGLE_POOL(string, SingleString);
   MERGE_SINGLE_POOL(vector<Real>, SingleVectorReal);
   MERGE_SINGLE_POOL(vector<string>, SingleVectorString);
+  MERGE_SINGLE_POOL(Tensor<Real>, SingleTensorReal);
 
   // multiple value:
   MERGE_POOL(Real, Real);
@@ -379,6 +432,7 @@ void Pool::merge(Pool& p, const string& mergeType) {
   MERGE_POOL(vector<string>, VectorString);
   MERGE_POOL(StereoSample, StereoSample);
   MERGE_POOL(TNT::Array2D<Real>, Array2DReal);
+  MERGE_POOL(Tensor<Real>, TensorReal);
 
   #undef MERGE_SINGLE_POOL
   #undef MERGE_POOL
@@ -444,6 +498,7 @@ SPECIALIZE_MERGE_IMPL(vector<Real>, VectorReal);
 SPECIALIZE_MERGE_IMPL(string, String);
 SPECIALIZE_MERGE_IMPL(vector<string>, VectorString);
 SPECIALIZE_MERGE_IMPL(StereoSample, StereoSample);
+SPECIALIZE_MERGE_IMPL(Tensor<Real>, TensorReal);
 
 #define SPECIALIZE_MERGE_SINGLE_IMPL(type, tname)                                                      \
 void Pool::mergeSingle(const string& name, const type& value, const string& mergeType) {               \
@@ -475,6 +530,7 @@ SPECIALIZE_MERGE_SINGLE_IMPL(Real, Real)
 SPECIALIZE_MERGE_SINGLE_IMPL(string, String)
 SPECIALIZE_MERGE_SINGLE_IMPL(vector<Real>, VectorReal)
 SPECIALIZE_MERGE_SINGLE_IMPL(vector<string>, VectorString)
+SPECIALIZE_MERGE_SINGLE_IMPL(Tensor<Real>, TensorReal)
 
 
 void Pool::merge(const string& name, const vector<Array2D<Real> >& value, const string& mergeType) {
@@ -545,6 +601,7 @@ bool Pool::isSingleValue(const string& name) {
   SEARCH_SINGLE(vector<Real>, SingleVectorReal);
   SEARCH_SINGLE(string, SingleString);
   SEARCH_SINGLE(vector<string>, SingleVectorString);
+  SEARCH_SINGLE(Tensor<Real>, SingleTensorReal);
 
   #undef SEARCH_SINGLE
   return false;

--- a/src/essentia/pool.h
+++ b/src/essentia/pool.h
@@ -101,6 +101,7 @@ class Pool {
   std::map<std::string, std::string> _poolSingleString;
   std::map<std::string, std::vector<Real> > _poolSingleVectorReal;  
   std::map<std::string, std::vector<std::string> > _poolSingleVectorString;
+  std::map<std::string, Tensor<Real> > _poolSingleTensorReal;
 
   // maps for vectors of values:
   PoolOf(Real) _poolReal;
@@ -108,6 +109,7 @@ class Pool {
   PoolOf(std::string) _poolString;
   PoolOf(std::vector<std::string>) _poolVectorString;
   PoolOf(TNT::Array2D<Real>) _poolArray2DReal;
+  PoolOf(Tensor<Real>) _poolTensorReal;
   PoolOf(StereoSample) _poolStereoSample;
 
   // WARNING: this function assumes that all sub-pools are locked
@@ -124,7 +126,8 @@ class Pool {
 
   mutable Mutex mutexReal, mutexVectorReal, mutexString, mutexVectorString,
                 mutexArray2DReal, mutexStereoSample,
-                mutexSingleReal, mutexSingleString, mutexSingleVectorReal, mutexSingleVectorString;
+                mutexSingleReal, mutexSingleString, mutexSingleVectorReal,
+                mutexSingleVectorString, mutexTensorReal, mutexSingleTensorReal;
 
   /**
    * Adds @e value to the Pool under @e name
@@ -161,6 +164,9 @@ class Pool {
 
   /** @copydoc add(const std::string&,const Real&,bool) */
   void add(const std::string& name, const TNT::Array2D<Real>& value, bool validityCheck = false);
+
+  /** @copydoc add(const std::string&,const Tensor<Real>& value,bool) */
+  void add(const std::string& name, const Tensor<Real>& value, bool validityCheck = false);
 
   /** @copydoc add(const std::string&,const Real&,bool) */
   void add(const std::string& name, const StereoSample& value, bool validityCheck = false);
@@ -204,6 +210,9 @@ class Pool {
   /** @copydoc set(const std::string&,const Real&i, bool) */
   void set(const std::string& name, const std::vector<std::string>& value, bool validityCheck=false);
 
+  /** @copydoc set(const std::string&, const Tensor<Real>& value, bool) */
+  void set(const std::string& name, const Tensor<Real>& value, bool validityCheck=false);
+
   /**
    * \brief Merges the current pool with the given one @e p.
    *
@@ -246,6 +255,9 @@ class Pool {
   void merge(const std::string& name, const std::vector<TNT::Array2D<Real> >& value, const std::string& type="");
 
   /** @copydoc merge(const std::string&, const std::vector<Real>&, const std::string&)*/
+  void merge(const std::string& name, const std::vector<Tensor<Real> >& value, const std::string& type="");
+
+  /** @copydoc merge(const std::string&, const std::vector<Real>&, const std::string&)*/
   void merge(const std::string& name, const std::vector<StereoSample>& value, const std::string& type="");
 
   /** @copydoc merge(const std::string&, const std::vector<Real>&, const std::string&)*/
@@ -256,6 +268,8 @@ class Pool {
   void mergeSingle(const std::string& name, const std::string& value, const std::string& type="");
   /** @copydoc merge(const std::string&, const std::vector<Real>&, const std::string&)*/
   void mergeSingle(const std::string& name, const std::vector<std::string>& value, const std::string& type="");
+  /** @copydoc merge(const std::string&, const std::vector<Real>&, const std::string&)*/
+  void mergeSingle(const std::string& name, const Tensor<Real> & value, const std::string& type="");
   /**
    * Removes the descriptor name @e name from the Pool along with the data it
    * points to. This function does nothing if @e name does not exist in the
@@ -331,6 +345,12 @@ class Pool {
 
   /**
    * @returns a std::map where the key is a descriptor name and the values are
+   *          of type Tensor<Real>
+   */
+  const PoolOf(Tensor<Real>)& getTensorRealPool() const { return _poolTensorReal; }
+
+  /**
+   * @returns a std::map where the key is a descriptor name and the values are
    *          of type StereoSample
    */
   const PoolOf(StereoSample)& getStereoSamplePool() const { return _poolStereoSample; }
@@ -358,6 +378,12 @@ class Pool {
    *          of type vector<string>
    */
   const std::map<std::string, std::vector<std::string> >& getSingleVectorStringPool() const { return _poolSingleVectorString; }
+
+  /**
+   * @returns a std::map where the key is a descriptor name and the value is
+   *          of type vector<string>
+   */
+  const std::map<std::string, Tensor<Real> >& getSingleTensorRealPool() const { return _poolSingleTensorReal; }
 
   /**
    * Checks that no descriptor name is in two different inner pool types at
@@ -402,6 +428,8 @@ SPECIALIZE_VALUE(std::string, SingleString);
 SPECIALIZE_VALUE(std::vector<std::vector<Real> >, VectorReal);
 SPECIALIZE_VALUE(std::vector<std::vector<std::string> >, VectorString);
 SPECIALIZE_VALUE(std::vector<TNT::Array2D<Real> >, Array2DReal);
+SPECIALIZE_VALUE(std::vector<Tensor<Real> >, TensorReal);
+SPECIALIZE_VALUE(Tensor<Real>, SingleTensorReal);
 SPECIALIZE_VALUE(std::vector<StereoSample>, StereoSample);
 
 // This value function is not under the macro above because it needs to check
@@ -476,6 +504,8 @@ SPECIALIZE_CONTAINS(std::string, SingleString);
 SPECIALIZE_CONTAINS(std::vector<std::vector<Real> >, VectorReal);
 SPECIALIZE_CONTAINS(std::vector<std::vector<std::string> >, VectorString);
 SPECIALIZE_CONTAINS(std::vector<TNT::Array2D<Real> >, Array2DReal);
+SPECIALIZE_CONTAINS(std::vector<Tensor<Real> >, TensorReal);
+SPECIALIZE_CONTAINS(Tensor<Real> , SingleTensorReal);
 SPECIALIZE_CONTAINS(std::vector<StereoSample>, StereoSample);
 
 // This value function is not under the macro above because it needs to check
@@ -535,11 +565,13 @@ MutexLocker lockVectorReal(mutexVectorReal);                \
 MutexLocker lockString(mutexString);                        \
 MutexLocker lockVectorString(mutexVectorString);            \
 MutexLocker lockArray2DReal(mutexArray2DReal);              \
+MutexLocker lockTensorReal(mutexTensorReal);              \
 MutexLocker lockStereoSample(mutexStereoSample);            \
 MutexLocker lockSingleReal(mutexSingleReal);                \
 MutexLocker lockSingleString(mutexSingleString);            \
 MutexLocker lockSingleVectorReal(mutexSingleVectorReal);    \
-MutexLocker lockSingleVectorString(mutexSingleVectorString);
+MutexLocker lockSingleVectorString(mutexSingleVectorString);\
+MutexLocker lockSingleTensorReal(mutexSingleTensorReal);
 
 
 

--- a/src/essentia/types.h
+++ b/src/essentia/types.h
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "debugging.h"
 #include "streamutil.h"
+#include <unsupported/Eigen/CXX11/Tensor>
 
 
 // fixed-size int types
@@ -369,6 +370,18 @@ class Tuple2 {
  */
 typedef Tuple2<Real> StereoSample;
 
+
+/**
+ * Alias for Eigen::Tensor.
+ */
+template<typename T>
+using Tensor = Eigen::Tensor<T, 4, 0>;
+
+/**
+ * Alias for Eigen::TensorMap.
+ */
+template<typename T>
+using TensorMap = Eigen::TensorMap<T, 0>;
 
 
 namespace streaming {

--- a/src/essentia/types.h
+++ b/src/essentia/types.h
@@ -373,9 +373,11 @@ typedef Tuple2<Real> StereoSample;
 
 /**
  * Alias for Eigen::Tensor.
+ * Store data in a rowMajor fashion to fit Tensorflow's behavior.
+ * https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/tensor_types.h
  */
 template<typename T>
-using Tensor = Eigen::Tensor<T, 4, 0>;
+using Tensor = Eigen::Tensor<T, 4, Eigen::RowMajor>;
 
 /**
  * Alias for Eigen::TensorMap.

--- a/src/essentia/types.h
+++ b/src/essentia/types.h
@@ -381,7 +381,7 @@ using Tensor = Eigen::Tensor<T, 4, 0>;
  * Alias for Eigen::TensorMap.
  */
 template<typename T>
-using TensorMap = Eigen::TensorMap<T, 0>;
+using TensorMap = Eigen::TensorMap<Tensor<T>, 0>;
 
 
 namespace streaming {

--- a/src/python/essentia.cpp
+++ b/src/python/essentia.cpp
@@ -72,6 +72,8 @@ init_essentia() {
       PyType_Ready(&PyStereoSampleType)       < 0 ||
       PyType_Ready(&VectorStereoSampleType)   < 0 ||
       PyType_Ready(&VectorMatrixRealType)     < 0 ||
+      PyType_Ready(&TensorRealType)           < 0 ||
+      PyType_Ready(&VectorTensorRealType)     < 0 ||
       PyType_Ready(&VectorVectorStereoSampleType) < 0) {
 
     cerr << "Unable to instantiate Essentia's wrapper types." << endl;

--- a/src/python/essentia/common.py
+++ b/src/python/essentia/common.py
@@ -166,7 +166,7 @@ def determineEdt(obj):
             else:
                 return Edt(Edt.LIST_ARRAY)
 
-    if isinstance(obj, numpy.ndarray) and obj.ndim > 2: # temporal solusion. Tensor should be generalized to <= 2 case too
+    if isinstance(obj, numpy.ndarray) and obj.ndim == 4:
         if obj.dtype == numpy.dtype('single'):
             return Edt(Edt.TENSOR_REAL)
 

--- a/src/python/essentia/common.py
+++ b/src/python/essentia/common.py
@@ -58,6 +58,8 @@ class Edt:  # Essentia Data Type
     MATRIX_REAL = 'MATRIX_REAL'
     MATRIX_COMPLEX = 'MATRIX_COMPLEX'
     VECTOR_MATRIX_REAL = 'VECTOR_MATRIX_REAL'
+    VECTOR_TENSOR_REAL = 'VECTOR_TENSOR_REAL'
+    TENSOR_REAL = 'TENSOR_REAL'
     POOL = 'POOL'
 
     # intermediate types
@@ -143,6 +145,9 @@ def determineEdt(obj):
         if firstElmtType == Edt.MATRIX_REAL:
             return Edt(Edt.VECTOR_MATRIX_REAL)
 
+        if firstElmtType == Edt.TENSOR_REAL:
+            return Edt(Edt.VECTOR_TENSOR_REAL)
+
         if firstElmtType == Edt.LIST_REAL:
             return Edt(Edt.LIST_LIST_REAL)
 
@@ -160,6 +165,16 @@ def determineEdt(obj):
                 return Edt(Edt.LIST_ARRAY_REAL)
             else:
                 return Edt(Edt.LIST_ARRAY)
+
+    if isinstance(obj, numpy.ndarray) and obj.ndim > 2: # temporal solusion. Tensor should be generalized to <= 2 case too
+        if obj.dtype == numpy.dtype('single'):
+            return Edt(Edt.TENSOR_REAL)
+
+        if obj.dtype == numpy.dtype('complex64'):
+            return Edt(Edt.TENSOR_COMPLEX)
+
+        raise TypeError('essentia can currently only accept two-dimensional numpy arrays of dtype '\
+                        '"single"')
 
     # numpy array matrices
     if isinstance(obj, numpy.ndarray) and obj.ndim == 2:
@@ -363,7 +378,8 @@ class Pool:
         else:
             if givenType in (Edt.REAL, Edt.STRING, Edt.STEREOSAMPLE,
                              Edt.VECTOR_REAL, Edt.VECTOR_STRING,
-                             Edt.VECTOR_STEREOSAMPLE, Edt.MATRIX_REAL):
+                             Edt.VECTOR_STEREOSAMPLE, Edt.MATRIX_REAL,
+                             Edt.TENSOR_REAL):
                 goalType = givenType
 
             # some exceptions
@@ -398,7 +414,7 @@ class Pool:
 
         # if we haven't seen this type before, we will have to guess its type
         else:
-            if givenType in (Edt.REAL, Edt.STRING, Edt.VECTOR_REAL):
+            if givenType in (Edt.REAL, Edt.STRING, Edt.VECTOR_REAL, Edt.TENSOR_REAL):
                 goalType = givenType
 
             # some exceptions
@@ -453,7 +469,8 @@ class Pool:
             if givenType in (Edt.REAL, Edt.STRING, Edt.STEREOSAMPLE,
                              Edt.VECTOR_REAL, Edt.VECTOR_STRING,
                              Edt.VECTOR_STEREOSAMPLE, Edt.MATRIX_REAL,
-                             Edt.VECTOR_VECTOR_REAL, Edt.VECTOR_MATRIX_REAL):
+                             Edt.VECTOR_VECTOR_REAL, Edt.VECTOR_MATRIX_REAL,
+                             Edt.VECTOR_TENSOR_REAL, Edt.TENSOR_REAL):
                 goalType = givenType
 
             # some exceptions

--- a/src/python/parsing.cpp
+++ b/src/python/parsing.cpp
@@ -156,6 +156,8 @@ PyObject* toPython(void* obj, Edt tp) {
     case VECTOR_VECTOR_COMPLEX: return VectorVectorComplex::toPythonCopy((vector<vector<complex<Real> > >*)obj);
     case VECTOR_VECTOR_STRING: return VectorVectorString::toPythonCopy((vector<vector<string> >*)obj);
     case VECTOR_VECTOR_STEREOSAMPLE: return VectorVectorStereoSample::toPythonCopy((vector<vector<StereoSample> >*)obj);
+    case TENSOR_REAL: return TensorReal::toPythonRef((Tensor<Real>*)obj);
+    case VECTOR_TENSOR_REAL: return VectorTensorReal::toPythonCopy((vector<Tensor<Real> >*)obj);
     case MATRIX_REAL: return MatrixReal::toPythonRef((TNT::Array2D<Real>*)obj);
     case VECTOR_MATRIX_REAL: return VectorMatrixReal::toPythonCopy((vector<TNT::Array2D<Real> >*)obj);
     case POOL: return PyPool::toPythonRef((Pool*)obj);

--- a/src/python/pyalgorithm.cpp
+++ b/src/python/pyalgorithm.cpp
@@ -235,6 +235,7 @@ PyObject* PyAlgorithm::compute(PyAlgorithm* self, PyObject* args) {
         case VECTOR_VECTOR_STRING: SET_PORT_COPY(VectorVectorString, vector<vector<string> >);
         case VECTOR_STEREOSAMPLE:  SET_PORT_COPY(VectorStereoSample, vector<StereoSample>);
         case MATRIX_REAL:          SET_PORT_COPY(MatrixReal, TNT::Array2D<Real>);
+        case TENSOR_REAL:          SET_PORT_COPY(TensorReal, Tensor<Real>);
 
         case POOL:                 SET_PORT_REF(PyPool, Pool);
         case VECTOR_REAL:          SET_PORT_REF(VectorReal, vector<Real>);

--- a/src/python/pytypes/pypool.cpp
+++ b/src/python/pytypes/pypool.cpp
@@ -150,6 +150,11 @@ PyObject* PyPool::keyType(PyPool* self, PyObject* obj) {
     return PyString_FromString( edtToString(VECTOR_MATRIX_REAL).c_str() );
   }
 
+  // search tensor sub-pool
+  if (p.getTensorRealPool().find(key) != p.getTensorRealPool().end()) {
+    return PyString_FromString( edtToString(VECTOR_TENSOR_REAL).c_str() );
+  }
+
   // search single real pool
   if (p.getSingleRealPool().find(key) != p.getSingleRealPool().end()) {
     return PyString_FromString( edtToString(REAL).c_str() );
@@ -163,6 +168,11 @@ PyObject* PyPool::keyType(PyPool* self, PyObject* obj) {
   // search single string pool
   if (p.getSingleStringPool().find(key) != p.getSingleStringPool().end()) {
     return PyString_FromString( edtToString(STRING).c_str() );
+  }
+
+  // search single tensor pool
+  if (p.getSingleTensorRealPool().find(key) != p.getSingleTensorRealPool().end()) {
+    return PyString_FromString( edtToString(TENSOR_REAL).c_str() );
   }
 
   // couldn't find the key
@@ -232,7 +242,7 @@ PyObject* PyPool::add(PyPool* self, PyObject* pyArgs) {
       case STEREOSAMPLE:  ADD_COPY(PyStereoSample, StereoSample);
       case VECTOR_STRING: ADD_COPY(VectorString, vector<string>);
       case MATRIX_REAL:   ADD_COPY(MatrixReal, TNT::Array2D<Real>);
-
+      case TENSOR_REAL:   ADD_COPY(TensorReal, Tensor<Real>);
       case VECTOR_REAL:   ADD_REF(VectorReal, RogueVector<Real>);
 
       default:
@@ -299,6 +309,7 @@ PyObject* PyPool::set(PyPool* self, PyObject* pyArgs) {
       case REAL: SET_COPY(PyReal, Real);
       case STRING: SET_COPY(String, string);
       case VECTOR_REAL: SET_REF(VectorReal, RogueVector<Real>);
+      case TENSOR_REAL: SET_COPY(TensorReal, Tensor<Real>);
       default:
         ostringstream msg;
         msg << "Pool.set does not support the type: " << edtToString(tp);
@@ -397,6 +408,7 @@ PyObject* PyPool::merge(PyPool* self, PyObject* pyArgs) {
       case VECTOR_VECTOR_REAL: MERGE_COPY(VectorVectorReal, vector<vector<Real> >);
       case VECTOR_VECTOR_STRING: MERGE_COPY(VectorVectorString, vector<vector<string> >);
       case VECTOR_MATRIX_REAL:   MERGE_COPY(VectorMatrixReal, vector<TNT::Array2D<Real> >);
+      case VECTOR_TENSOR_REAL:   MERGE_COPY(VectorTensorReal,  vector<Tensor<Real> >);
       //case POOL: p.merge(args[1].cppPool, mergeType)
 
 
@@ -517,6 +529,11 @@ PyObject* PyPool::value(PyPool* self, PyObject* pyArgs) {
       case VECTOR_VECTOR_REAL: return VectorVectorReal::toPythonCopy(&p.value<vector<vector<Real> > >(key));
       case VECTOR_VECTOR_STRING: return VectorVectorString::toPythonCopy(&p.value<vector<vector<string> > >(key));
       case VECTOR_MATRIX_REAL: return VectorMatrixReal::toPythonCopy(&p.value<vector<TNT::Array2D<Real> > >(key));
+      case VECTOR_TENSOR_REAL: return VectorTensorReal::toPythonCopy(&p.value<vector<Tensor<Real> > >(key));
+      case TENSOR_REAL: {
+        Tensor<Real>* t = new Tensor<Real>(p.value<Tensor<Real> >(key));
+        return TensorReal::toPythonRef(t);
+      }
       default:
         ostringstream msg;
         msg << "Pool.value does not support the type: " << edtToString(tp);

--- a/src/python/pytypes/tensorreal.cpp
+++ b/src/python/pytypes/tensorreal.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#include "typedefs.h"
+
+
+using namespace std;
+using namespace essentia;
+
+DEFINE_PYTHON_TYPE(TensorReal);
+
+
+PyObject* TensorReal::toPythonRef(essentia::Tensor<essentia::Real>* tensor) {
+  PyObject* result;
+
+  int nd = tensor->rank();
+  npy_intp dims[nd];
+
+  for (int i = 0; i < nd; i++)
+    dims[i] = tensor->dimension(i);
+
+  result = PyArray_SimpleNewFromData(nd, dims, PyArray_FLOAT, tensor->data());
+
+  assert(result->strides[3] == sizeof(Real));
+
+  if (result == NULL) {
+    throw EssentiaException("TensorReal: dang null object");
+  }
+
+  PyArray_BASE(result) = TO_PYTHON_PROXY(TensorReal, tensor);
+  return result;
+}
+
+
+void* TensorReal::fromPythonCopy(PyObject* obj) {
+  if (!PyArray_Check(obj)) {
+    throw EssentiaException("TensorReal::fromPythonRef: expected PyArray, received: ", strtype(obj));
+  }
+  if (PyArray_NDIM(obj) != 4) {
+    throw EssentiaException("TensorReal::fromPythonCopy: argument is not a 4-dimensional PyArray");
+  }
+
+  // // copy data from numpy array to matrix
+  PyArrayObject* numpyarr = (PyArrayObject*)obj;
+  if (numpyarr->descr->type_num != PyArray_FLOAT) {
+     throw EssentiaException("TensorReal::fromPythonRef: this NumPy array doesn't contain Reals (maybe you forgot dtype='f4')");
+   }
+
+  return new Tensor<Real>(TensorMap<Tensor<Real> >((Real *)PyArray_DATA(numpyarr),
+                                                    PyArray_DIM(obj, 0),
+                                                    PyArray_DIM(obj, 1),
+                                                    PyArray_DIM(obj, 2),
+                                                    PyArray_DIM(obj, 3)));
+}

--- a/src/python/pytypes/tensorreal.cpp
+++ b/src/python/pytypes/tensorreal.cpp
@@ -62,9 +62,9 @@ void* TensorReal::fromPythonCopy(PyObject* obj) {
      throw EssentiaException("TensorReal::fromPythonRef: this NumPy array doesn't contain Reals (maybe you forgot dtype='f4')");
    }
 
-  return new Tensor<Real>(TensorMap<Tensor<Real> >((Real *)PyArray_DATA(numpyarr),
-                                                    PyArray_DIM(obj, 0),
-                                                    PyArray_DIM(obj, 1),
-                                                    PyArray_DIM(obj, 2),
-                                                    PyArray_DIM(obj, 3)));
+  return new Tensor<Real>(TensorMap<Real>((Real *)PyArray_DATA(numpyarr),
+                                                  PyArray_DIM(obj, 0),
+                                                  PyArray_DIM(obj, 1),
+                                                  PyArray_DIM(obj, 2),
+                                                  PyArray_DIM(obj, 3)));
 }

--- a/src/python/pytypes/vectortensorreal.cpp
+++ b/src/python/pytypes/vectortensorreal.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#include "typedefs.h"
+
+using namespace std;
+using namespace essentia;
+
+DEFINE_PYTHON_TYPE(VectorTensorReal);
+
+
+
+PyObject* VectorTensorReal::toPythonCopy(const vector<Tensor<Real> >* tenVec) {
+  int size = tenVec->size();
+  PyObject* result = PyList_New(size);
+
+  for (int i=0; i<size; ++i) {
+    const Tensor<Real>& tensor = (*tenVec)[i];
+
+    int nd = tensor.rank();
+    npy_intp dims[nd];
+
+    for (int j = 0; j< nd; j++)
+      dims[j] = tensor.dimension(j);
+
+    PyArrayObject* numpyarr = (PyArrayObject*)PyArray_SimpleNew(nd, dims, PyArray_FLOAT);
+    
+    if (numpyarr == NULL) {
+      throw EssentiaException("VectorTensorReal::toPythonCopy: dang null object");
+    }
+
+    Real* dest = (Real*)numpyarr->data;
+    const Real* src = tensor.data();
+    fastcopy(dest, src, tensor.size());
+
+    PyList_SET_ITEM(result, i, (PyObject*)numpyarr);
+  }
+
+  return result;
+}
+
+
+void* VectorTensorReal::fromPythonCopy(PyObject* obj) {
+  if (!PyList_Check(obj)) {
+    throw EssentiaException("VectorTensorReal::fromPythonCopy: input is not a list");
+  }
+
+  int size = PyList_Size(obj);
+  vector<Tensor<Real> >* v = new vector<Tensor<Real> >(size);
+
+  for (int i=0; i<size; ++i) {
+    try {
+      (*v)[i] = *(Tensor<Real> *)TensorReal::fromPythonCopy(PyList_GET_ITEM(obj, i));
+    }
+
+    catch (const exception&) {
+      delete v;
+      throw;
+    }
+
+  }
+
+  return v;
+}

--- a/src/python/typedefs.h
+++ b/src/python/typedefs.h
@@ -49,6 +49,8 @@ enum Edt {
   VECTOR_VECTOR_COMPLEX,
   VECTOR_VECTOR_STRING,
   VECTOR_VECTOR_STEREOSAMPLE,
+  TENSOR_REAL,
+  VECTOR_TENSOR_REAL,
   MATRIX_REAL,
   VECTOR_MATRIX_REAL,
   POOL,
@@ -72,6 +74,8 @@ inline Edt typeInfoToEdt(const std::type_info& tp) {
   if (essentia::sameType(tp, typeid(std::vector<std::vector<std::complex<essentia::Real> > >))) return VECTOR_VECTOR_COMPLEX;
   if (essentia::sameType(tp, typeid(std::vector<std::vector<std::string> >))) return VECTOR_VECTOR_STRING;
   if (essentia::sameType(tp, typeid(std::vector<std::vector<essentia::StereoSample> >))) return VECTOR_VECTOR_STEREOSAMPLE;
+  if (essentia::sameType(tp, typeid(essentia::Tensor<essentia::Real>))) return TENSOR_REAL;
+  if (essentia::sameType(tp, typeid(std::vector<essentia::Tensor<essentia::Real> >))) return VECTOR_TENSOR_REAL;
   if (essentia::sameType(tp, typeid(TNT::Array2D<essentia::Real>))) return MATRIX_REAL;
   if (essentia::sameType(tp, typeid(std::vector<TNT::Array2D<essentia::Real> >))) return VECTOR_MATRIX_REAL;
   if (essentia::sameType(tp, typeid(essentia::Pool))) return POOL;
@@ -94,6 +98,8 @@ inline std::string edtToString(Edt tp) {
     case VECTOR_VECTOR_COMPLEX: return "VECTOR_VECTOR_COMPLEX";
     case VECTOR_VECTOR_STRING: return "VECTOR_VECTOR_STRING";
     case VECTOR_VECTOR_STEREOSAMPLE: return "VECTOR_VECTOR_STEREOSAMPLE";
+    case TENSOR_REAL: return "TENSOR_REAL";
+    case VECTOR_TENSOR_REAL: return "VECTOR_TENSOR_REAL";
     case MATRIX_REAL: return "MATRIX_REAL";
     case VECTOR_MATRIX_REAL: return "VECTOR_MATRIX_REAL";
     case POOL: return "POOL";
@@ -117,6 +123,8 @@ inline Edt stringToEdt(const std::string& tpName) {
   if (tpName == "VECTOR_VECTOR_COMPLEX") return VECTOR_VECTOR_COMPLEX;
   if (tpName == "VECTOR_VECTOR_STRING") return VECTOR_VECTOR_STRING;
   if (tpName == "VECTOR_VECTOR_STEREOSAMPLE") return VECTOR_VECTOR_STEREOSAMPLE;
+  if (tpName == "TENSOR_REAL") return TENSOR_REAL;
+  if (tpName == "VECTOR_TENSOR_REAL") return VECTOR_TENSOR_REAL;
   if (tpName == "MATRIX_REAL") return MATRIX_REAL;
   if (tpName == "VECTOR_MATRIX_REAL") return VECTOR_MATRIX_REAL;
   if (tpName == "POOL") return POOL;
@@ -163,6 +171,8 @@ inline void* allocate(Edt tp) {
     case VECTOR_VECTOR_COMPLEX: return new std::vector<std::vector<std::complex<essentia::Real> > >;
     case VECTOR_VECTOR_STRING: return new std::vector<std::vector<std::string> >;
     case VECTOR_VECTOR_STEREOSAMPLE: return new std::vector<std::vector<essentia::StereoSample> >;
+    case TENSOR_REAL: return new essentia::Tensor<essentia::Real>;
+    case VECTOR_TENSOR_REAL: return new std::vector<essentia::Tensor<essentia::Real> >;
     case MATRIX_REAL: return new TNT::Array2D<essentia::Real>;
     case VECTOR_MATRIX_REAL: return new std::vector<TNT::Array2D<essentia::Real> >;
     case POOL: return new essentia::Pool;
@@ -187,6 +197,8 @@ inline void dealloc(void* ptr, Edt tp) {
     case VECTOR_VECTOR_COMPLEX: delete (std::vector<std::vector<std::complex<essentia::Real> > >*)ptr; break;
     case VECTOR_VECTOR_STRING: delete (std::vector<std::vector<std::string> >*)ptr; break;
     case VECTOR_VECTOR_STEREOSAMPLE: delete (std::vector<std::vector<essentia::StereoSample> >*)ptr; break;
+    case TENSOR_REAL: delete (essentia::Tensor<essentia::Real>*)ptr; break;
+    case VECTOR_TENSOR_REAL: delete (std::vector<essentia::Tensor<essentia::Real> >*)ptr; break;
     case MATRIX_REAL: delete (TNT::Array2D<essentia::Real>*)ptr; break;
     case VECTOR_MATRIX_REAL: delete (std::vector<TNT::Array2D<essentia::Real> >*)ptr; break;
     case POOL: delete (essentia::Pool*)ptr; break;
@@ -228,6 +240,12 @@ DECLARE_PYTHON_TYPE(VectorComplex);
 
 DECLARE_PROXY_TYPE(VectorStereoSample, std::vector<essentia::StereoSample>);
 DECLARE_PYTHON_TYPE(VectorStereoSample);
+
+DECLARE_PROXY_TYPE(TensorReal, essentia::Tensor<essentia::Real>);
+DECLARE_PYTHON_TYPE(TensorReal);
+
+DECLARE_PROXY_TYPE(VectorTensorReal, std::vector<essentia::Tensor<essentia::Real> >);
+DECLARE_PYTHON_TYPE(VectorTensorReal);
 
 DECLARE_PROXY_TYPE(VectorVectorReal, std::vector<std::vector<essentia::Real> >);
 DECLARE_PYTHON_TYPE(VectorVectorReal);

--- a/src/wscript
+++ b/src/wscript
@@ -222,7 +222,7 @@ def configure(ctx):
     # use it to replace the outdated TNT code for matrices and linear algebra
     ctx.env.USES += ' EIGEN3'
 
-    # this flag guarantees that all the Eigen code that we are #including is
+    # this flag guarantees that all the Eigen code that we are including is
     # licensed under MPL2 or more permissive licenses (like BSD)
     # http://eigen.tuxfamily.org/index.php?title=Main_Page#License
     ctx.env.DEFINES += ['EIGEN_MPL2_ONLY']

--- a/src/wscript
+++ b/src/wscript
@@ -6,7 +6,7 @@ from __future__ import print_function
 import sys
 import os.path
 
-dependencies_list = ['libav', 'libsamplerate', 'taglib', 'yaml', 'fftw', 'libchromaprint']
+dependencies_list = ['libav', 'libsamplerate', 'taglib', 'yaml', 'fftw', 'libchromaprint', 'eigen']
 
 def options(ctx):
     ctx.add_option('--with-python', action='store_true',
@@ -118,6 +118,9 @@ def configure(ctx):
        return
 
 
+    ctx.check_cfg(package='eigen3', uselib_store='EIGEN3',
+                  args=['eigen3 >= 3.3.4'] + check_cfg_args)
+
     if 'libav' in ctx.env.WITH_LIBS_LIST:
         ctx.check_cfg(package='libavcodec', uselib_store='AVCODEC',
                       args=['libavcodec >= 55.34.1'] + check_cfg_args,
@@ -214,6 +217,15 @@ def configure(ctx):
 
             print('   IMPORTANT NOTE: You will encounter compilation errors, because some other algorithms rely on FFT.')
             print('                   To avoid these errors, use alternative FFT libraries (see the --fft flag).\n')
+
+    # TODO Eigen is set as a mandatory dependecy as the long-term goal is to
+    # use it to replace the outdated TNT code for matrices and liner algebra
+    ctx.env.USES += ' EIGEN3'
+
+    # this flag guarantees that all the Eigen code that we are #including is
+    # licensed under MPL2 or more permissive licenses (like BSD)
+    # http://eigen.tuxfamily.org/index.php?title=Main_Page#License
+    ctx.env.DEFINES += ['EIGEN_MPL2_ONLY']
 
     # MonoLoader, EqloudLoader, and EasyLoader are dependent on Resample
     algos = [ 'AudioLoader', 'MonoLoader', 'EqloudLoader', 'EasyLoader', 'MonoWriter', 'AudioWriter' ]
@@ -468,7 +480,7 @@ def build(ctx):
     # do not compile Cephes functions if we are not compiling SNR
     if 'SNR' not in ctx.env.ALGOIGNORE:
         ctx.env.INCLUDES += ['3rdparty/cephes/bessel/' ]
-        sources += ctx.path.ant_glob('3rdparty/cephes/bessel/*.cpp') 
+        sources += ctx.path.ant_glob('3rdparty/cephes/bessel/*.cpp')
     else:
         print('Building without 3rdparty Cephes library code (Bessel functions) because SNR algorithm is ignored')
 

--- a/src/wscript
+++ b/src/wscript
@@ -218,8 +218,8 @@ def configure(ctx):
             print('   IMPORTANT NOTE: You will encounter compilation errors, because some other algorithms rely on FFT.')
             print('                   To avoid these errors, use alternative FFT libraries (see the --fft flag).\n')
 
-    # TODO Eigen is set as a mandatory dependecy as the long-term goal is to
-    # use it to replace the outdated TNT code for matrices and liner algebra
+    # TODO Eigen is set as a mandatory dependency as the long-term goal is to
+    # use it to replace the outdated TNT code for matrices and linear algebra
     ctx.env.USES += ' EIGEN3'
 
     # this flag guarantees that all the Eigen code that we are #including is

--- a/test/src/unittests/base/test_pool.py
+++ b/test/src/unittests/base/test_pool.py
@@ -67,6 +67,14 @@ class TestPool(TestCase):
         self.assertAlmostEqualVector(p['foo.bar'], [expectedVal1])
         self.assertAlmostEqualVector(p['bar.foo'], [expectedVal2])
 
+    def testRealTensorPoolSimple(self):
+        expectedTen = numpy.ones([1, 2, 3, 4]).astype('float32')
+
+        p = Pool()
+        p.add('foo.bar', expectedTen)
+
+        self.assertAlmostEqualMatrix(p['foo.bar'], [expectedTen])
+
     def testRealVectorPoolSimple(self):
         expectedVec = [1.6, 0.9, 19.85]
 
@@ -84,6 +92,16 @@ class TestPool(TestCase):
         p.add('foo.bar', expectedVec2)
 
         self.assertAlmostEqualMatrix(p['foo.bar'], [expectedVec1, expectedVec2])
+
+    def testRealTensorPoolMultiple(self):
+        expectedTen1 = numpy.ones([1, 2, 3, 4]).astype('float32')
+        expectedTen2 = numpy.ones([4, 3, 2, 1]).astype('float32')
+
+        p = Pool()
+        p.add('foo.bar', expectedTen1)
+        p.add('foo.bar', expectedTen2)
+
+        self.assertAlmostEqualMatrix(p['foo.bar'], [expectedTen1, expectedTen2])
 
     def testRealVectorPoolMultipleLabels(self):
         expectedVec1 = [1.6, 0.9, 19.85]

--- a/test/src/unittests/essentia_test.py
+++ b/test/src/unittests/essentia_test.py
@@ -154,16 +154,11 @@ class TestCase(BaseTestCase):
             return self.assertTrue(almostEqualArray(found, expected, precision))
 
         self.assertEqual(len(found), len(expected))
-        count = 0
+
         for v1, v2 in zip(found, expected):
             self.assertEqual(len(v1), len(v2))
-            for val1, val2 in zip(v1, v2):
-                if (isinstance(val1, numpy.ndarray)):
-                    self.assertAlmostEqual(val1.all(), val2.all(), precision)
-                else:
-                    self.assertAlmostEqual(val1, val2, precision)
+            self.assertAlmostEqualVector(array(v1).flatten(), array(v2).flatten(), precision)
 
-            count += 1
 
     def assertAlmostEqualAbs(self, found, expected, precision = 0.1):
         diff = abs(expected - found)

--- a/test/src/unittests/io/test_yamloutput.py
+++ b/test/src/unittests/io/test_yamloutput.py
@@ -354,6 +354,30 @@ stereosample: [{left: 3, right: 6}, {left: -1, right: 2}]
         self.assertEqual(expected, actual)
         os.unlink('test.json')
 
+    def testIgnoreTensors(self):
+        import yaml
+
+        tensor = array(numpy.ones([1, 1, 1, 1]))
+        arr = array(numpy.ones([1]))
+        p = Pool()
+
+        # Single tensor
+        p.set('tensor', tensor)
+
+        # Vector of tensors
+        p.add('tensors', tensor)
+        p.add('tensors', tensor)
+
+        p.set('array', arr)
+
+        YamlOutput(filename='test.yaml')(p)
+        actual = yaml.load(getYaml('test.yaml'))
+
+        # Assert that the tensors are not written
+        self.assertEqual(['metadata', 'array'], list(actual.keys()))
+
+        # Also assert that the array was correctly written
+        self.assertEqual([1], actual['array'])
 
 
 suite = allTests(TestYamlOutput)


### PR DESCRIPTION
We decided to make Eigen3 an external dependency attending to these reasons:
 - reduce the amount of fixed src in Essentia
 - allow better compatibility with Gaia
 - make it easy to update

Also, this is a first step towards substituting TNT by Eigen so it was decided to make it already a required dependancy even if we only use it for tensors (4D matrices) right now.

This PR also adds the following features:
 - New types `Tensor<>` and `TensorMap<>`
 - Support for `Tensor<Real>` and `VectorTensor<Real>` in Pools
 - `set()` and `add()` methods for those
 - Python interface for Pools with tensors
 - packaging scripts for Eigen3
 - update Gaia to a version that relies on Eigen as an external package
 - updated documentation and Licensing info