### PR TITLE
Fix cross compilation for Android

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -125,11 +125,11 @@ Build Essentia with static examples:
 Cross-compiling for Android
 ---------------------------
 
-A lightweight version of Essentia can be compiled using the ```--cross-compile-android``` flag. It requires reducing the dependencies to a bare minimum using KissFFT library for FFT. Specify the installation prefix with ```--prefix``` flag. Update the ```PATH``` variable to point to where you have your Android Standalone Toolchain.
+A lightweight version of Essentia can be compiled using the ```--cross-compile-android``` flag. You also need to pass a valid ```--android-target``` ABI. Possible values are ```aarch64```, ```armv7a```, ```i686```, ```x86_64```. It requires reducing the dependencies to a bare minimum using KissFFT library for FFT. Specify the installation prefix with ```--prefix``` flag. Update the ```PATH``` variable to point to where you have your Android NDK installed.
 
 ```
-export PATH=~/Dev/android/toolchain/bin:$PATH;
-./waf configure --cross-compile-android --lightweight= --fft=KISS --prefix=/Users/carthach/Dev/android/modules/essentia
+export PATH=$NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin:$PATH
+./waf configure --cross-compile-android --android-target=armv7a --lightweight= --fft=KISS --ignore-algos=LPC --prefix=/Users/carthach/Dev/android/modules/essentia
 ./waf
 ./waf install
 ```

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-export PATH=~/Dev/android/toolchain/bin:$PATH;
+export PATH=$NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin:$PATH;
 ./waf clean;
-./waf configure --cross-compile-android --lightweight= --fft=KISS --ignore-algos=LPC --prefix=/Users/carthach/Dev/android/modules/essentia;
+./waf configure --cross-compile-android --android-target=armv7a --lightweight= --fft=KISS --ignore-algos=LPC --prefix=/Users/carthach/Dev/android/modules/essentia;
 ./waf;
 ./waf install;

--- a/wscript
+++ b/wscript
@@ -54,6 +54,10 @@ def options(ctx):
                    dest='ARCH', default="x64",
                    help='Target architecture when compiling on OSX: i386, x64 or FAT')
 
+    ctx.add_option('--android-target', action='store',
+                   dest='ANDROID_TARGET', default='arm',
+                   help='Target ABI when cross compiling for Android: aarch64, armv7a, i686, x86_64')
+
     ctx.add_option('--no-msse', action='store_true',
                    dest='NO_MSSE', default=False,
                    help='never add compiler flags for msse')
@@ -235,14 +239,21 @@ def configure(ctx):
         """
 
     if ctx.options.CROSS_COMPILE_ANDROID:
-        print ("→ Cross-compiling for Android ARM")
-        # GCC is depricated for Android NDK
-        # Use clang with libc++
-        #ctx.find_program('arm-linux-androideabi-gcc', var='CC')
-        #ctx.find_program('arm-linux-androideabi-g++', var='CXX')
-        #ctx.find_program('arm-linux-androideabi-ar', var='AR')
-        ctx.find_program('clang', var='CC')
-        ctx.find_program('clang++', var='CXX')
+        print ("→ Cross-compiling for Android")
+        if ctx.options.ANDROID_TARGET == 'aarch64':
+            ctx.find_program('aarch64-linux-android21-clang', var='CC')
+            ctx.find_program('aarch64-linux-android21-clang++', var='CXX')
+        elif ctx.options.ANDROID_TARGET == 'armv7a':
+            ctx.find_program('armv7a-linux-androideabi21-clang', var='CC')
+            ctx.find_program('armv7a-linux-androideabi21-clang++', var='CXX')
+        elif ctx.options.ANDROID_TARGET == 'i686':
+            ctx.find_program('i686-linux-android21-clang', var='CC')
+            ctx.find_program('i686-linux-android21-clang++', var='CXX')
+        elif ctx.options.ANDROID_TARGET == 'x86_64':
+            ctx.find_program('x86_64-linux-android21-clang', var='CC')
+            ctx.find_program('x86_64-linux-android21-clang++', var='CXX')
+        else:
+            raise ValueError('--android-target not set or set to an incorrect option')
         ctx.env.CXXFLAGS += ['-std=c++11']
         ctx.env.LINKFLAGS += ['-Wl,-soname,libessentia.so', '-latomic']
 


### PR DESCRIPTION
Currently, essentia builds invalid binaries while cross compiling for Android. This is because the generic clang compiler is used instead of the one available in Android NDK toolchain. Also, either an ABI specific clang compiler provided in the toolchain should be used or the -target flag must be passed to the android specific clang compiler. These changes have been made in accordance with the [official NDK documentation](https://developer.android.com/ndk/guides/other_build_systems#overview).