### PR TITLE
modify script to work on mac as well as linux

### DIFF
--- a/doc/build_sphinx_doc.sh
+++ b/doc/build_sphinx_doc.sh
@@ -22,7 +22,7 @@ doxygen doc/Doxyfile
 
 
 # now build Sphinx doc
-cd doc/sphinxdoc
+cd ./doc/sphinxdoc
 echo "******** GENERATE ALGORITHMS REFERENCE AND TUTORIALS ********"
 
 # force using default python3 if the the argument is not supplied


### PR DESCRIPTION
The command `./waf doc` doesn't work on Mac OS X, as it complains it can't find the directory. Using the `.` fixes that issue. I've tested this on Mac OS X 10.15.4 and on Ubuntu 20.04 and both worked as expected.