### PR TITLE
Several improvements related to  Eigen Tensors

### DIFF
--- a/src/algorithms/standard/tensornormalize.cpp
+++ b/src/algorithms/standard/tensornormalize.cpp
@@ -61,7 +61,7 @@ void TensorNormalize::compute() {
 
         if (globalStd == 0) {
           E_INFO("TensorNormalize: Received tensor with constant value.");
-          // Set std to 0 so we return a vector of all 0s.
+          // Set std to 1 so we return a vector of all 0s.
           globalStd = 1;
         }
 

--- a/src/algorithms/standard/tensornormalize.cpp
+++ b/src/algorithms/standard/tensornormalize.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#include "tensornormalize.h"
+#include <sstream>
+
+using namespace essentia;
+using namespace standard;
+
+using namespace std;
+
+const char* TensorNormalize::name = "TensorNormalize";
+const char* TensorNormalize::category = "Standard";
+const char* TensorNormalize::description = DOC("This algorithm performs normalization over a tensor.\n"
+"When the axis parameter is set to -1 the input tensor is globally normalized. Any other value means"
+" that the tensor will be normalized along that axis.\n"
+"This algorithm supports Standard and MinMax normalizations.\n"
+"\n"
+"References:\n"
+"  [1] Feature scaling - Wikipedia, the free encyclopedia,\n"
+"  https://en.wikipedia.org/wiki/Feature_scaling");
+
+
+  TensorNormalize::Scaler TensorNormalize::scalerFromString(const std::string& name) const {
+    if (name == "standard") return STANDARD;
+    if (name == "minMax") return MINMAX;
+
+    throw EssentiaException("TensorNormalize: Unknown scaler type: ", name);
+  }
+
+  void TensorNormalize::configure() {
+    _scaler = scalerFromString(parameter("scaler").toString());
+    _axis = parameter("axis").toInt();
+  }
+
+void TensorNormalize::compute() {
+  const Tensor<Real>& input = _input.get();
+  Tensor<Real>& output = _output.get();
+
+  switch (_scaler) {
+
+  case STANDARD:
+    {
+      if (_axis == -1) {
+        Real means = mean(input);
+        Real stds = stddev(input, means);
+
+        output = (input - input.constant(means)) / input.constant(stds);
+
+      } else {
+        Tensor<Real> means = mean(input, _axis);
+        Tensor<Real> stds = stddev(input, means, _axis);
+
+        array<Eigen::Index, TENSORRANK> broadcastShape = input.dimensions();
+        broadcastShape[_axis] = 1;
+
+        output = (input - means.broadcast(broadcastShape)) / stds.broadcast(broadcastShape);
+      }
+
+      break;
+    }
+
+  case MINMAX:
+    {
+      if (_axis == -1) {
+        Real minima = tensorMin(input);
+        Real maxima = tensorMax(input);
+
+        output = (input - minima) / (maxima - minima);
+
+      } else {
+        Tensor<Real> minima = tensorMin(input, _axis);
+        Tensor<Real> maxima = tensorMax(input, _axis);
+
+        array<Eigen::Index, TENSORRANK> broadcastShape = input.dimensions();
+        broadcastShape[_axis] = 1;
+
+        output = (input - minima.broadcast(broadcastShape)) /
+          (maxima - minima).broadcast(broadcastShape);
+      }
+
+      break;
+    }
+
+  default:
+    throw EssentiaException("TensorNormalize: Unknown scaler type.");
+  }
+
+}

--- a/src/algorithms/standard/tensornormalize.cpp
+++ b/src/algorithms/standard/tensornormalize.cpp
@@ -54,9 +54,7 @@ void TensorNormalize::compute() {
   Tensor<Real>& output = _output.get();
 
   switch (_scaler) {
-
-  case STANDARD:
-    {
+    case STANDARD: {
       if (_axis == -1) {
         Real means = mean(input);
         Real stds = stddev(input, means);
@@ -72,12 +70,9 @@ void TensorNormalize::compute() {
 
         output = (input - means.broadcast(broadcastShape)) / stds.broadcast(broadcastShape);
       }
-
       break;
     }
-
-  case MINMAX:
-    {
+    case MINMAX: {
       if (_axis == -1) {
         Real minima = tensorMin(input);
         Real maxima = tensorMax(input);
@@ -94,12 +89,11 @@ void TensorNormalize::compute() {
         output = (input - minima.broadcast(broadcastShape)) /
           (maxima - minima).broadcast(broadcastShape);
       }
-
       break;
     }
-
-  default:
-    throw EssentiaException("TensorNormalize: Unknown scaler type.");
+    default: {
+      throw EssentiaException("TensorNormalize: Unknown scaler type.");
+    }
   }
 
 }

--- a/src/algorithms/standard/tensornormalize.h
+++ b/src/algorithms/standard/tensornormalize.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#ifndef ESSENTIA_TENSORNORMALIZE_H
+#define ESSENTIA_TENSORNORMALIZE_H
+
+#include "algorithm.h"
+#include "essentiamath.h"
+#include <unsupported/Eigen/CXX11/Tensor>
+
+namespace essentia {
+namespace standard {
+
+
+class TensorNormalize : public Algorithm {
+
+ protected:
+  enum Scaler {
+    STANDARD,
+    MINMAX
+  };
+
+  Scaler scalerFromString(const std::string& name) const;
+
+  Input<Tensor<Real> > _input;
+  Output<Tensor<Real> > _output;
+
+  Scaler _scaler;
+  int _axis;
+
+ public:
+  TensorNormalize() {
+    declareInput(_input, "tensor", "the input tensor");
+    declareOutput(_output, "tensor", "the normalized output tensor");
+  }
+
+  void declareParameters() {
+    declareParameter("scaler", "the type of the normalization to apply to input tensor", "{standard,minMax}", "standard");
+    declareParameter("axis", "Normalize along the given axis. -1 to normalize along all the dimensions", "[-1, 4)", 0);
+  }
+
+  void configure();
+  void compute();
+
+  static const char* name;
+  static const char* category;
+  static const char* description;
+
+};
+
+} // namespace standard
+} // namespace essentia
+
+#include "streamingalgorithmwrapper.h"
+
+namespace essentia {
+namespace streaming {
+
+class TensorNormalize : public StreamingAlgorithmWrapper {
+
+ protected:
+  Sink<Tensor<Real> > _input;
+  Source<Tensor<Real> > _output;
+
+ public:
+  TensorNormalize() {
+    declareAlgorithm("TensorNormalize");
+    declareInput(_input, TOKEN, "tensor");
+    declareOutput(_output, TOKEN, "tensor");
+  }
+};
+
+} // namespace streaming
+} // namespace essentia
+
+#endif // ESSENTIA_TENSORNORMALIZE_H

--- a/src/algorithms/standard/tensortranspose.cpp
+++ b/src/algorithms/standard/tensortranspose.cpp
@@ -45,6 +45,13 @@ const char* TensorTranspose::description = DOC("This algorithm performs transpos
     int maximum = *max_element(_permutation.begin(), _permutation.end());
     if (maximum > TENSORRANK -1) throw EssentiaException("TensorTranspose: one of the elements of the permutation vector was set to ",
                                                           maximum, ", while the maximum value has to be ", TENSORRANK -1);
+
+    for (int i = 0; i < TENSORRANK; i++) {
+      if (!count(_permutation.begin(), _permutation.end(), i)) {
+        throw EssentiaException("TensorTranspose: Index (", i, ") not found in `permutaiton`.");
+      }
+    }
+    
   }
 
 void TensorTranspose::compute() {

--- a/src/algorithms/standard/tensortranspose.cpp
+++ b/src/algorithms/standard/tensortranspose.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#include "tensortranspose.h"
+#include <sstream>
+
+using namespace essentia;
+using namespace standard;
+
+using namespace std;
+
+const char* TensorTranspose::name = "TensorTranspose";
+const char* TensorTranspose::category = "Standard";
+const char* TensorTranspose::description = DOC("This algorithm performs transpositions over the axes of a tensor.\n");
+
+  void TensorTranspose::configure() {
+    if (!parameter("permutation").isConfigured()) return;
+    _permutation = parameter("permutation").toVectorInt();
+
+    if (_permutation.size() != TENSORRANK) {
+      throw EssentiaException("TensorTranspose: the size of the permutation vector is ",
+                              _permutation.size(), " while it should be ", TENSORRANK );
+    }
+
+    int minimun = *min_element(_permutation.begin(), _permutation.end());
+    if (minimun < 0) throw EssentiaException("TensorTranspose: one of the elements of the permutation vector was set to ",
+                                             minimun, ", while the minimum value has to be be 0");
+
+    int maximum = *max_element(_permutation.begin(), _permutation.end());
+    if (maximum > TENSORRANK -1) throw EssentiaException("TensorTranspose: one of the elements of the permutation vector was set to ",
+                                                          maximum, ", while the maximum value has to be ", TENSORRANK -1);
+  }
+
+void TensorTranspose::compute() {
+  const Tensor<Real>& input = _input.get();
+  Tensor<Real>& output = _output.get();
+
+  output = input.shuffle(_permutation);
+}

--- a/src/algorithms/standard/tensortranspose.h
+++ b/src/algorithms/standard/tensortranspose.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#ifndef ESSENTIA_TENSORTRANSPOSE_H
+#define ESSENTIA_TENSORTRANSPOSE_H
+
+#include "algorithm.h"
+
+namespace essentia {
+namespace standard {
+
+
+class TensorTranspose : public Algorithm {
+
+ protected:
+  Input<Tensor<Real> > _input;
+  Output<Tensor<Real> > _output;
+
+  std::vector<int> _permutation;
+
+ public:
+  TensorTranspose() {
+    declareInput(_input, "tensor", "the input tensor");
+    declareOutput(_output, "tensor", "the transposed output tensor");
+  }
+
+  void declareParameters() {
+    declareParameter("permutation", "permutation of [0,1,2,3]. The i'th dimension of the returned tensor will correspond to the dimension numbered permutation[i] of the input.", "", Parameter::VECTOR_INT);
+  }
+
+  void configure();
+  void compute();
+
+  static const char* name;
+  static const char* category;
+  static const char* description;
+
+};
+
+} // namespace standard
+} // namespace essentia
+
+#include "streamingalgorithmwrapper.h"
+
+namespace essentia {
+namespace streaming {
+
+class TensorTranspose : public StreamingAlgorithmWrapper {
+
+ protected:
+  Sink<Tensor<Real> > _input;
+  Source<Tensor<Real> > _output;
+
+ public:
+  TensorTranspose() {
+    declareAlgorithm("TensorTranspose");
+    declareInput(_input, TOKEN, "tensor");
+    declareOutput(_output, TOKEN, "tensor");
+  }
+};
+
+} // namespace streaming
+} // namespace essentia
+
+#endif // ESSENTIA_TENSORTRANSPOSE_H

--- a/src/algorithms/standard/vectorrealtotensor.cpp
+++ b/src/algorithms/standard/vectorrealtotensor.cpp
@@ -216,8 +216,8 @@ AlgorithmStatus VectorRealToTensor::process() {
     Tensor<Real>& tensor = *(Tensor<Real> *)_tensor.getFirstToken();
 
     // Explicit convertion of std:vector to std::array<Eigen::Index> for Clang.
-    std::array<Eigen::Index, 4> shapeEigenIndex;
-    std::copy_n(shape.begin(), 4, shapeEigenIndex.begin());
+    std::array<Eigen::Index, TENSORRANK> shapeEigenIndex;
+    std::copy_n(shape.begin(), TENSORRANK, shapeEigenIndex.begin());
 
     tensor.resize(shapeEigenIndex);
 

--- a/src/algorithms/standard/vectorrealtotensor.cpp
+++ b/src/algorithms/standard/vectorrealtotensor.cpp
@@ -221,7 +221,6 @@ AlgorithmStatus VectorRealToTensor::process() {
 
     tensor.resize(shapeEigenIndex);
 
-    // TODO: Add flag to swap frequency axis from 4 to 2.
     for (int i = 0; i < shape[0]; i++) {      // Batch axis
       for (int j = 0; j < shape[2]; j++) {    // Time axis
         for (int k = 0; k < shape[3]; k++) {  // Freq axis

--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -1200,6 +1200,142 @@ std::vector<std::vector<T> > pairwiseDistance(const std::vector<std::vector<T> >
   return pdist;
 }
 
+/**
+ * Sets `squeezeShape`, `summerizerShape`, `broadcastShape` to perform operations 
+ * on a Tensor with the shape of `tesor` along the `axis` dimension.
+ */
+template <typename T>
+void tensorGeometricalInfo(const Tensor<T>& tensor, int& axis,
+                           std::array<Eigen::Index, TENSORRANK - 1>& squeezeShape,
+                           std::array<Eigen::Index, TENSORRANK>& summerizerShape,
+                           std::array<Eigen::Index, TENSORRANK>& broadcastShape) {
+  // To perform tensor operations along an specific axis we need to get
+  // some geometrical information before:
+
+  // First, an array with dimensions to squeeze (all but the axis).
+  int i = 0;
+  for (int j = 0; j < TENSORRANK; j++) {
+    if (j != axis) {
+      squeezeShape[i] = j;
+      i++;
+    }
+  }
+
+  // An array with all singleton dimension but the axis of interest.
+  summerizerShape = {1, 1, 1, 1};
+  summerizerShape[axis] = tensor.dimension(axis);
+
+  // An array with the number of times we need to copy the accumulator
+  // tensors per dimension in order to match the input tensor shape.
+  broadcastShape = tensor.dimensions();
+  broadcastShape[axis] = 1;
+}
+
+/**
+ * Returns the mean of a tensor.
+ */
+template <typename T>
+T mean(const Tensor<T>& tensor) {
+  return (T)((TensorScalar)tensor.mean())(0);
+}
+
+/**
+ * Returns the mean of a tensor along the given axis.
+ */
+template <typename T>
+Tensor<T> mean(const Tensor<T>& tensor, int axis) {
+  std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
+  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+  Tensor1D means = tensor.mean(squeezeShape);
+
+  return TensorMap<Real>(means.data(), summerizerShape);
+}
+
+/**
+ * Returns the standard deviation of a tensor.
+ */
+template <typename T>
+T stddev(const Tensor<T>& tensor, const T mean) {
+  // Substract the mean.
+  Tensor<Real> tmp = tensor - tensor.constant(mean);
+  // Sum of squares.
+  Real sos = ((TensorScalar)tmp.pow(2).sum())(0);
+
+  return sqrt(sos / tensor.size());
+}
+
+/**
+ * Returns the standard deviation of a tensor along the given axis.
+ */
+template <typename T>
+Tensor<T> stddev(const Tensor<T>& tensor, const Tensor<T> mean, int axis) {
+  std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
+  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+
+  // Get the number of elements on each sub-tensor.
+  Real normalization = tensor.size() / tensor.dimension(axis);
+
+  // Substract the means along the axis using broadcast to replicate
+  // them along the rest of dimensions.
+  Tensor<Real> tmp = tensor - mean.broadcast(broadcastShape);
+
+  // Cumpute the sum of squares.
+  Tensor1D sos = tmp.pow(2).sum(squeezeShape);
+
+  // Compute the standard deviations and put them into a Tensor along the axis.
+  Tensor1D stds = (sos / normalization).sqrt();
+
+  return TensorMap<Real>(stds.data(), summerizerShape);
+}
+
+/**
+ * Returns the minimum of a tensor.
+ */
+template <typename T>
+T tensorMin(const Tensor<T>& tensor) {
+  return (T)((TensorScalar)tensor.minimum())(0);
+}
+
+/**
+ * Returns the minimum of a tensor along the given axis.
+ */
+template <typename T>
+Tensor<T> tensorMin(const Tensor<T>& tensor, int axis) {
+  std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
+  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+  Tensor1D minima = tensor.minimum(squeezeShape);
+
+  return TensorMap<Real>(minima.data(), summerizerShape);
+}
+
+/**
+ * Returns the maximum of a tensor.
+ */
+template <typename T>
+T tensorMax(const Tensor<T>& tensor) {
+  return (T)((TensorScalar)tensor.maximum())(0);
+}
+
+/**
+ * Returns the maximum of a tensor along the given axis.
+ */
+template <typename T>
+Tensor<T> tensorMax(const Tensor<T>& tensor, int axis) {
+  std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
+  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+  Tensor1D maxima = tensor.maximum(squeezeShape);
+
+  return TensorMap<Real>(maxima.data(), summerizerShape);
+}
+
 } // namespace essentia
 
 #endif // ESSENTIA_MATH_H

--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -1201,13 +1201,13 @@ std::vector<std::vector<T> > pairwiseDistance(const std::vector<std::vector<T> >
 }
 
 /**
- * Sets `squeezeShape`, `summerizerShape`, `broadcastShape` to perform operations 
- * on a Tensor with the shape of `tesor` along the `axis` dimension.
+ * Sets `squeezeShape`, `summarizerShape`, `broadcastShape` to perform operations 
+ * on a Tensor with the shape of `tensor` along the `axis` dimension.
  */
 template <typename T>
 void tensorGeometricalInfo(const Tensor<T>& tensor, int& axis,
                            std::array<Eigen::Index, TENSORRANK - 1>& squeezeShape,
-                           std::array<Eigen::Index, TENSORRANK>& summerizerShape,
+                           std::array<Eigen::Index, TENSORRANK>& summarizerShape,
                            std::array<Eigen::Index, TENSORRANK>& broadcastShape) {
   // To perform tensor operations along an specific axis we need to get
   // some geometrical information before:
@@ -1222,8 +1222,8 @@ void tensorGeometricalInfo(const Tensor<T>& tensor, int& axis,
   }
 
   // An array with all singleton dimension but the axis of interest.
-  summerizerShape = {1, 1, 1, 1};
-  summerizerShape[axis] = tensor.dimension(axis);
+  summarizerShape = {1, 1, 1, 1};
+  summarizerShape[axis] = tensor.dimension(axis);
 
   // An array with the number of times we need to copy the accumulator
   // tensors per dimension in order to match the input tensor shape.
@@ -1245,12 +1245,12 @@ T mean(const Tensor<T>& tensor) {
 template <typename T>
 Tensor<T> mean(const Tensor<T>& tensor, int axis) {
   std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
-  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+  std::array<Eigen::Index, TENSORRANK> summarizerShape, broadcastShape;
 
-  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summarizerShape, broadcastShape);
   Tensor1D means = tensor.mean(squeezeShape);
 
-  return TensorMap<Real>(means.data(), summerizerShape);
+  return TensorMap<Real>(means.data(), summarizerShape);
 }
 
 /**
@@ -1272,9 +1272,9 @@ T stddev(const Tensor<T>& tensor, const T mean) {
 template <typename T>
 Tensor<T> stddev(const Tensor<T>& tensor, const Tensor<T> mean, int axis) {
   std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
-  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+  std::array<Eigen::Index, TENSORRANK> summarizerShape, broadcastShape;
 
-  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summarizerShape, broadcastShape);
 
   // Get the number of elements on each sub-tensor.
   Real normalization = tensor.size() / tensor.dimension(axis);
@@ -1289,7 +1289,7 @@ Tensor<T> stddev(const Tensor<T>& tensor, const Tensor<T> mean, int axis) {
   // Compute the standard deviations and put them into a Tensor along the axis.
   Tensor1D stds = (sos / normalization).sqrt();
 
-  return TensorMap<Real>(stds.data(), summerizerShape);
+  return TensorMap<Real>(stds.data(), summarizerShape);
 }
 
 /**
@@ -1306,12 +1306,12 @@ T tensorMin(const Tensor<T>& tensor) {
 template <typename T>
 Tensor<T> tensorMin(const Tensor<T>& tensor, int axis) {
   std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
-  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+  std::array<Eigen::Index, TENSORRANK> summarizerShape, broadcastShape;
 
-  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summarizerShape, broadcastShape);
   Tensor1D minima = tensor.minimum(squeezeShape);
 
-  return TensorMap<Real>(minima.data(), summerizerShape);
+  return TensorMap<Real>(minima.data(), summarizerShape);
 }
 
 /**
@@ -1328,12 +1328,12 @@ T tensorMax(const Tensor<T>& tensor) {
 template <typename T>
 Tensor<T> tensorMax(const Tensor<T>& tensor, int axis) {
   std::array<Eigen::Index, TENSORRANK - 1> squeezeShape;
-  std::array<Eigen::Index, TENSORRANK> summerizerShape, broadcastShape;
+  std::array<Eigen::Index, TENSORRANK> summarizerShape, broadcastShape;
 
-  tensorGeometricalInfo(tensor, axis, squeezeShape, summerizerShape, broadcastShape);
+  tensorGeometricalInfo(tensor, axis, squeezeShape, summarizerShape, broadcastShape);
   Tensor1D maxima = tensor.maximum(squeezeShape);
 
-  return TensorMap<Real>(maxima.data(), summerizerShape);
+  return TensorMap<Real>(maxima.data(), summarizerShape);
 }
 
 } // namespace essentia

--- a/src/essentia/types.h
+++ b/src/essentia/types.h
@@ -389,6 +389,26 @@ using Tensor = Eigen::Tensor<T, TENSORRANK, Eigen::RowMajor>;
 template<typename T>
 using TensorMap = Eigen::TensorMap<Tensor<T>, 0>;
 
+/**
+ * Alias for a 0-dimensional Eigen::Tensor.
+ */
+using TensorScalar = Eigen::Tensor<Real, 0, Eigen::RowMajor>;
+
+/**
+ * Alias for a 1-dimensional Eigen::Tensor.
+ */
+using Tensor1D = Eigen::Tensor<Real, 1, Eigen::RowMajor>;
+
+/**
+ * Alias for a 2-dimensional Eigen::Tensor.
+ */
+using Tensor2D = Eigen::Tensor<Real, 2, Eigen::RowMajor>;
+
+/**
+ * Alias for a 3-dimensional Eigen::Tensor.
+ */
+using Tensor3D = Eigen::Tensor<Real, 3, Eigen::RowMajor>;
+
 
 namespace streaming {
 

--- a/src/essentia/types.h
+++ b/src/essentia/types.h
@@ -370,6 +370,10 @@ class Tuple2 {
  */
 typedef Tuple2<Real> StereoSample;
 
+/**
+ * Macro used to define the rank (number of dimensions) of Essentia::Tensor.
+ */
+#define TENSORRANK 4
 
 /**
  * Alias for Eigen::Tensor.
@@ -377,7 +381,7 @@ typedef Tuple2<Real> StereoSample;
  * https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/tensor_types.h
  */
 template<typename T>
-using Tensor = Eigen::Tensor<T, 4, Eigen::RowMajor>;
+using Tensor = Eigen::Tensor<T, TENSORRANK, Eigen::RowMajor>;
 
 /**
  * Alias for Eigen::TensorMap.

--- a/src/python/parsing.cpp
+++ b/src/python/parsing.cpp
@@ -157,7 +157,7 @@ PyObject* toPython(void* obj, Edt tp) {
     case VECTOR_VECTOR_COMPLEX: return VectorVectorComplex::toPythonCopy((vector<vector<complex<Real> > >*)obj);
     case VECTOR_VECTOR_STRING: return VectorVectorString::toPythonCopy((vector<vector<string> >*)obj);
     case VECTOR_VECTOR_STEREOSAMPLE: return VectorVectorStereoSample::toPythonCopy((vector<vector<StereoSample> >*)obj);
-    case TENSOR_REAL: return TensorReal::toPythonRef((Tensor<Real>*)obj);
+    case TENSOR_REAL: return TensorReal::toPythonCopy((Tensor<Real>*)obj);
     case VECTOR_TENSOR_REAL: return VectorTensorReal::toPythonCopy((vector<Tensor<Real> >*)obj);
     case MATRIX_REAL: return MatrixReal::toPythonRef((TNT::Array2D<Real>*)obj);
     case VECTOR_MATRIX_REAL: return VectorMatrixReal::toPythonCopy((vector<TNT::Array2D<Real> >*)obj);

--- a/src/python/pytypes/pypool.cpp
+++ b/src/python/pytypes/pypool.cpp
@@ -530,10 +530,7 @@ PyObject* PyPool::value(PyPool* self, PyObject* pyArgs) {
       case VECTOR_VECTOR_STRING: return VectorVectorString::toPythonCopy(&p.value<vector<vector<string> > >(key));
       case VECTOR_MATRIX_REAL: return VectorMatrixReal::toPythonCopy(&p.value<vector<TNT::Array2D<Real> > >(key));
       case VECTOR_TENSOR_REAL: return VectorTensorReal::toPythonCopy(&p.value<vector<Tensor<Real> > >(key));
-      case TENSOR_REAL: {
-        Tensor<Real>* t = new Tensor<Real>(p.value<Tensor<Real> >(key));
-        return TensorReal::toPythonRef(t);
-      }
+      case TENSOR_REAL:  return TensorReal::toPythonCopy(&p.value<Tensor<Real> >(key));
       default:
         ostringstream msg;
         msg << "Pool.value does not support the type: " << edtToString(tp);

--- a/src/python/pytypes/tensorreal.cpp
+++ b/src/python/pytypes/tensorreal.cpp
@@ -55,7 +55,7 @@ void* TensorReal::fromPythonCopy(PyObject* obj) {
   if (!PyArray_Check(obj)) {
     throw EssentiaException("TensorReal::fromPythonRef: expected PyArray, received: ", strtype(obj));
   }
-  if (PyArray_NDIM(obj) != 4) {
+  if (PyArray_NDIM(obj) != TENSORRANK) {
     throw EssentiaException("TensorReal::fromPythonCopy: argument is not a 4-dimensional PyArray");
   }
 

--- a/src/python/pytypes/tensorreal.cpp
+++ b/src/python/pytypes/tensorreal.cpp
@@ -26,7 +26,7 @@ using namespace essentia;
 DEFINE_PYTHON_TYPE(TensorReal);
 
 
-PyObject* TensorReal::toPythonRef(essentia::Tensor<essentia::Real>* tensor) {
+PyObject* TensorReal::toPythonCopy(const essentia::Tensor<essentia::Real>* tensor) {
   PyObject* result;
 
   int nd = tensor->rank();
@@ -35,7 +35,11 @@ PyObject* TensorReal::toPythonRef(essentia::Tensor<essentia::Real>* tensor) {
   for (int i = 0; i < nd; i++)
     dims[i] = tensor->dimension(i);
 
-  result = PyArray_SimpleNewFromData(nd, dims, PyArray_FLOAT, tensor->data());
+  result = PyArray_SimpleNew(nd, dims, PyArray_FLOAT);
+
+  Real* dest = (Real*)(((PyArrayObject*)result)->data);
+  const Real* src = tensor->data();
+  fastcopy(dest, src, tensor->size());
 
   assert(result->strides[3] == sizeof(Real));
 
@@ -43,7 +47,6 @@ PyObject* TensorReal::toPythonRef(essentia::Tensor<essentia::Real>* tensor) {
     throw EssentiaException("TensorReal: dang null object");
   }
 
-  PyArray_BASE(result) = TO_PYTHON_PROXY(TensorReal, tensor);
   return result;
 }
 

--- a/src/wscript
+++ b/src/wscript
@@ -146,6 +146,10 @@ def configure(ctx):
     ctx.check_cfg(package=lib_map['EIGEN3'], uselib_store='EIGEN3',
                   args=['eigen3 >= 3.3.4'] + check_cfg_args)
 
+    # Disable Eigen warnings related to meaningless type qualifiers
+    # https://gitlab.com/libeigen/eigen/-/issues/115
+    ctx.env.DEFINES += ['EIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS']
+
     if 'libav' in ctx.env.CHECK_LIBS:
         ctx.check_cfg(package=lib_map['AVCODEC'], uselib_store='AVCODEC',
                       args=['{} >= 55.34.1'.format(lib_map['AVCODEC'])] + check_cfg_args,

--- a/test/src/unittests/standard/test_tensornormalize.py
+++ b/test/src/unittests/standard/test_tensornormalize.py
@@ -44,7 +44,7 @@ class TestTensorNormalize(TestCase):
 
         original = numpy.arange(3, dtype='float32')
 
-        expected =scaler.fit_transform(original.reshape(-1, 1))
+        expected = scaler.fit_transform(original.reshape(-1, 1))
 
         original = numpy.expand_dims(original, axis=[0, 1, 2])
         result = TensorNormalize(scaler=scaler_name, axis=-1)(original)

--- a/test/src/unittests/standard/test_tensornormalize.py
+++ b/test/src/unittests/standard/test_tensornormalize.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Affero GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+
+from essentia_test import *
+from sklearn.preprocessing import MinMaxScaler, StandardScaler
+
+
+class TestTensorNormalize(TestCase):
+
+    def scalerSingleValue(self, scaler_arg=('standard', StandardScaler())):
+        scaler_name, scaler = scaler_arg
+
+        original = numpy.arange(1, dtype='float32')
+
+        # Use Scipy to generate the expected results
+        expected =scaler.fit_transform(original.reshape(-1, 1))
+
+        # Add singleton dimensions to trainsform the input vector into a tensor
+        original = numpy.expand_dims(original, axis=[0, 1, 2])
+        result = TensorNormalize(scaler=scaler_name, axis=-1)(original)
+
+        self.assertAlmostEqualVector(result.flatten(), expected.flatten(), 1e-6)
+
+    def scalerOverall(self, scaler_arg=('standard', StandardScaler())):
+        scaler_name, scaler = scaler_arg
+
+        original = numpy.arange(3, dtype='float32')
+
+        expected =scaler.fit_transform(original.reshape(-1, 1))
+
+        original = numpy.expand_dims(original, axis=[0, 1, 2])
+        result = TensorNormalize(scaler=scaler_name, axis=-1)(original)
+
+        self.assertAlmostEqualVector(result.flatten(), expected.flatten(), 1e-6)
+
+    def scalerAlongAxis(self, axis=0, scaler_arg=('standard', StandardScaler())):
+        scaler_name, scaler = scaler_arg
+
+        dims, length = 4, 2
+        original = numpy.arange(length ** dims, dtype='float32').reshape([length] * dims)
+
+        expected = numpy.empty(original.shape)
+
+        for i in range(original.shape[0]):
+            # Swap the axes before and after so we can test all the dimensions
+            # using the same operator ([i, :, :, :]).
+            original = numpy.swapaxes(original, 0, axis)
+            expected = numpy.swapaxes(expected, 0, axis)
+            tmp = scaler.fit_transform(original[i, :, :, :].reshape(-1, 1))
+            expected[i, :, :, :] = tmp.reshape([1] + [length] * (dims - 1))
+            original = numpy.swapaxes(original, 0, axis)
+            expected = numpy.swapaxes(expected, 0, axis)
+
+        result = TensorNormalize(scaler=scaler_name, axis=axis)(original)
+        self.assertAlmostEqualVector(result.flatten(), expected.flatten(), 1e-6)
+
+    def testStandardScalerOverall(self):
+        self.scalerOverall(scaler_arg=('standard', StandardScaler()))
+
+    def testMinMaxScalerOverall(self):
+        self.scalerOverall(scaler_arg=('minMax', MinMaxScaler()))
+
+    def testStandardScalerAlongAxis(self):
+        for i in range(4):
+            self.scalerAlongAxis(axis=i, scaler_arg=('standard', StandardScaler()))
+
+    def testMinMaxScalerAlongAxis(self):
+        for i in range(4):
+            self.scalerAlongAxis(axis=i, scaler_arg=('minMax', MinMaxScaler()))
+
+    def testInvalidParam(self):
+        self.assertConfigureFails(TensorNormalize(), { 'axis': -2 })
+        self.assertConfigureFails(TensorNormalize(), { 'axis': 5 })
+        self.assertConfigureFails(TensorNormalize(), { 'scaler': 'MAXMIN' })
+
+
+suite = allTests(TestTensorNormalize)
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=2).run(suite)

--- a/test/src/unittests/standard/test_tensortranspose.py
+++ b/test/src/unittests/standard/test_tensortranspose.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Affero GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+
+from essentia_test import *
+import itertools
+
+DIMS = 4  # Essentia only supports 4-dimensional Tensors.
+
+class TestTensorTranspose(TestCase):
+
+    def assertPermutations(self, original):
+        # Iterate over all posible permutations
+        indices = range(DIMS)
+        for permutation in itertools.permutations(indices):
+            expected = numpy.transpose(original, permutation)
+            result = TensorTranspose(permutation=list(permutation))(original)
+
+            self.assertEqualVector(result.shape, expected.shape)
+            self.assertEqualVector(result.flatten(), expected.flatten())
+
+    def testTranspose(self):
+        length = 2
+        original = numpy.arange(length ** DIMS, dtype='float32').reshape([length] * DIMS)
+        self.assertPermutations(original)
+
+    def testEmptyTensor(self):
+        original = numpy.array([[[[]]]], dtype='float32')
+        self.assertPermutations(original)
+
+    def testUnitaryTensor(self):
+        original = numpy.array([[[[1]]]], dtype='float32')
+        self.assertPermutations(original)
+    
+    def testInvalidParam(self):
+        self.assertConfigureFails(TensorTranspose(), { 'permutation': [0, -1, 2, 3] })
+        self.assertConfigureFails(TensorTranspose(), { 'permutation': [0, 1, 2, 5] })
+        self.assertConfigureFails(TensorTranspose(), { 'permutation': [0, 1, 2] })
+
+
+
+suite = allTests(TestTensorTranspose)
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=2).run(suite)

--- a/test/src/unittests/standard/test_tensortranspose.py
+++ b/test/src/unittests/standard/test_tensortranspose.py
@@ -53,6 +53,7 @@ class TestTensorTranspose(TestCase):
         self.assertConfigureFails(TensorTranspose(), { 'permutation': [0, -1, 2, 3] })
         self.assertConfigureFails(TensorTranspose(), { 'permutation': [0, 1, 2, 5] })
         self.assertConfigureFails(TensorTranspose(), { 'permutation': [0, 1, 2] })
+        self.assertConfigureFails(TensorTranspose(), { 'permutation': [0, 1, 2, 2] })
 
 
 


### PR DESCRIPTION
This PR contains several improvements related to  Eigen Tensors:

- TensorReal toPythonRef -> toPythonCopy to fix #1013 
- Add convenience aliases for tensors of different ranks
- Disable build-time Eigen-related warnings
- Add basic statistic operations with tensors (mean, std, min, max)
- Add new Algorithms `TensorTranspose` & `TensorNormalize`