### PR TITLE
Fix PitchContours when no salient frames present

### DIFF
--- a/src/algorithms/tonal/pitchcontours.cpp
+++ b/src/algorithms/tonal/pitchcontours.cpp
@@ -68,14 +68,6 @@ void PitchContours::compute() {
   _numberFrames = peakBins.size();
   duration = _numberFrames * _frameDuration;
 
-  if (!_numberFrames) {
-    // no peaks -> empty pitch contours output
-    contoursBins.clear();
-    contoursSaliences.clear();
-    contoursStartTimes.clear();
-    return;
-  }
-
   for (size_t i=0; i<_numberFrames; i++) {
 
     if (peakBins[i].size() != peakSaliences[i].size()) {
@@ -124,6 +116,14 @@ void PitchContours::compute() {
         salientInFrame.push_back(make_pair(i,j));
       }
     }
+  }
+
+  if (salientInFrame.size() == 0) {
+    // no peaks -> empty pitch contours output
+    contoursBins.clear();
+    contoursSaliences.clear();
+    contoursStartTimes.clear();
+    return;
   }
 
   // gather distribution statistics for overall peak filtering

--- a/test/src/unittests/tonal/test_pitchmelodia.py
+++ b/test/src/unittests/tonal/test_pitchmelodia.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2020  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Affero GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+
+from essentia_test import *
+
+
+class TestPitchMelodia(TestCase):
+
+    def testZero(self):
+        signal = zeros(256)
+        pitch, confidence = PitchMelodia()(signal)
+        self.assertAlmostEqualVector(pitch, [0., 0., 0.])
+        self.assertAlmostEqualVector(confidence, [0., 0., 0.])
+
+
+suite = allTests(TestPitchMelodia)
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Fixing a bug that occurs when there is a non-zero number of frames, but none of them have any peaks (e.g. when the audio signal is all zeros). In this situation, [this check](https://github.com/cifkao/essentia/blob/ba79be6515f2fd0cde75ee3f6fa98706a66f4c36/src/algorithms/tonal/pitchcontours.cpp#L71) is not triggered and an error occurs [here](https://github.com/cifkao/essentia/blob/ba79be6515f2fd0cde75ee3f6fa98706a66f4c36/src/algorithms/tonal/pitchcontours.cpp#L137) (trying to compute the mean of an empty array). The fix is to find the salient bin indices first, and then check if the result is non-empty.

Also adding a test for this.