### PR TITLE
Fixed OutOfBounds access to vector in Histogram

### DIFF
--- a/src/algorithms/stats/histogram.cpp
+++ b/src/algorithms/stats/histogram.cpp
@@ -62,7 +62,7 @@ void Histogram::compute() {
 
   for(size_t i = 0; i < array.size(); i++){
     if(array[i] < _maxValue && array[i] >= _minValue)
-      histogram[floor(array[i]/(Real)binWidth)]++;
+      histogram[floor((array[i] - _minValue)/(Real)binWidth)]++;
     else if(array[i] == _maxValue) 
       histogram[_numberBins-1]++;
   }


### PR DESCRIPTION
The previous histogram logic had a bug which lead to undefined behavior. For example, suppose the min, max values and the bin width of the histogram are set to be 10, 25 and 1 respectively. The number of bins for this histogram would then be 15. If the input array for which the histogram is to be computed has a value of `21` in it, the bin value to be incremented by the old logic would be:
`floor(array[i]/(Real)binWidth` = floor(21/1.0f) = `21`

In line 60 of histogram.cpp, the vector histogram would be resized to `_numberBins` which in this case is `15`. Accessing `histogram[21]` would be illegal but C++ doesn't not define the behavior for such an OutOfBounds access operation (refer `Notes` section [here](https://en.cppreference.com/w/cpp/container/vector/operator_at)).

This PR fixes the logic by offsetting the histogram input by the `_minValue`, hence avoiding the undefined behavior.