### PR TITLE
Fix docstrings and added some improvements in streaming mode music similarity 

### DIFF
--- a/src/algorithms/highlevel/chromacrosssimilarity.cpp
+++ b/src/algorithms/highlevel/chromacrosssimilarity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *
@@ -43,7 +43,7 @@ const char* ChromaCrossSimilarity::description = DOC("This algorithm computes a 
 "The input chromagram should be in the shape (n_frames, numbins), where 'n_frames' is number of frames and 'numbins' for the number of bins in the chromagram. An exception is thrown otherwise.\n\n"
 "An exception is also thrown if either one of the input chromagrams are empty.\n\n"
 "While param 'streaming=True', the algorithm accumulates the input 'queryFeature' in the pairwise similarity matrix calculation on each call of compute() method. You can reset it using the reset() method.\n\n"
-"References:\n"
+"References:\n\n"
 "[1] Serra, J., Gómez, E., & Herrera, P. (2008). Transposing chroma representations to a common key, IEEE Conference on The Use of Symbols to Represent Music and Multimedia Objects.\n\n"
 "[2] Serra, J., Serra, X., & Andrzejak, R. G. (2009). Cross recurrence quantification for cover song identification.New Journal of Physics.\n\n"
 "[3] Serra, Joan, et al. Chroma binary similarity and local alignment applied to cover song identification. IEEE Transactions on Audio, Speech, and Language Processing 16.6 (2008).\n");

