### PR TITLE
VectorRealToTensor fixes

### DIFF
--- a/src/algorithms/standard/vectorrealtotensor.cpp
+++ b/src/algorithms/standard/vectorrealtotensor.cpp
@@ -169,6 +169,9 @@ AlgorithmStatus VectorRealToTensor::process() {
           EXEC_DEBUG("VectorRealToTensor: 0 frames remaining.");
 
         } else {
+          if (frame.size() < 10) {
+            E_WARNING("VectorRealToTensor: Last patch produced by repeating the last " << frame.size() << " frames. May result in unreliable predictions.");
+          }
           vector<vector<Real> > padded_frame = frame;
 
           for (int i = 0; i < _timeStamps; i++) {
@@ -181,6 +184,7 @@ AlgorithmStatus VectorRealToTensor::process() {
 
       } else if (_lastPatchMode == "discard") {
         EXEC_DEBUG("VectorRealToTensor: Discarding last frames");
+
       } else {
         throw EssentiaException("VectorRealToTensor: Incomplete patch found "
                                 "before reaching the end of the stream. This is not supposed to happen");

--- a/src/algorithms/standard/vectorrealtotensor.cpp
+++ b/src/algorithms/standard/vectorrealtotensor.cpp
@@ -72,7 +72,6 @@ void VectorRealToTensor::configure() {
 
   _acc.assign(0, vector<vector<Real> >(_shape[2], vector<Real>(_shape[3], 0.0)));
   _push = false;
-  _pushedEverything = false;
 
   if (_patchHopSize > _timeStamps) {
     throw EssentiaException("VectorRealToTensor: `patchHopSize` has to be smaller that the number of timestamps");
@@ -99,20 +98,22 @@ AlgorithmStatus VectorRealToTensor::process() {
 
   // Check if we have enough frames to add a patch.
   int available = _frame.available();
-  bool addPatch = (_timeStamps <= available);
+  bool addPatch = (available >= _timeStamps);
 
   // If we should stop just take the remaining frames.
   if (shouldStop() && (available < _timeStamps)) {
     _frame.setAcquireSize(available);
     _frame.setReleaseSize(available);
+
+    // Push if there are remaining frames
+    if (_lastPatchMode == "repeat" && available > 0) {
+      addPatch = true;
+      _push = true;
   
-    // If we have been accumulating it is time to push!
-    if (_accumulate) {
-      // This is necesary to prevent and infinite loop.
-      if (!_pushedEverything) {
-        addPatch = true;
-        _push = true;
-      }
+    // or if we have been accumulating.
+    } else if (_accumulate && _acc.size() >= 1) {
+      addPatch = true;
+      _push = true;
     }
   }
 
@@ -149,6 +150,7 @@ AlgorithmStatus VectorRealToTensor::process() {
   if (addPatch) {
     const vector<vector<Real> >& frame = _frame.tokens();
 
+    // Sanity check.
     for (size_t i = 0; i < frame.size(); i++) {
       if ((int)frame[i].size() != _shape[3]) {
         throw EssentiaException("VectorRealToTensor: Found input frame with size ", frame[i].size(),
@@ -156,27 +158,29 @@ AlgorithmStatus VectorRealToTensor::process() {
       }
     }
 
+    // Add a regular patch.
     if ((int)frame.size() == _timeStamps) {
       _acc.push_back(frame);
+
+    // If size does not match rather repeat frames or discard them.
     } else {
-      // Rather repeat frames or discard the last patch.
-      if (shouldStop()) {
-        if (_lastPatchMode == "repeat") {
-          int padAmount = _timeStamps - frame.size();
+      if (_lastPatchMode == "repeat") {
+        if (frame.size() == 0) {
+          EXEC_DEBUG("VectorRealToTensor: 0 frames remaining.");
 
-          vector<vector<Real> > frame_padded = frame;
+        } else {
+          vector<vector<Real> > padded_frame = frame;
 
-          for (int i = 0; i < padAmount; i++) {
-            frame_padded.push_back(frame[i % frame.size()]); 
+          for (int i = 0; i < _timeStamps; i++) {
+            padded_frame.push_back(frame[i % frame.size()]);
           }
 
-          _acc.push_back(frame_padded);
+          EXEC_DEBUG("VectorRealToTensor: Repeating the remaining " << frame.size() << " frames to make one last patch.");
+          _acc.push_back(padded_frame);
         }
 
-        if (_lastPatchMode == "discard") {
-          EXEC_DEBUG("discarding last frames");
-        }
-
+      } else if (_lastPatchMode == "discard") {
+        EXEC_DEBUG("VectorRealToTensor: Discarding last frames");
       } else {
         throw EssentiaException("VectorRealToTensor: Incomplete patch found "
                                 "before reaching the end of the stream. This is not supposed to happen");
@@ -184,7 +188,7 @@ AlgorithmStatus VectorRealToTensor::process() {
     }
   }
 
-  // We only push if when we have filled the whole batch  
+  // We only push if when we have filled the whole batch
   // or if we have reached the end of the stream in
   // accumulate mode.
   if (_push) {
@@ -203,8 +207,6 @@ AlgorithmStatus VectorRealToTensor::process() {
                                 "produce a patch of the desired size. Consider setting the `lastPatchMode` "
                                 "parameter to `repeat` in order to produce a batch.");
       }
-    
-      _pushedEverything = true;
     }
 
     Tensor<Real>& tensor = *(Tensor<Real> *)_tensor.getFirstToken();
@@ -240,7 +242,6 @@ AlgorithmStatus VectorRealToTensor::process() {
 void VectorRealToTensor::reset() {
   _acc.assign(0, vector<vector<Real> >(_shape[1], vector<Real>(_shape[2], 0.0)));
   _push = false;
-  _pushedEverything = false;
 }
 
 } // namespace streaming

--- a/src/algorithms/standard/vectorrealtotensor.h
+++ b/src/algorithms/standard/vectorrealtotensor.h
@@ -37,7 +37,6 @@ class VectorRealToTensor : public Algorithm {
   int _patchHopSize;
   bool _push;
   bool _accumulate;
-  bool _pushedEverything;
   std::string _lastPatchMode;
 
   std::vector<std::vector<std::vector<Real> > > _acc;

--- a/test/src/unittests/machinelearning/test_tensorflowpredict.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredict.py
@@ -68,7 +68,7 @@ class TestTensorFlowPredict(TestCase):
 
         foundValues = poolOut['model/Softmax'].mean(axis=0).squeeze()
 
-        self.assertAlmostEqualVector(foundValues, expectedValues, 1e-6)
+        self.assertAlmostEqualVector(foundValues, expectedValues, 1e-5)
 
     def testInvalidFilename(self):
         self.assertComputeFails(TensorflowPredict(graphFilename=''), (Pool()))

--- a/test/src/unittests/machinelearning/test_tensorflowpredict_streaming.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredict_streaming.py
@@ -125,20 +125,26 @@ class TestTensorflowPredict_Streaming(TestCase):
             self.assertAlmostEqualVector(foundValues, expectedValues, 1e-2)
 
     def testIdentityModel(self):
-        # Patch size equal to number of frames
+        # The test audio file has 430 frames.
+        # Setting the patchSize to produce exactly 10 patches.
         numberOfFrames = 43
-        found, expected = self.identityModel(patchSize=numberOfFrames, lastPatchMode='repeat')
+        found, expected = self.identityModel(patchSize=numberOfFrames,
+                                             lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
-        # Default parameters
+        # Now the number of frames does not match an exact number of patches.
+        # The expected output is trimmed to the found shape as with
+        # lastPatchMode='discard' the remaining frames not fitting into a
+        # patch are discarded.
         found, expected = self.identityModel(frameSize=256, hopSize=128,
-                                             lastPatchMode='repeat')
+                                             lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
 
-        # Increse aquire size
+        # Increase the patch size.
         found, expected = self.identityModel(frameSize=256, hopSize=128,
-                                             patchSize=300, lastPatchMode='repeat')
+                                             patchSize=300, lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
 
 suite = allTests(TestTensorflowPredict_Streaming)
 

--- a/test/src/unittests/streaming/test_tensortopool.py
+++ b/test/src/unittests/streaming/test_tensortopool.py
@@ -25,8 +25,10 @@ from essentia.streaming import *
 class TestTensorToPool(TestCase):
 
     def identityOperation(self, frameSize=1024, hopSize=512, patchSize=187,
-                          lastPatchMode='discard'):
-        # Identity test to check that the data flows properly
+                          lastPatchMode='discard', accumulate=False):
+        
+        batchHopSize = -1 if accumulate else 1
+
         filename = join(testdata.audio_dir, 'recorded', 'cat_purrrr.wav')
         namespace='tensor'
 
@@ -52,25 +54,98 @@ class TestTensorToPool(TestCase):
 
         return pool['framesOut'], pool['framesIn']
 
-    def testFramesToPoolAndBackToFrames(self):
+    def testFramesToTensorAndBackToFramesDiscard(self):
         # Patch size equal to number of frames
+        numberOfFrames = 43
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='discard')
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
+        # Default patch size. The expected output is trimmed to the found
+        # shape as with lastPatchMode='discard' the remaining frames not
+        # fitting into a patch are discarded.
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 lastPatchMode='discard')
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+        # Increse aquire size
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 patchSize=300, lastPatchMode='discard')
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+    def testFramesToTensorAndBackToFramesDiscardAccumulate(self):
+        # Repeat the tests in accumulate mode. Here the patches are stored
+        # internally and pushed at once at the end of the stream.
+        numberOfFrames = 43
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='discard',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 lastPatchMode='discard',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 patchSize=300, lastPatchMode='discard',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+    def testFramesToTensorAndBackToFramesRepeat(self):
+        # Reapeat the experiments with lastPatchMode='repeat'. Now the found
+        # patches will be equal or bigger then the expected ones. They will
+        # be trimmed to fit the expected output. 
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
-        # Default parameters
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  lastPatchMode='repeat')
-        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
-        # Increse aquire size
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  patchSize=300, lastPatchMode='repeat')
-        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
+
+    def testFramesToTensorAndBackToFramesRepeatAccumulate(self):
+        # Repeat the text with lastPatchMode='repeat' and in accumulate mode.
+        numberOfFrames = 43
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='repeat',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 lastPatchMode='repeat',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 patchSize=300, lastPatchMode='repeat',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
     def testInvalidParam(self):
         self.assertConfigureFails(TensorToPool(), {'mode': ''})
+
+    def testRepeatMode(self):
+        # Our test audio has 430 frames. If patchSize is set to 428 with
+        # lastPatchMode='repeat' VectorRealToTensor will produce a second
+        # patch of 428 frames by looping the last 2 spare samples.
+        numberOfFrames = 428
+        loopFrames = 430 - numberOfFrames
+        
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='repeat')
+
+        expected = numpy.vstack([expected[:numberOfFrames]] +  #  frames for the first patch
+                                [expected[numberOfFrames:numberOfFrames + loopFrames]] *  # remaining frames for the second patch
+                                (numberOfFrames // loopFrames))  # number of repetitions to fill the second patch
+
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
 
 suite = allTests(TestTensorToPool)
 

--- a/test/src/unittests/streaming/test_tensortopool.py
+++ b/test/src/unittests/streaming/test_tensortopool.py
@@ -55,20 +55,22 @@ class TestTensorToPool(TestCase):
         return pool['framesOut'], pool['framesIn']
 
     def testFramesToTensorAndBackToFramesDiscard(self):
-        # Patch size equal to number of frames
+        # The test audio file has 430 frames.
+        # Setting the patchSize to produce exactly 10 patches.
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
-        # Default patch size. The expected output is trimmed to the found
-        # shape as with lastPatchMode='discard' the remaining frames not
-        # fitting into a patch are discarded.
+        # Now the number of frames does not match an exact number of patches.
+        # The expected output is trimmed to the found shape as with
+        # lastPatchMode='discard' the remaining frames not fitting into a
+        # patch are discarded.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
 
-        # Increse aquire size
+        # Increase the patch size.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  patchSize=300, lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
@@ -93,24 +95,29 @@ class TestTensorToPool(TestCase):
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
 
     def testFramesToTensorAndBackToFramesRepeat(self):
-        # Reapeat the experiments with lastPatchMode='repeat'. Now the found
-        # patches will be equal or bigger then the expected ones. They will
-        # be trimmed to fit the expected output. 
+        # Repeat the experiments with lastPatchMode='repeat'. Now if there
+        # are remaining frames they will be looped into a final patch.
+        # The found shape will be equal or bigger than the expected one.
+        # Found values will be trimmed to fit the expected shape.
+
+        # No remaining frames.
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
+        # Some remaining frames.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
+        # Increase the patch size.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  patchSize=300, lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
     def testFramesToTensorAndBackToFramesRepeatAccumulate(self):
-        # Repeat the text with lastPatchMode='repeat' and in accumulate mode.
+        # The behavior should be the same in accumulate mode.
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='repeat',
@@ -131,9 +138,9 @@ class TestTensorToPool(TestCase):
         self.assertConfigureFails(TensorToPool(), {'mode': ''})
 
     def testRepeatMode(self):
-        # Our test audio has 430 frames. If patchSize is set to 428 with
+        # The test audio file has 430 frames. If patchSize is set to 428 with
         # lastPatchMode='repeat' VectorRealToTensor will produce a second
-        # patch of 428 frames by looping the last 2 spare samples.
+        # patch of 428 frames by looping the last two spare samples.
         numberOfFrames = 428
         loopFrames = 430 - numberOfFrames
         

--- a/test/src/unittests/streaming/test_vectorrealtotensor.py
+++ b/test/src/unittests/streaming/test_vectorrealtotensor.py
@@ -51,20 +51,22 @@ class TestVectorRealToTensor(TestCase):
 
 
     def testFramesToTensorAndBackToFramesDiscard(self):
-        # Patch size equal to number of frames
+        # The test audio file has 430 frames.
+        # Setting the patchSize to produce exactly 10 patches.
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
-        # Default patch size. The expected output is trimmed to the found
-        # shape as with lastPatchMode='discard' the remaining frames not
-        # fitting into a patch are discarded.
+        # Now the number of frames does not match an exact number of patches.
+        # The expected output is trimmed to the found shape as with
+        # lastPatchMode='discard' the remaining frames not fitting into a
+        # patch are discarded.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
 
-        # Increse aquire size
+        # Increase the patch size.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  patchSize=300, lastPatchMode='discard')
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
@@ -89,24 +91,29 @@ class TestVectorRealToTensor(TestCase):
         self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
 
     def testFramesToTensorAndBackToFramesRepeat(self):
-        # Reapeat the experiments with lastPatchMode='repeat'. Now the found
-        # patches will be equal or bigger then the expected ones. They will
-        # be trimmed to fit the expected output. 
+        # Repeat the experiments with lastPatchMode='repeat'. Now if there
+        # are remaining frames they will be looped into a final patch.
+        # The found shape will be equal or bigger than the expected one.
+        # Found values will be trimmed to fit the expected shape.
+
+        # No remaining frames.
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
+        # Some remaining frames.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
+        # Increase the patch size.
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  patchSize=300, lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
     def testFramesToTensorAndBackToFramesRepeatAccumulate(self):
-        # Repeat the text with lastPatchMode='repeat' and in accumulate mode.
+        # The behavior should be the same in accumulate mode.
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='repeat',
@@ -134,9 +141,9 @@ class TestVectorRealToTensor(TestCase):
         self.assertConfigureFails(VectorRealToTensor(), {'shape': [1, 1, 0, 0]})
 
     def testRepeatMode(self):
-        # Our test audio has 430 frames. If patchSize is set to 428 with
+        # The test audio file has 430 frames. If patchSize is set to 428 with
         # lastPatchMode='repeat' VectorRealToTensor will produce a second
-        # patch of 428 frames by looping the last 2 spare samples.
+        # patch of 428 frames by looping the last two spare samples.
         numberOfFrames = 428
         loopFrames = 430 - numberOfFrames
         

--- a/test/src/unittests/streaming/test_vectorrealtotensor.py
+++ b/test/src/unittests/streaming/test_vectorrealtotensor.py
@@ -25,13 +25,15 @@ from essentia.streaming import *
 class TestVectorRealToTensor(TestCase):
 
     def identityOperation(self, frameSize=1024, hopSize=512, patchSize=187,
-                          lastPatchMode='discard'):
-        # Identity test to check that the data flows properly.
+                          lastPatchMode='discard', accumulate=False):
+
+        batchHopSize = -1 if accumulate else 1
+
         filename = join(testdata.audio_dir, 'recorded', 'cat_purrrr.wav')
 
         ml = MonoLoader(filename=filename)
         fc = FrameCutter(frameSize=frameSize, hopSize=hopSize)
-        vtt = VectorRealToTensor(shape=[1, 1, patchSize, frameSize],
+        vtt = VectorRealToTensor(shape=[batchHopSize, 1, patchSize, frameSize],
                                  lastPatchMode=lastPatchMode)
         ttv = TensorToVectorReal()
 
@@ -47,22 +49,79 @@ class TestVectorRealToTensor(TestCase):
 
         return pool['framesOut'], pool['framesIn']
 
-    def testFramesToTensorAndBackToFrames(self):
+
+    def testFramesToTensorAndBackToFramesDiscard(self):
         # Patch size equal to number of frames
+        numberOfFrames = 43
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='discard')
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
+        # Default patch size. The expected output is trimmed to the found
+        # shape as with lastPatchMode='discard' the remaining frames not
+        # fitting into a patch are discarded.
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 lastPatchMode='discard')
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+        # Increse aquire size
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 patchSize=300, lastPatchMode='discard')
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+    def testFramesToTensorAndBackToFramesDiscardAccumulate(self):
+        # Repeat the tests in accumulate mode. Here the patches are stored
+        # internally and pushed at once at the end of the stream.
+        numberOfFrames = 43
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='discard',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 lastPatchMode='discard',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 patchSize=300, lastPatchMode='discard',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+
+    def testFramesToTensorAndBackToFramesRepeat(self):
+        # Reapeat the experiments with lastPatchMode='repeat'. Now the found
+        # patches will be equal or bigger then the expected ones. They will
+        # be trimmed to fit the expected output. 
         numberOfFrames = 43
         found, expected = self.identityOperation(patchSize=numberOfFrames,
                                                  lastPatchMode='repeat')
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
-        # Default parameters
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  lastPatchMode='repeat')
-        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
-        # Increse aquire size
         found, expected = self.identityOperation(frameSize=256, hopSize=128,
                                                  patchSize=300, lastPatchMode='repeat')
-        self.assertAlmostEqualMatrix(found, expected[:found.shape[0], :], 1e-8)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
+
+    def testFramesToTensorAndBackToFramesRepeatAccumulate(self):
+        # Repeat the text with lastPatchMode='repeat' and in accumulate mode.
+        numberOfFrames = 43
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='repeat',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 lastPatchMode='repeat',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
+
+        found, expected = self.identityOperation(frameSize=256, hopSize=128,
+                                                 patchSize=300, lastPatchMode='repeat',
+                                                 accumulate=True)
+        self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
     def testInvalidParam(self):
         # VectorRealToTensor only supports single chanel data
@@ -73,6 +132,23 @@ class TestVectorRealToTensor(TestCase):
         self.assertConfigureFails(VectorRealToTensor(), {'shape': [1, 0, 1, 1]})
         self.assertConfigureFails(VectorRealToTensor(), {'shape': [1, 1, 0, 1]})
         self.assertConfigureFails(VectorRealToTensor(), {'shape': [1, 1, 0, 0]})
+
+    def testRepeatMode(self):
+        # Our test audio has 430 frames. If patchSize is set to 428 with
+        # lastPatchMode='repeat' VectorRealToTensor will produce a second
+        # patch of 428 frames by looping the last 2 spare samples.
+        numberOfFrames = 428
+        loopFrames = 430 - numberOfFrames
+        
+        found, expected = self.identityOperation(patchSize=numberOfFrames,
+                                                 lastPatchMode='repeat')
+
+        expected = numpy.vstack([expected[:numberOfFrames]] +  #  frames for the first patch
+                                [expected[numberOfFrames:numberOfFrames + loopFrames]] *  # remaining frames for the second patch
+                                (numberOfFrames // loopFrames))  # number of repetitions to fill the second patch
+
+        self.assertAlmostEqualMatrix(found, expected, 1e-8)
+
 
 suite = allTests(TestVectorRealToTensor)
 


### PR DESCRIPTION
- Improve the logic to decide if a patch should be added when shouldStop()
- Do not add a last patch in repeat mode when there are 0 frames remaining
- Remove unnecessary `_pushedEverything` variable
- Improve comments and exception information

Additionally, several unit tests are added.