### PR TITLE
Waf run_python_tests fixes

### DIFF
--- a/wscript
+++ b/wscript
@@ -339,7 +339,7 @@ def run_python_tests(ctx):
     os.system('cp -r src/python/essentia build/python/')
     os.system('cp build/src/python/_essentia*.so build/python/essentia')
 
-    ret = os.system('PYTHONPATH=build/python %s test/src/unittests/all_tests.py' % sys.executable)
+    ret = os.system('PYTHONPATH=build/python:$PYTHONPATH %s test/src/unittests/all_tests.py' % sys.executable)
     if ret:
         ctx.fatal('failed to run python tests. Check test output')
 

--- a/wscript
+++ b/wscript
@@ -299,7 +299,7 @@ def configure(ctx):
         
         # flags required for linking to static ffmpeg libs
         # -Bsymbolic flag is not available on clang
-        if ctx.env.CXX_NAME is not "clang":
+        if ctx.env.CXX_NAME != "clang":
             ctx.env.LINKFLAGS += ['-Wl,-Bsymbolic']
             ctx.env.LDFLAGS += ['-Wl,-Bsymbolic']
 


### PR DESCRIPTION
A couple of fixes for the `run_python_test` Waf method:

- Replace 'is not' by '!=' for literals, which throws a warning in Python 3.8.

- Don't overwrite PYTHONPATH when running the unit tests, so the user's required packages located in PYTHONPATH directories are correctly loaded.

This solves one of the issues described in  #914