### PR TITLE
Fixed mem leak in MonoLoader - Disconnect DevNulls

### DIFF
--- a/src/algorithms/io/monoloader.h
+++ b/src/algorithms/io/monoloader.h
@@ -40,6 +40,12 @@ class MonoLoader : public AlgorithmComposite {
   MonoLoader();
 
   ~MonoLoader() {
+    // Disconnect all null connections to delete the corresponding DevNull objects created.
+    disconnect(_audioLoader->output("md5"), NOWHERE);
+    disconnect(_audioLoader->output("bit_rate"), NOWHERE);
+    disconnect(_audioLoader->output("codec"), NOWHERE);
+    disconnect(_audioLoader->output("sampleRate"), NOWHERE);
+    
     delete _audioLoader;
     delete _mixer;
     delete _resample;

--- a/src/essentia/streaming/algorithms/devnull.cpp
+++ b/src/essentia/streaming/algorithms/devnull.cpp
@@ -57,7 +57,7 @@ void disconnect(SourceBase& source, DevNullConnector devnull) {
     Algorithm* sinkAlg = sink.parent();
 
     // TODO: huh?
-    if (sinkAlg->name() == "DevNull") {
+    if ((sinkAlg) && (sinkAlg->name().find("DevNull") != std::string::npos)){
       disconnect(source, sink);
 
       // since the DevNull is no longer connected to a network, it must be


### PR DESCRIPTION
Memory leaks were previously found in the MonoLoader standard class due to the `NOWHERE` connections. Here's a simple program to reproduce it:

```cpp
// TestMonoLoader.cpp

#include <memory>
#include <string>
#include <vector>

#include <essentia/algorithm.h>
#include <essentia/algorithmfactory.h>
#include <essentia/essentia.h>

int main()
{
    std::string testFileName = "<audioFileName>";

    essentia::init();
   
    std::unique_ptr<essentia::standard::Algorithm> monoloader(essentia::standard::AlgorithmFactory::create("MonoLoader", "filename", testFileName, "sampleRate", 16000));
    std::vector<essentia::Real> monoOut;
    monoloader->output("audio").set(monoOut);
    monoloader->compute();
   
    essentia::shutdown();
    
    return 0;
}
```

The output on running this with valgrind without the fix is:
```sh
$ valgrind ./TestMonoLoader
==23563== Memcheck, a memory error detector
==23563== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==23563== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==23563== Command: ./TestMonoLoader
==23563== 
==23563== 
==23563== HEAP SUMMARY:
==23563==     in use at exit: 52,653 bytes in 271 blocks
==23563==   total heap usage: 59,673 allocs, 59,402 frees, 61,852,582 bytes allocated
==23563== 
==23563== LEAK SUMMARY:
==23563==    definitely lost: 2,456 bytes in 5 blocks
==23563==    indirectly lost: 753 bytes in 15 blocks
==23563==      possibly lost: 1,352 bytes in 18 blocks
==23563==    still reachable: 48,092 bytes in 233 blocks
==23563==                       of which reachable via heuristic:
==23563==                         newarray           : 1,536 bytes in 16 blocks
==23563==         suppressed: 0 bytes in 0 blocks
==23563== Rerun with --leak-check=full to see details of leaked memory
==23563== 
==23563== For lists of detected and suppressed errors, rerun with: -s
==23563== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
The line `==23563==    definitely lost: 2,456 bytes in 5 blocks` clearly indicates memory leaks in the program.

On applying the fix, the output of valgrind is:
```sh
$ valgrind ./TestMonoLoader 
==24318== Memcheck, a memory error detector
==24318== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==24318== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==24318== Command: ./TestMonoLoader
==24318== 
==24318== 
==24318== HEAP SUMMARY:
==24318==     in use at exit: 49,980 bytes in 252 blocks
==24318==   total heap usage: 59,673 allocs, 59,421 frees, 61,852,582 bytes allocated
==24318== 
==24318== LEAK SUMMARY:
==24318==    definitely lost: 536 bytes in 1 blocks
==24318==    indirectly lost: 0 bytes in 0 blocks
==24318==      possibly lost: 1,352 bytes in 18 blocks
==24318==    still reachable: 48,092 bytes in 233 blocks
==24318==                       of which reachable via heuristic:
==24318==                         newarray           : 1,536 bytes in 16 blocks
==24318==         suppressed: 0 bytes in 0 blocks
==24318== Rerun with --leak-check=full to see details of leaked memory
==24318== 
==24318== For lists of detected and suppressed errors, rerun with: -s
==24318== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

There is still a leak of `536 bytes` but running valgrind with `--leak-check=full` shows memory leak in libav. The MonoLoader related leaks are eliminated.