### PR TITLE
Fix highlevel parameter in MusicExtractor, which couldn't be specified

### DIFF
--- a/src/algorithms/extractor/musicextractor.cpp
+++ b/src/algorithms/extractor/musicextractor.cpp
@@ -168,7 +168,8 @@ void MusicExtractor::setExtractorDefaultOptions() {
   options.set("highlevel.compute", false);
 #if HAVE_GAIA2
   if (!svmModels.empty()) {
-    options.add("highlevel.svm_models", svmModels);
+    for (const string &model: svmModels)
+        options.add("highlevel.svm_models", model);
     options.set("highlevel.compute", true);
   }
 #endif


### PR DESCRIPTION
Specifying the highlevel parameter in the MusicExtractor constructor
raised a RuntimeError exception because the value of `highlevel.svm_models`
wasn't being set with the right type.

Since Pool::set doesn't support a vector of strings, this fixes the issue by
adding the paths passed as arguments one by one, so the resulting type
is `vector<string>`. 

Fixes #1051