--- a/src/algorithms/highlevel/chromacrosssimilarity.cpp
+++ b/src/algorithms/highlevel/chromacrosssimilarity.cpp
@@ -37,6 +37,7 @@ namespace standard {
 const char* ChromaCrossSimilarity::name = "ChromaCrossSimilarity";
 const char* ChromaCrossSimilarity::category = "Music Similarity";
 const char* ChromaCrossSimilarity::description = DOC("This algorithm computes a binary cross similarity matrix from two chromagam feature vectors of a query and reference song.\n\n"
+"With default parameters, this algorithm computes cross-similarity of two given input chromagrams as described in [2].\n\n"
 "Use HPCP algorithm for computing the chromagram with default parameters of this algorithm for the best results.\n\n"
 "If parameter 'oti=True', the algorithm transpose the reference song chromagram by optimal transposition index as described in [1].\n\n"
 "If parameter 'otiBinary=True', the algorithm computes the binary cross-similarity matrix based on optimal transposition index between each feature pairs instead of euclidean distance as described in [3].\n\n"

--- a/src/algorithms/highlevel/chromacrosssimilarity.h
+++ b/src/algorithms/highlevel/chromacrosssimilarity.h
@@ -40,9 +40,9 @@ class ChromaCrossSimilarity : public Algorithm {
     declareParameter("frameStackStride", "stride size to form a stack of frames (e.g., 'frameStackStride'=1 to use consecutive frames; 'frameStackStride'=2 for using every second frame)", "[1,inf)", 1);
     declareParameter("frameStackSize", "number of input frames to stack together and treat as a feature vector for similarity computation. Choose 'frameStackSize=1' to use the original input frames without stacking", "[0,inf)", 9);
     declareParameter("binarizePercentile", "maximum percent of distance values to consider as similar in each row and each column", "[0,1]", 0.095);
-    declareParameter("oti", "whether to transpose the key of the reference song to the query song by (OTI)", "{true,false}", true);
-    declareParameter("noti", "Number of circular shifts to be checked for optimal transposition index", "[0, inf)", 12);
-    declareParameter("otiBinary", "whether to use the OTI-based chroma binary similarity method", "{true,false}", false);
+    declareParameter("oti", "whether to transpose the key of the reference song to the query song by Optimal Transposition Index [1]", "{true,false}", true);
+    declareParameter("noti", "number of circular shifts to be checked for Optimal Transposition Index [1]", "[0, inf)", 12);
+    declareParameter("otiBinary", "whether to use the OTI-based chroma binary similarity method [3]", "{true,false}", false);
     declareParameter("streaming", "whether to accumulate the input 'queryFeature' in the euclidean similarity matrix calculation on each compute() method call", "{true,false}", false);
   }
 

--- a/src/algorithms/highlevel/chromacrosssimilarity.h
+++ b/src/algorithms/highlevel/chromacrosssimilarity.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *
@@ -31,8 +31,8 @@ class ChromaCrossSimilarity : public Algorithm {
    Output<std::vector<std::vector<Real> > > _csm;
   public:
    ChromaCrossSimilarity() {
-    declareInput(_queryFeature, "queryFeature", "input chromagram of the query song (e.g., a HPCP)");
-    declareInput(_referenceFeature, "referenceFeature", "input chromagram of the reference song (e.g., a HPCP)");
+    declareInput(_queryFeature, "queryFeature", "frame-wise chromagram of the query song (e.g., a HPCP)");
+    declareInput(_referenceFeature, "referenceFeature", "frame-wise chromagram of the reference song (e.g., a HPCP)");
     declareOutput(_csm, "csm", "2D binary cross-similarity matrix of the query and reference features");
    }
 

--- a/src/algorithms/highlevel/coversongsimilarity.cpp
+++ b/src/algorithms/highlevel/coversongsimilarity.cpp
@@ -271,7 +271,7 @@ void CoverSongSimilarity::subFrameQmax(std::vector<std::vector<Real> >& inputFra
 Real gammaState(Real value, const Real disOnset, const Real disExtension) {
   if      (int(value) == 1) return disOnset;
   else if (int(value) == 0) return disExtension;
-  else throw EssentiaException("CoverSongSimilarity:Non-binary elements found in the inputsimilarity matrix. Expected a binary similarity matrix!");
+  else throw EssentiaException("CoverSongSimilarity:Non-binary elements found in the input similarity matrix. Expected a binary similarity matrix!");
 }
 
 

--- a/src/algorithms/highlevel/coversongsimilarity.cpp
+++ b/src/algorithms/highlevel/coversongsimilarity.cpp
@@ -82,13 +82,13 @@ void CoverSongSimilarity::compute() {
     for(size_t i = 2; i < xFrames; i++) {
       for(size_t j = 2; j < yFrames; j++) {
         // measure the diagonal when a similarity is found in the input matrix
-        if (simMatrix[i][j] == 1) {
+        if (int(simMatrix[i][j]) == 1) {
           c1 = scoreMatrix[i-1][j-1];
           c2 = scoreMatrix[i-2][j-1];
           c3 = scoreMatrix[i-1][j-2];
           Real row[3] = {c1, c2 , c3};
           scoreMatrix[i][j] = *std::max_element(row, row+3) + 1;
-          }
+        }
         else {
         // apply gap penalty onset for disruption and extension when similarity is not found in the input matrix
           c1 = scoreMatrix[i-1][j-1] - gammaState(simMatrix[i-1][j-1], _disOnset, _disExtension);
@@ -96,7 +96,7 @@ void CoverSongSimilarity::compute() {
           c3 = scoreMatrix[i-1][j-2] - gammaState(simMatrix[i-1][j-2], _disOnset, _disExtension);
           Real row2[4] = {0, c1, c2, c3};
           scoreMatrix[i][j] = *std::max_element(row2, row2+4);
-          }
+        }
       }
     }
   }
@@ -105,7 +105,7 @@ void CoverSongSimilarity::compute() {
     for(size_t i = 3; i < xFrames; i++) {
       for(size_t j = 3; j < yFrames; j++) {
         // measure the diagonal when a similarity is found in the input matrix
-        if (simMatrix[i][j] == 1.) {
+        if (int(simMatrix[i][j]) == 1) {
           c2 = scoreMatrix[i-2][j-1] + simMatrix[i-1][j];
           c3 = scoreMatrix[i-1][j-2] + simMatrix[i][j-1];
           c4 = scoreMatrix[i-3][j-1] + simMatrix[i-2][j] + simMatrix[i-1][j];
@@ -144,12 +144,14 @@ void CoverSongSimilarity::compute() {
 namespace essentia {
 namespace streaming {
 
+
 const char* CoverSongSimilarity::name = standard::CoverSongSimilarity::name;
 const char* CoverSongSimilarity::description = standard::CoverSongSimilarity::description;
 
 void CoverSongSimilarity::configure() {
   _disOnset = parameter("disOnset").toReal();
   _disExtension = parameter("disExtension").toReal();
+  _pipeDistance = parameter("pipeDistance").toBool();
   std::string distanceType = toLower(parameter("distanceType").toString());
   if      (distanceType == "symmetric") _distanceType = SYMMETRIC;
   else if (distanceType == "asymmetric") _distanceType = ASYMMETRIC;
@@ -157,16 +159,11 @@ void CoverSongSimilarity::configure() {
   _c1 = 0;
   _c2 = 0;
   _c3 = 0;
-  _c4 = 0;
-  _c5 = 0;
-  _minFramesSize = 2*2;
-
-  input("inputArray").setAcquireSize(_minFramesSize);
-  input("inputArray").setReleaseSize(_minFramesSize);
-
+  // set the acquire and release size for the inputs and outputs for the streaming network
+  input("inputArray").setAcquireSize(_minFrameAcquireSize);
+  input("inputArray").setReleaseSize(_minFrameReleaseSize);
   output("scoreMatrix").setAcquireSize(1);
   output("scoreMatrix").setReleaseSize(1);
-
 }
 
 AlgorithmStatus CoverSongSimilarity::process() {
@@ -179,7 +176,7 @@ AlgorithmStatus CoverSongSimilarity::process() {
   AlgorithmStatus status = acquireData();
   EXEC_DEBUG("data acquired (in: " << _inputArray.acquireSize()
              << " - out: " << _scoreMatrix.acquireSize() << ")");
-
+  
   if (status != OK) {
     if (!shouldStop()) return status;
 
@@ -198,77 +195,68 @@ AlgorithmStatus CoverSongSimilarity::process() {
   std::vector<std::vector<Real> > inputFramesCopy = inputFrames; 
   /* if we have less input frame streams than the required '_minFrameSize' in the last stream, 
    we append the already acquired frames of the current stream until it satisfies the condition */
-  if (input("inputArray").acquireSize() < _minFramesSize) {
-    for (int i=0; i<(_minFramesSize - input("inputArray").acquireSize()); i++) {
+  if (input("inputArray").acquireSize() < _minFrameAcquireSize) {
+    for (int i=0; i<(_minFrameAcquireSize - input("inputArray").acquireSize()); i++) {
       inputFramesCopy.push_back(inputFrames[i]);
     }
   }
 
   _xFrames = inputFramesCopy.size();
   _yFrames = inputFramesCopy[0].size();
-  std::vector<std::vector<Real> > incrementMatrix(_xFrames, std::vector<Real>(_yFrames, 0));
 
-  // if it's the very first stream of feature array, we initialize the state varibales and indexes
   if (_iterIdx == 0) {
-    _prevCumMatrixFrames.assign(_xFrames, std::vector<Real>(_yFrames, 0));
-    for (size_t i=0; i<_xFrames; i++) {
-      _previnputMatrixFrames.push_back(inputFramesCopy[i]);
-    }
-    _accumXFrameSize = _xFrames;
-    _x = 2;
-    _xIter = 2;
+    _mainScoreMatrix.assign(_xFrames, std::vector<Real>(_yFrames, 0));
   }
-  // otherwise we update the indexes with respected to the previously stored prevcumMatrixFrames
   else {
-    for (size_t i=0; i<_xFrames; i++) {
-      _previnputMatrixFrames.push_back(inputFramesCopy[i]);
-    }
-    _accumXFrameSize = _xFrames * (_iterIdx +  1);
-    _x = _xFrames * _iterIdx;
-    _xIter = 0;
+    _mainScoreMatrix.push_back(std::vector<Real>(_yFrames, 0));
   }
-  
-  // iterate through the similarity matrix to recursively construct the smith-waterman scoring cumilative matrix
-  for(size_t i = _x; i < _accumXFrameSize; i++) {
-    for(size_t j = 2; j < _yFrames; j++) {
-      // measure the diagonal when a similarity is found in the input matrix
-      if (inputFramesCopy[_xIter][j] == 1) {
-        _c1 = _prevCumMatrixFrames[i-1][j-1];
-        _c2 = _prevCumMatrixFrames[i-2][j-1];
-        _c3 = _prevCumMatrixFrames[i-1][j-2];
-        Real row[3] = {_c1, _c2 , _c3};
-        incrementMatrix[_xIter][j] = *std::max_element(row, row+3) + 1;
-        }
-      // apply gap penalty onset for disruption and extension when similarity is not found in the input matrix
-      else {
-        _c1 = _prevCumMatrixFrames[i-1][j-1] - gammaState(_previnputMatrixFrames[i-1][j-1], _disOnset, _disExtension);
-        _c2 = _prevCumMatrixFrames[i-2][j-1] - gammaState(_previnputMatrixFrames[i-2][j-1], _disOnset, _disExtension);
-        _c3 = _prevCumMatrixFrames[i-1][j-2] - gammaState(_previnputMatrixFrames[i-1][j-2], _disOnset, _disExtension);
-        Real row2[4] = {0, _c1, _c2, _c3};
-        incrementMatrix[_xIter][j] = *std::max_element(row2, row2+4);
-      }
-    }
-    if (_xIter < _xFrames) _xIter++;
-  }
-  _iterIdx++;
-  // add the resulted score matrix to the buffer variables
-  for (size_t i=0; i<_xFrames; i++) {
-    _bufferScoreMatrix.push_back(incrementMatrix[i]);
-    _prevCumMatrixFrames.push_back(incrementMatrix[i]);
-  }
+
+  // compute qmax alignment score matrix for each 3 sub frames of input stream 
+  subFrameQmax(inputFramesCopy);
+
+  // compute distance
   if (_distanceType == SYMMETRIC) {
-    distance[0] = maxElementArray(_bufferScoreMatrix);
+    distance[0] = maxElementArray(_mainScoreMatrix);
   }
   else if (_distanceType == ASYMMETRIC) {
     // compute cover song similarity distance by normalising it with the length of reference song as described in [2].
-    distance[0] = sqrt(_yFrames) / maxElementArray(_bufferScoreMatrix);
+    distance[0] = sqrt(_yFrames) / maxElementArray(_mainScoreMatrix);
   }
-  // std::cout << distance[0] << std::endl;
-  E_INFO(distance[0]);
-  scoreMatrix[0] = vecvecToArray2D(incrementMatrix);
+  if (_pipeDistance) E_INFO(distance[0]);
+  _iterIdx++;
+  scoreMatrix[0] = vecvecToArray2D(_perFrameScoreMatrix);
+  _perFrameScoreMatrix.clear();
   releaseData();
   return OK;
 }
+
+// compute smith-waterman alignment based on [2] for each 3 frames streams of array input
+void CoverSongSimilarity::subFrameQmax(std::vector<std::vector<Real> >& inputFrames) {
+  
+  if (int(_xFrames) != _minFrameAcquireSize) throw EssentiaException("CoverSongSimilarity: Wrong input frame size!");
+  int i = 2;
+  for (size_t j=2; j<_yFrames; j++) {
+    // measure the diagonal when a similarity is found in the input matrix
+    if (int(inputFrames[i][j]) == 1) {
+      _c1 = _mainScoreMatrix[_iterRow-1][j-1];
+      _c2 = _mainScoreMatrix[_iterRow-2][j-1];
+      _c3 = _mainScoreMatrix[_iterRow-1][j-2];
+      Real row[3] = {_c1, _c2 , _c3};
+      _mainScoreMatrix[_iterRow][j] = *std::max_element(row, row+3) + 1;
+    }
+    else {
+    // apply gap penalty onset for disruption and extension when similarity is not found in the input matrix
+    _c1 = _mainScoreMatrix[_iterRow-1][j-1] - gammaState(inputFrames[i-1][j-1], _disOnset, _disExtension);
+    _c2 = _mainScoreMatrix[_iterRow-2][j-1] - gammaState(inputFrames[i-2][j-1], _disOnset, _disExtension);
+    _c3 = _mainScoreMatrix[_iterRow-1][j-2] - gammaState(inputFrames[i-1][j-2], _disOnset, _disExtension);
+    Real row2[4] = {0, _c1, _c2, _c3};
+    _mainScoreMatrix[_iterRow][j] = *std::max_element(row2, row2+4);
+    }
+  }
+  _perFrameScoreMatrix.push_back(_mainScoreMatrix[_iterRow]);
+  _iterRow++;
+};
+
 
 } // namespace streaming
 } // namespace essentia
@@ -276,8 +264,8 @@ AlgorithmStatus CoverSongSimilarity::process() {
 
 // apply gap penalty for disruption  onset and extension
 Real gammaState(Real value, const Real disOnset, const Real disExtension) {
-  if      (value == 1.0) return disOnset;
-  else if (value == 0.0) return disExtension;
+  if      (int(value) == 1) return disOnset;
+  else if (int(value) == 0) return disExtension;
   else throw EssentiaException("CoverSongSimilarity:Non-binary elements found in the inputsimilarity matrix. Expected a binary similarity matrix!");
 }
 

--- a/src/algorithms/highlevel/coversongsimilarity.cpp
+++ b/src/algorithms/highlevel/coversongsimilarity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *
@@ -36,10 +36,10 @@ namespace standard {
 const char* CoverSongSimilarity::name = "CoverSongSimilarity";
 const char* CoverSongSimilarity::category = "Music Similarity";
 const char* CoverSongSimilarity::description = DOC("This algorithm computes a cover song similiarity measure from an input cross similarity matrix of two chroma vectors of a query and reference song using various alignment constraints of smith-waterman local-alignment algorithm.\n\n"
-"This algorithm expects to recieve the input matrix from essentia 'ChromaCrossSimilarity' algorithm or essentia 'CrossSimilarityMatrix' with parameter 'binarize=True'.\n\n"
+"This algorithm expects to recieve the binary similarity matrix input from essentia 'ChromaCrossSimilarity' algorithm or essentia 'CrossSimilarityMatrix' with parameter 'binarize=True'.\n\n"
 "The algorithm provides two different allignment contraints for computing the smith-waterman score matrix (check references).\n\n"
 "Exceptions are thrown if the input similarity matrix is not binary or empty.\n\n"
-"References:\n"
+"References:\n\n"
 "[1] Smith-Waterman algorithm (Wikipedia, https://en.wikipedia.org/wiki/Smith%E2%80%93Waterman_algorithm).\n\n"
 "[2] Serra, J., Serra, X., & Andrzejak, R. G. (2009). Cross recurrence quantification for cover song identification.New Journal of Physics.\n\n"
 "[3] Chen, N., Li, W., & Xiao, H. (2017). Fusing similarity functions for cover song identification. Multimedia Tools and Applications.\n");

--- a/src/algorithms/highlevel/coversongsimilarity.cpp
+++ b/src/algorithms/highlevel/coversongsimilarity.cpp
@@ -35,7 +35,7 @@ namespace standard {
 
 const char* CoverSongSimilarity::name = "CoverSongSimilarity";
 const char* CoverSongSimilarity::category = "Music Similarity";
-const char* CoverSongSimilarity::description = DOC("This algorithm computes a cover song similiarity measure from an input cross similarity matrix of two chroma vectors of a query and reference song using various alignment constraints of smith-waterman local-alignment algorithm.\n\n"
+const char* CoverSongSimilarity::description = DOC("This algorithm computes a cover song similiarity measure from a binary cross similarity matrix input between two chroma vectors of a query and reference song using various alignment constraints of smith-waterman local-alignment algorithm.\n\n"
 "This algorithm expects to recieve the binary similarity matrix input from essentia 'ChromaCrossSimilarity' algorithm or essentia 'CrossSimilarityMatrix' with parameter 'binarize=True'.\n\n"
 "The algorithm provides two different allignment contraints for computing the smith-waterman score matrix (check references).\n\n"
 "Exceptions are thrown if the input similarity matrix is not binary or empty.\n\n"
@@ -146,7 +146,12 @@ namespace streaming {
 
 
 const char* CoverSongSimilarity::name = standard::CoverSongSimilarity::name;
-const char* CoverSongSimilarity::description = standard::CoverSongSimilarity::description;
+const char* CoverSongSimilarity::description = DOC("This algorithm computes a cover song similiarity measure from a binary cross similarity matrix input between two chroma vectors of a query and reference song using specific alignment constraint [2] of smith-waterman local-alignment algorithm [1].\n\n"
+"This algorithm expects to recieve the binary similarity matrix input from essentia 'ChromaCrossSimilarity' algorithm or essentia 'CrossSimilarityMatrix' with parameter 'binarize=True'.\n\n"
+"Exceptions are thrown if the input similarity matrix is not binary or empty.\n\n"
+"References:\n\n"
+"[1] Smith-Waterman algorithm (Wikipedia, https://en.wikipedia.org/wiki/Smith%E2%80%93Waterman_algorithm).\n\n"
+"[2] Serra, J., Serra, X., & Andrzejak, R. G. (2009). Cross recurrence quantification for cover song identification.New Journal of Physics.\n\n");
 
 void CoverSongSimilarity::configure() {
   _disOnset = parameter("disOnset").toReal();

--- a/src/algorithms/highlevel/coversongsimilarity.h
+++ b/src/algorithms/highlevel/coversongsimilarity.h
@@ -79,31 +79,28 @@ class CoverSongSimilarity : public Algorithm {
    Source<Real> _distance;
    
    // params and global protected variables
-   int _minFramesSize = 2;
-   int _iterIdx = 0;
    Real _disOnset;
    Real _disExtension;
+   bool _pipeDistance;
    enum DistanceType {
      SYMMETRIC, ASYMMETRIC
    };
    DistanceType _distanceType;
+   int _minFrameAcquireSize = 3;
+   int _minFrameReleaseSize = 2;
+   int _iterIdx = 0;
+   int _iterRow = 2;
    Real _c1;
    Real _c2;
    Real _c3;
-   Real _c4;
-   Real _c5;
    size_t _xFrames;
    size_t _yFrames;
-   size_t _xIter;
-   size_t _accumXFrameSize;
-   size_t _x;
-   std::vector<std::vector<Real> > _prevCumMatrixFrames;
-   std::vector<std::vector<Real> > _previnputMatrixFrames;
-   std::vector<std::vector<Real> > _bufferScoreMatrix;
+   std::vector<std::vector<Real> > _perFrameScoreMatrix;
+   std::vector<std::vector<Real> > _mainScoreMatrix;
 
   public:
    CoverSongSimilarity() : Algorithm() {
-    declareInput(_inputArray, _minFramesSize, "inputArray", "a 2D binary cross similarity matrix of two audio chroma vectors (refer CrossSimilarityMatrix algorithm').");
+    declareInput(_inputArray, _minFrameAcquireSize, "inputArray", "a 2D binary cross similarity matrix of two audio chroma vectors (refer CrossSimilarityMatrix algorithm').");
     declareOutput(_scoreMatrix, 1, "scoreMatrix", "a 2D smith-waterman alignment score matrix from the input binary cross-similarity matrix as described in [2].");
     declareOutput(_distance, 1, "distance", "cover song similarity distance between the query and reference song from the input similarity. Either 'asymmetric' (as described in [2]) or 'symmetric' (maximum score in the alignment score matrix).");
   }
@@ -114,9 +111,12 @@ class CoverSongSimilarity : public Algorithm {
     declareParameter("disOnset", "penalty for disruption onset", "[0,inf)", 0.5);
     declareParameter("disExtension", "penalty for disruption extension", "[0,inf)", 0.5);
     declareParameter("distanceType", "choose the type of distance. By default the algorithm outputs a asymmetric disctance which is obtained by normalising the maximum score in the alignment score matrix with length of reference song", "{asymmetric,symmetric}", "asymmetric");
+    declareParameter("pipeDistance", "whether to pipe-out the computed cover song similarity distance for each stream of input similarity matrix", "{true,false}", false);
   }
 
   void configure();
+
+  void subFrameQmax(std::vector<std::vector<Real> >& inputFrames);
 
   static const char* name;
   static const char* category;

--- a/src/algorithms/highlevel/coversongsimilarity.h
+++ b/src/algorithms/highlevel/coversongsimilarity.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *
@@ -33,7 +33,7 @@ namespace standard {
    Real disExtension;
   public:
    CoverSongSimilarity() {
-     declareInput(_inputArray, "inputArray", " a 2D binary cross-similarity matrix of two audio chroma vectors (query vs reference song) (refer 'ChromaCrossSimilarity' algorithm').");
+     declareInput(_inputArray, "inputArray", " a 2D binary cross-similarity matrix between two audio chroma vectors (query vs reference song) (refer 'ChromaCrossSimilarity' algorithm').");
      declareOutput(_scoreMatrix, "scoreMatrix", "a 2D smith-waterman alignment score matrix from the input binary cross-similarity matrix");
      declareOutput(_distance, "distance", "cover song similarity distance between the query and reference song from the input similarity matrix. Either 'asymmetric' (as described in [2]) or 'symmetric' (maximum score in the alignment score matrix).");
    }

--- a/src/algorithms/highlevel/crosssimilaritymatrix.cpp
+++ b/src/algorithms/highlevel/crosssimilaritymatrix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *
@@ -33,7 +33,7 @@ const char* CrossSimilarityMatrix::description = DOC("This algorithm computes a 
 "The default parameters for binarizing are optimized according to [1] for cover song identification using chroma features. \n\n"
 "The input feature arrays are vectors of frames of features in the shape (n_frames, n_features), where 'n_frames' is the number frames, 'n_features' is the number of frame features.\n\n"
 "An exception is also thrown if either one of the input feature arrays are empty or if the output similarity matrix is empty.\n\n"
-"References:\n"
+"References:\n\n"
 "[1] Serra, J., Serra, X., & Andrzejak, R. G. (2009). Cross recurrence quantification for cover song identification. New Journal of Physics.\n\n");
 
 

--- a/src/algorithms/highlevel/crosssimilaritymatrix.h
+++ b/src/algorithms/highlevel/crosssimilaritymatrix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *

--- a/src/examples/standard_chromacrosssimilarity.cpp
+++ b/src/examples/standard_chromacrosssimilarity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *

--- a/src/examples/standard_coversongsimilarity.cpp
+++ b/src/examples/standard_coversongsimilarity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *

--- a/src/examples/standard_crosssimilaritymatrix.cpp
+++ b/src/examples/standard_crosssimilaritymatrix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *

--- a/src/examples/streaming_chromacrosssimilarity.cpp
+++ b/src/examples/streaming_chromacrosssimilarity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *

--- a/src/examples/streaming_coversongsimilarity.cpp
+++ b/src/examples/streaming_coversongsimilarity.cpp
@@ -105,7 +105,8 @@ int main(int argc, char* argv[]) {
   Algorithm* alignment = factory.create("CoverSongSimilarity",
                                   "disExtension", disExtension,
                                   "disOnset", disOnset,
-                                  "distanceType", "asymmetric");
+                                  "distanceType", "asymmetric",
+                                  "pipeDistance", true);
 
   /////////// CONNECTING THE ALGORITHMS ////////////////
   cout << "-------- connecting algos ---------" << endl;

--- a/src/examples/streaming_coversongsimilarity.cpp
+++ b/src/examples/streaming_coversongsimilarity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+ * Copyright (C) 2006-2020 Music Technology Group - Universitat Pompeu Fabra
  *
  * This file is part of Essentia
  *

--- a/test/src/unittests/highlevel/test_chromacrosssimilarity.py
+++ b/test/src/unittests/highlevel/test_chromacrosssimilarity.py
@@ -37,7 +37,7 @@ class TestChromaCrossSimilarity(TestCase):
     expected_crp_simmatrix = array([[0., 0., 1.],
                                     [0., 0., 0.]])
 
-    # expected bianry similarity matrix using oti-based similarity method using the python implementation from https://github.com/albincorreya/ChromaCoverId
+    # expected binary similarity matrix using oti-based similarity method using the python implementation from https://github.com/albincorreya/ChromaCoverId
     expected_oti_simmatrix = array([[1., 0., 0.], 
                                     [1., 0., 0.]])
 


### PR DESCRIPTION
This PR address the following changes.

-  Fix typos and formatting in the music similarity category algorithms to improve the documentation.
- Fixed a bug in the streaming mode [`CoverSongSimilarity`](https://essentia.upf.edu/reference/streaming_CoverSongSimilarity.html) algorithm while computing the sub-sequence alignment and updated the examples and unit tests.
- Updated copyright year range in these files.