### PR TITLE
PercivalBpmEstimator: push float literal instead of double

### DIFF
--- a/src/algorithms/rhythm/percivalbpmestimator.cpp
+++ b/src/algorithms/rhythm/percivalbpmestimator.cpp
@@ -213,7 +213,7 @@ AlgorithmStatus PercivalBpmEstimator::process() {
 
   // If there are no lag estimates, return bpm 0
   if (lags.size() == 0) {
-    _bpm.push(0.0);
+    _bpm.push(0.0f);
     return FINISHED;
   }
 


### PR DESCRIPTION
fix error due to missing conversion from double to Real. gcc 10.2.0
RuntimeError: In PercivalBpmEstimator.compute: While trying to push item into source PercivalBpmEstimator::bpm:
Error when checking types. Expected: Real, received: double