### PR TITLE
Drop support for Python 3.4 wheels

### DIFF
--- a/travis/build_wheels.sh
+++ b/travis/build_wheels.sh
@@ -14,6 +14,10 @@ set -e -x
 #PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 #PKG_CONFIG_PATH=/io/packaging/debian_3rdparty/lib/pkgconfig
 
+# We are dropping support for Python 3.4 since PyYaml is not supporting it anymore.
+# We can just remove the Python3.4 folder until ManyLinux1 drops the support too.
+rm -rf /opt/python/cp34-cp34m
+
 # Build static libessentia.a library
 # Use Python3.6. CentOS 5's native python is too old...
 PYBIN=/opt/python/cp36-cp36m/bin/


### PR DESCRIPTION
We are dropping support for Python 3.4 since PyYaml is not supporting it anymore.
We can just remove the Python3.4 folder until ManyLinux1 drops the support too. 
This way, we prevent making skip conditions in two 2 different loops so the code doesn't get too messy.