### PR TITLE
Fix infinite loop in PitchContoursMultiMelody

### DIFF
--- a/src/algorithms/tonal/pitchcontoursmultimelody.cpp
+++ b/src/algorithms/tonal/pitchcontoursmultimelody.cpp
@@ -142,10 +142,8 @@ void PitchContoursMultiMelody::compute() {
 
   // no contours -> zero pitch vector output
   if (contoursBins.empty()) {
-      vector<Real> zero;
-      zero.push_back(0.0);
       for (int i=0; i<(int)pitch.size(); i++){
-          pitch.push_back(zero);
+          pitch[i].push_back(0.0);
       }
     return;
   }


### PR DESCRIPTION
Fixes #1054; #835 may be related too. There is a loop that keeps adding new elements to `pitches` instead of updating the existing ones, therefore the loop never ends and the vector eventually fills up the memory.