### PR TITLE
Many dependencies required on Ubuntu 18.04

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -1,3 +1,5 @@
 sudo apt install -y libavcodec-dev libeigen3-dev libavformat-dev libavutil-dev libavresample-dev libsamplerate0-dev libyaml-dev libtaglib-cil* libtag1-dev python3-taglib libfftw3-* libchromaprint-*
 # https://github.com/supermihi/pytaglib
+./waf configure --with-example=streaming_extractor_music
+./waf
 pip install pytaglib

--- a/install_dependencies_debian.sh
+++ b/install_dependencies_debian.sh
@@ -1,0 +1,3 @@
+sudo apt install -y libavcodec-dev libeigen3-dev libavformat-dev libavutil-dev libavresample-dev libsamplerate0-dev libyaml-dev libtaglib-cil* libtag1-dev python3-taglib libfftw3-* libchromaprint-*
+# https://github.com/supermihi/pytaglib
+pip install pytaglib


### PR DESCRIPTION
./waf --configure will fail if `build_debian.sh` is not first run