### PR TITLE
Unit tests for LoopBpmEstimator and LoopBpmConfidence

### DIFF
--- a/src/algorithms/rhythm/loopbpmconfidence.cpp
+++ b/src/algorithms/rhythm/loopbpmconfidence.cpp
@@ -54,66 +54,71 @@ void LoopBpmConfidence::compute() {
   } else {
     const vector<Real>& signal = _signal.get();
 
-    // Get original duration
+    // Get original duration.
     int duration_samples = signal.size();
 
-    // Compute envelope
-    vector<Real> envelope;
-    _envelope->input("signal").set(signal);
-    _envelope->output("signal").set(envelope);
-    _envelope->compute();
+    // Check first that the signal is non-empty
+    if (duration_samples!=0){
+      // Compute envelope
+      vector<Real> envelope;
+      _envelope->input("signal").set(signal);
+      _envelope->output("signal").set(envelope);
+      _envelope->compute();
 
-    // Compute threshold
-    Real threshold = *std::max_element(envelope.begin(), envelope.end()) * 0.05;
+      // Compute threshold
+      Real threshold = *std::max_element(envelope.begin(), envelope.end()) * 0.05;
 
-    // Find start position
-    int start_position = 0;
-    for (int i=0; i<(int)envelope.size(); i++){
-      if (envelope[i] >= threshold){
-        start_position = i;
-        break;
-      }
-    }
-
-    // Find end position
-    int end_position = 0;
-    for (int i=envelope.size() - 1; i>=0; i--){
-      if (envelope[i] >= threshold){
-        end_position = i;
-        break;
-      }
-    }
-
-    // Build vector with all durations to check
-    std::vector<int> durations_to_check;
-    durations_to_check.resize(4);
-    durations_to_check[0] = duration_samples;
-    durations_to_check[1] = duration_samples - start_position;
-    durations_to_check[2] = end_position;
-    durations_to_check[3] = end_position - start_position;
-
-    // Check all durations
-    std::vector<Real> confidences;
-    confidences.resize(4);
-    Real beatDuration = (60.0 * parameter("sampleRate").toReal()) / bpmEstimate;
-    Real lambdaThreshold = beatDuration * 0.5;
-    for (int i=0; i<(int)durations_to_check.size(); i++){
-      int duration = durations_to_check[i];
-      int minDistance = duration_samples; // Set maximum duration
-      for (int j=1; j<128; j++) { // Iterate over possible beat lengths (1-127)
-        int nBeatDuration = (int)round(beatDuration * j);
-        int distance = abs(duration - nBeatDuration);
-        if (distance < minDistance) {
-          minDistance = distance;
+      // Find start position
+      int start_position = 0;
+      for (int i=0; i<(int)envelope.size(); i++){
+        if (envelope[i] >= threshold){
+          start_position = i;
+          break;
         }
       }
-      if (minDistance > lambdaThreshold) {
-        confidences[i] = 0.0;
-      } else {
-        confidences[i] = 1.0 - (Real)minDistance / lambdaThreshold;
+
+      // Find end position
+      int end_position = 0;
+      for (int i=envelope.size() - 1; i>=0; i--){
+        if (envelope[i] >= threshold){
+          end_position = i;
+          break;
+        }
       }
-    }  
-    confidence = *std::max_element(confidences.begin(), confidences.end());
+
+      // Build vector with all durations to check
+      std::vector<int> durations_to_check;
+      durations_to_check.resize(4);
+      durations_to_check[0] = duration_samples;
+      durations_to_check[1] = duration_samples - start_position;
+      durations_to_check[2] = end_position;
+      durations_to_check[3] = end_position - start_position;
+
+      // Check all durations
+      std::vector<Real> confidences;
+      confidences.resize(4);
+      Real beatDuration = (60.0 * parameter("sampleRate").toReal()) / bpmEstimate;
+      Real lambdaThreshold = beatDuration * 0.5;
+      for (int i=0; i<(int)durations_to_check.size(); i++){
+        int duration = durations_to_check[i];
+        int minDistance = duration_samples; // Set maximum duration
+        for (int j=1; j<128; j++) { // Iterate over possible beat lengths (1-127)
+          int nBeatDuration = (int)round(beatDuration * j);
+          int distance = abs(duration - nBeatDuration);
+          if (distance < minDistance) {
+            minDistance = distance;
+          }
+        }
+        if (minDistance > lambdaThreshold) {
+          confidences[i] = 0.0;
+        } else {
+          confidences[i] = 1.0 - (Real)minDistance / lambdaThreshold;
+        }
+      }  
+      confidence = *std::max_element(confidences.begin(), confidences.end());
+    } else {
+      confidence = 0.0;  // Confidence set to zero for empty signals.
+    }
   }
 }
 

--- a/test/src/unittests/rhythm/test_loopbpmconfidence.py
+++ b/test/src/unittests/rhythm/test_loopbpmconfidence.py
@@ -135,34 +135,27 @@ class TestLoopBpmConfidence(TestCase):
     def testSilentEdges(self):
 
         audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))() 
-        bpmEstimate = 125
+        bpmEstimate = 120
         confidence = LoopBpmConfidence()(audio, bpmEstimate)              
         lenSilence = int(0.01*len(audio)) # Choose a silent length 1% of audio
         silentAudio = zeros(lenSilence)
+        benchmarkConfidence= 0.89  # This figure was arrived at emperically from the min. confidence observed with test runs 
 
         # case 1: there is non-musical* silence before the loop starts
         signal1  = numpy.append(silentAudio, audio)
         confidence = LoopBpmConfidence()(signal1, bpmEstimate)              
-        self.assertGreater(confidence, 0.9) 
-
-        # Silent Edges dont always work.
-        # When adding silence to the end of this loop the confidence drops.
-        # This isnt a big problem since it is just a way 
-        # to try to better estimate confidence if the loop is not well cut.
-        # In any case, the "mellifluousanonymous" loop mentioned above
-        # works well with silence added at the end.
+        self.assertGreater(confidence,benchmarkConfidence)
 
         # case 2: there is non-musical silence after the loop ends        
         signal2  = numpy.append(audio,silentAudio)
         confidence = LoopBpmConfidence()(signal2, bpmEstimate)  
-        self.assertGreater(confidence, 0.27) 
-
+        self.assertGreater(confidence, benchmarkConfidence) 
 
         # case 3: there is non-musical silence at both ends
         signal3 = numpy.append(signal1, silentAudio)
         confidence = LoopBpmConfidence()(signal3, bpmEstimate)              
-        self.assertGreater(confidence, 0.27) 
-          
+        self.assertGreater(confidence, benchmarkConfidence) 
+
     def testEmpty(self):
         # Zero estimate check results in zero confidence
         emptyAudio = []

--- a/test/src/unittests/rhythm/test_loopbpmconfidence.py
+++ b/test/src/unittests/rhythm/test_loopbpmconfidence.py
@@ -29,31 +29,47 @@ class TestLoopBpmConfidence(TestCase):
 
     def testRegression(self):
         audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))()        
+
+        # Test for different BPMs starting with correct one then with decreasing accuracy
+        # and corresponding levels decreasing confidence.
+        # Figures obtained from previous runs algorithm as of baseline 10-Feb-2021
+        # In keeping with regression tests principles , no future changes of algorothm
+        # should break these tests.
+        bpmEstimate = 125
+        expectedConfidence = 1
+        confidence = LoopBpmConfidence()(audio,bpmEstimate)        
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.1)
+
         bpmEstimate = 120
         expectedConfidence = 0.87
-        confidence = LoopBpmConfidence()(audio,bpmEstimate)        
-        self.assertAlmostEqual( expectedConfidence, confidence,0.1)
+        confidence = LoopBpmConfidence()(audio, bpmEstimate)        
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.1)
+
+        bpmEstimate = 70
+        expectedConfidence = 0.68
+        confidence = LoopBpmConfidence()(audio, bpmEstimate)                
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.1)
 
     def testEmpty(self):
         emptyAudio = []
         bpmEstimate = 0
         expectedConfidence = 0
-        confidence = LoopBpmConfidence()(emptyAudio,bpmEstimate)                  
-        self.assertEquals( expectedConfidence, confidence)
+        confidence = LoopBpmConfidence()(emptyAudio, bpmEstimate)                  
+        self.assertEquals(expectedConfidence, confidence)
 
     def testZero(self):
         zeroAudio = zeros(1000)
         bpmEstimate = 0
         expectedConfidence = 0
-        confidence = LoopBpmConfidence()(zeroAudio,bpmEstimate)
-        self.assertEquals( expectedConfidence, confidence)
+        confidence = LoopBpmConfidence()(zeroAudio, bpmEstimate)
+        self.assertEquals(expectedConfidence, confidence)
 
     def testConstantInput(self):
         onesAudio = ones(100)
         bpmEstimate = 0
         expectedConfidence = 0
-        confidence = LoopBpmConfidence()(onesAudio,bpmEstimate)
-        self.assertEquals( expectedConfidence, confidence)
+        confidence = LoopBpmConfidence()(onesAudio, bpmEstimate)
+        self.assertEquals(expectedConfidence, confidence)
 
 suite = allTests(TestLoopBpmConfidence)
 

--- a/test/src/unittests/rhythm/test_loopbpmconfidence.py
+++ b/test/src/unittests/rhythm/test_loopbpmconfidence.py
@@ -32,42 +32,47 @@ class TestLoopBpmConfidence(TestCase):
         """
          Confidence figures are obtained from previous runs algorithm as of
          code baseline on 10-Feb-2021
-         In keeping with regression tests principles, no future changes of algorithm
+         In keeping with regression tests principles, no future changes of the algorithm
          should break these tests.
-         Test for different BPMs starting with correct one(125),
+         Test for different BPMs starting with correct one: 125,
          and check the confidence levels obtained from previous runs.
-         The 3rd param in assertAlmostEqual() has been optimised to 0.02.
+         The 3rd param in assertAlmostEqual() has been optimised to 0.01.
+         We chose this reasonable margin since the expected confidence benchmark 
+         has been rounded to two places of decimal.
         """        
 
         bpmEstimate = 125
         expectedConfidence = 1
         confidence = LoopBpmConfidence()(audio, bpmEstimate)        
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02)
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01)
 
         bpmEstimate = 120
         expectedConfidence = 0.87
         confidence = LoopBpmConfidence()(audio, bpmEstimate)        
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02)
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01)
 
         bpmEstimate = 70
         expectedConfidence = 0.68
         confidence = LoopBpmConfidence()(audio, bpmEstimate)                
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02)
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01)
 
         """
-         Apply same principle above to Sub-Sections of Audio.       
+         Apply same principle above but now to Sub-Sections of Audio,
+         truncating a bit at the end
          The following confidence measurements were taken on 11 Feb. 2021
          for a given set of parameters on different audio subsections.
-         A segment of techno_loop gives a non-ideal estimation of BPM.
-         
-         Subsection [1000:6000], (Randomly chosen points, section 1)
-         BPM Estimate: 125: Confidence: 0.5275888442993164
-         BPM Estimate: 120: Confidence: 0.5464853048324585
-         BPM Estimate: 70: Confidence: 0.7354497313499451
-         Subsection [22000:38000], (Randomly chosen points, section 2)
-         BPM Estimate: 125: Confidence: 0.5117157697677612
-         BPM Estimate: 120: Confidence: 0.4512471556663513
-         BPM Estimate: 70: Confidence: 0.15343916416168213
+         A segment of techno_loop gives a non-ideal estimation of BPM
+         so we expect the confidence to drop.
+       
+         Subsection [0:len90]
+         BPM Estimate: 125: Confidence: 0.19992440938949585
+         BPM Estimate: 120: Confidence: 0.4305669069290161
+         BPM Estimate: 70: Confidence: 0.5011640191078186
+
+         Subsection [len01:len90],
+         BPM Estimate: 125: Confidence: 0.9199735522270203
+         BPM Estimate: 120: Confidence: 0.3631746172904968
+         BPM Estimate: 70: Confidence: 0.7951852083206177
          The ASSERTs will check for these to two places of decimal
         
          These checks act as integrity checks. If any future changes break these asserts,
@@ -75,44 +80,42 @@ class TestLoopBpmConfidence(TestCase):
          The 3rd param in assertAlmostEqual() has been optimised, lowest possible value chosen.
         """
 
-        # Randomly chosen points, Section 1
-        samplePoint1 = 1000
-        samplePoint2 = 6000
+        # Define Markers for significant meaningful subsections 
+        # consistent with sampling rate
+        len90 = int(0.9*len(audio))  # End point for 90% loop and subsection        
+        len01 = int(0.01*len(audio)) # Begin point for subsection loop 
 
+        # Truncated Audios 90%
         bpmEstimate = 125
-        expectedConfidence = 0.53
-        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+        expectedConfidence = 0.2 # rounded from measured 0.19992440938949585
+        confidence = LoopBpmConfidence()(audio[0:len90], bpmEstimate)              
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01) 
 
         bpmEstimate = 120
-        expectedConfidence = 0.55
-        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+        expectedConfidence = 0.43 # rounded from measured 0.4305669069290161
+        confidence = LoopBpmConfidence()(audio[0:len90], bpmEstimate)                          
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01) 
         
         bpmEstimate = 70
-        expectedConfidence = 0.74
-        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)            
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
-
-        # Randomly chosen points, Section 2
-        samplePoint1 = 22000
-        samplePoint2 = 38000
-        expectedEstimate = 100
+        expectedConfidence = 0.50 # rounded from measured 0.5011640191078186
+        confidence = LoopBpmConfidence()(audio[0:len90], bpmEstimate)                     
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01)
         
+        # Truncated Audios 90% and 1% at beginning
         bpmEstimate = 125
-        expectedConfidence = 0.51
-        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+        expectedConfidence = 0.92 # rounded from measured 0.9199735522270203
+        confidence = LoopBpmConfidence()(audio[len01:len90], bpmEstimate)                         
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01) 
 
         bpmEstimate = 120
-        expectedConfidence = 0.45
-        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+        expectedConfidence =  0.36 # rounded from measured 0.3631746172904968
+        confidence = LoopBpmConfidence()(audio[len01:len90], bpmEstimate)           
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01) 
         
-        bpmEstimate = 70
-        expectedConfidence = 0.15
-        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)            
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.05) 
+        bpmEstimate = 70 
+        expectedConfidence =  0.79 # rounded from measured 0.7951852083206177
+        confidence = LoopBpmConfidence()(audio[len01:len90], bpmEstimate)
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.01) 
         
     def testEmpty(self):
         # Zero estimate check results in zero confidence
@@ -128,25 +131,27 @@ class TestLoopBpmConfidence(TestCase):
         self.assertEquals(0, confidence)
 
     def testZero(self):
-        zeroAudio = zeros(1000)
+        audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))() 
+        zeroAudio = zeros(len(audio))
         bpmEstimate = 0
         confidence = LoopBpmConfidence()(zeroAudio, bpmEstimate)
         self.assertEquals(0, confidence)
 
         # Non-zero estimate check results in non-zero confidence
-        # FIX-ME: Maybe given contant zero input, we should expect zero confidence
+        # FIXME: Maybe given contant zero input, we should expect zero confidence
         bpmEstimate = 125
         confidence = LoopBpmConfidence()(zeroAudio, bpmEstimate)
         self.assertNotEquals(0, confidence)
          
     def testConstantInput(self):
-        onesAudio = ones(100)
+        audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))() 
+        onesAudio = ones(len(audio))
         bpmEstimate = 0
         confidence = LoopBpmConfidence()(onesAudio, bpmEstimate)
         self.assertEquals(0, confidence)
 
         # Non-zero estimate check results in non-zero confidence
-        # FIX-ME: Maybe given contant input, we should expect zero confidence
+        # FIXME: Maybe given contant input, we should expect zero confidence
         bpmEstimate = 125
         confidence = LoopBpmConfidence()(onesAudio, bpmEstimate)
         self.assertNotEquals(0, confidence)

--- a/test/src/unittests/rhythm/test_loopbpmconfidence.py
+++ b/test/src/unittests/rhythm/test_loopbpmconfidence.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Affero GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+
+from essentia_test import *
+from essentia.standard import MonoLoader, LoopBpmConfidence
+
+class TestLoopBpmConfidence(TestCase):
+
+    def testInvalidParam(self):
+        self.assertConfigureFails(LoopBpmConfidence(), { 'sampleRate': -1})
+
+    def testRegression(self):
+        audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))()        
+        bpmEstimate = 120
+        expectedConfidence = 0.87
+        confidence = LoopBpmConfidence()(audio,bpmEstimate)        
+        self.assertAlmostEqual( expectedConfidence, confidence,0.1)
+
+    def testEmpty(self):
+        emptyAudio = []
+        bpmEstimate = 0
+        expectedConfidence = 0
+        confidence = LoopBpmConfidence()(emptyAudio,bpmEstimate)                  
+        self.assertEquals( expectedConfidence, confidence)
+
+    def testZero(self):
+        zeroAudio = zeros(1000)
+        bpmEstimate = 0
+        expectedConfidence = 0
+        confidence = LoopBpmConfidence()(zeroAudio,bpmEstimate)
+        self.assertEquals( expectedConfidence, confidence)
+
+    def testConstantInput(self):
+        onesAudio = ones(100)
+        bpmEstimate = 0
+        expectedConfidence = 0
+        confidence = LoopBpmConfidence()(onesAudio,bpmEstimate)
+        self.assertEquals( expectedConfidence, confidence)
+
+suite = allTests(TestLoopBpmConfidence)
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=2).run(suite)
+

--- a/test/src/unittests/rhythm/test_loopbpmconfidence.py
+++ b/test/src/unittests/rhythm/test_loopbpmconfidence.py
@@ -18,61 +18,140 @@
 # version 3 along with this program. If not, see http://www.gnu.org/licenses/
 
 
-
 from essentia_test import *
 from essentia.standard import MonoLoader, LoopBpmConfidence
 
 class TestLoopBpmConfidence(TestCase):
 
     def testInvalidParam(self):
-        self.assertConfigureFails(LoopBpmConfidence(), { 'sampleRate': -1})
+        self.assertConfigureFails(LoopBpmConfidence(), {'sampleRate': -1})
 
     def testRegression(self):
         audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))()        
 
-        # Test for different BPMs starting with correct one then with decreasing accuracy
-        # and corresponding levels decreasing confidence.
-        # Figures obtained from previous runs algorithm as of baseline 10-Feb-2021
-        # In keeping with regression tests principles , no future changes of algorothm
-        # should break these tests.
+        """
+         Confidence figures are obtained from previous runs algorithm as of
+         code baseline on 10-Feb-2021
+         In keeping with regression tests principles, no future changes of algorithm
+         should break these tests.
+         Test for different BPMs starting with correct one(125),
+         and check the confidence levels obtained from previous runs.
+         The 3rd param in assertAlmostEqual() has been optimised to 0.02.
+        """        
+
         bpmEstimate = 125
         expectedConfidence = 1
-        confidence = LoopBpmConfidence()(audio,bpmEstimate)        
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.1)
+        confidence = LoopBpmConfidence()(audio, bpmEstimate)        
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02)
 
         bpmEstimate = 120
         expectedConfidence = 0.87
         confidence = LoopBpmConfidence()(audio, bpmEstimate)        
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.1)
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02)
 
         bpmEstimate = 70
         expectedConfidence = 0.68
         confidence = LoopBpmConfidence()(audio, bpmEstimate)                
-        self.assertAlmostEqual(expectedConfidence, confidence, 0.1)
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02)
 
+        """
+         Apply same principle above to Sub-Sections of Audio.       
+         The following confidence measurements were taken on 11 Feb. 2021
+         for a given set of parameters on different audio subsections.
+         A segment of techno_loop gives a non-ideal estimation of BPM.
+         
+         Subsection [1000:6000], (Randomly chosen points, section 1)
+         BPM Estimate: 125: Confidence: 0.5275888442993164
+         BPM Estimate: 120: Confidence: 0.5464853048324585
+         BPM Estimate: 70: Confidence: 0.7354497313499451
+         Subsection [22000:38000], (Randomly chosen points, section 2)
+         BPM Estimate: 125: Confidence: 0.5117157697677612
+         BPM Estimate: 120: Confidence: 0.4512471556663513
+         BPM Estimate: 70: Confidence: 0.15343916416168213
+         The ASSERTs will check for these to two places of decimal
+        
+         These checks act as integrity checks. If any future changes break these asserts,
+         then this will indicate that accuracy of algorithm has changed.
+         The 3rd param in assertAlmostEqual() has been optimised, lowest possible value chosen.
+        """
+
+        # Randomly chosen points, Section 1
+        samplePoint1 = 1000
+        samplePoint2 = 6000
+
+        bpmEstimate = 125
+        expectedConfidence = 0.53
+        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+
+        bpmEstimate = 120
+        expectedConfidence = 0.55
+        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+        
+        bpmEstimate = 70
+        expectedConfidence = 0.74
+        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)            
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+
+        # Randomly chosen points, Section 2
+        samplePoint1 = 22000
+        samplePoint2 = 38000
+        expectedEstimate = 100
+        
+        bpmEstimate = 125
+        expectedConfidence = 0.51
+        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+
+        bpmEstimate = 120
+        expectedConfidence = 0.45
+        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)                
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.02) 
+        
+        bpmEstimate = 70
+        expectedConfidence = 0.15
+        confidence = LoopBpmConfidence()(audio[samplePoint1:samplePoint2], bpmEstimate)            
+        self.assertAlmostEqual(expectedConfidence, confidence, 0.05) 
+        
     def testEmpty(self):
+        # Zero estimate check results in zero confidence
         emptyAudio = []
         bpmEstimate = 0
-        expectedConfidence = 0
         confidence = LoopBpmConfidence()(emptyAudio, bpmEstimate)                  
-        self.assertEquals(expectedConfidence, confidence)
+        self.assertEquals(0, confidence)
+
+        # Non-zero estimate check results in zero confidence
+        emptyAudio = []
+        bpmEstimate = 125
+        confidence = LoopBpmConfidence()(emptyAudio, bpmEstimate)                  
+        self.assertEquals(0, confidence)
 
     def testZero(self):
         zeroAudio = zeros(1000)
         bpmEstimate = 0
-        expectedConfidence = 0
         confidence = LoopBpmConfidence()(zeroAudio, bpmEstimate)
-        self.assertEquals(expectedConfidence, confidence)
+        self.assertEquals(0, confidence)
 
+        # Non-zero estimate check results in non-zero confidence
+        # FIX-ME: Maybe given contant zero input, we should expect zero confidence
+        bpmEstimate = 125
+        confidence = LoopBpmConfidence()(zeroAudio, bpmEstimate)
+        self.assertNotEquals(0, confidence)
+         
     def testConstantInput(self):
         onesAudio = ones(100)
         bpmEstimate = 0
-        expectedConfidence = 0
         confidence = LoopBpmConfidence()(onesAudio, bpmEstimate)
-        self.assertEquals(expectedConfidence, confidence)
+        self.assertEquals(0, confidence)
 
+        # Non-zero estimate check results in non-zero confidence
+        # FIX-ME: Maybe given contant input, we should expect zero confidence
+        bpmEstimate = 125
+        confidence = LoopBpmConfidence()(onesAudio, bpmEstimate)
+        self.assertNotEquals(0, confidence)
+         
 suite = allTests(TestLoopBpmConfidence)
 
 if __name__ == '__main__':
     TextTestRunner(verbosity=2).run(suite)
-

--- a/test/src/unittests/rhythm/test_loopbpmestimator.py
+++ b/test/src/unittests/rhythm/test_loopbpmestimator.py
@@ -18,30 +18,89 @@
 # version 3 along with this program. If not, see http://www.gnu.org/licenses/
 
 
-
 from essentia_test import *
 from essentia.standard import MonoLoader, LoopBpmEstimator
+import numpy as np
 
 class TestLoopBpmEstimator(TestCase):
 
     def testInvalidParam(self):
-        self.assertConfigureFails(LoopBpmEstimator(), { 'confidenceThreshold': -1})
+        self.assertConfigureFails(LoopBpmEstimator(), {'confidenceThreshold': -1})
 
     def testRegression(self):
         audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))()        
       
         expectedEstimate= 125
         estimate = LoopBpmEstimator(confidenceThreshold=0.95)(audio)            
-        self.assertAlmostEqual( expectedEstimate ,estimate,0.05) 
+        self.assertEqual(expectedEstimate, estimate) 
         
-        # Test for upperbound of confidence Threshold
+        # Test for upperbound of Confidence Threshold
         estimate = LoopBpmEstimator(confidenceThreshold=1)(audio)     
-        self.assertAlmostEqual( expectedEstimate ,estimate,0.05)
+        self.assertEqual(expectedEstimate, estimate)
 
-        # Test for lowerbound of confidence Threshold
-        estimate = LoopBpmEstimator(confidenceThreshold=0)(audio)    
-        self.assertAlmostEqual( expectedEstimate ,estimate,0.05)
-        
+        # Test for lowerbound of Confidence Threshold
+        estimate = LoopBpmEstimator(confidenceThreshold=0)(audio)   
+        self.assertEqual(expectedEstimate, estimate)
+
+        # Further integrity checks at randomly chosen points in audio.
+        # If any future changes break these asserts,
+        # then this will indicates algorithm is compromised.
+
+        # Randomly chosen points, Section 1
+        # A segment of techno_loop gives a non-ideal estimation of BPM.
+        samplePoint1 = 1000
+        samplePoint2 = 6000
+        expectedEstimate = 100.0
+
+        # 0% confidence expectation triggers non-zero bpm close to estimate result in this section 1
+        estimate = LoopBpmEstimator(confidenceThreshold=0.0)(audio[samplePoint1:samplePoint2])                
+        self.assertAlmostEqual(expectedEstimate, estimate, 0.1) 
+
+        # 10% confidence expectation triggers non-zero result in this section 1
+        estimate = LoopBpmEstimator(confidenceThreshold=0.1)(audio[samplePoint1:samplePoint2])                
+        self.assertNotEqual(0, estimate) 
+
+        # Higher than 20% confidence expectation triggers non-zero bpm result in this section 1
+        estimate = LoopBpmEstimator(confidenceThreshold=0.25)(audio[samplePoint1:samplePoint2])                
+        self.assertNotEqual(0, estimate) 
+
+        # Higher than 50% confidence expectation triggers non-zero bpm result in this section 1
+        estimate = LoopBpmEstimator(confidenceThreshold=0.55)(audio[samplePoint1:samplePoint2])                
+        self.assertAlmostEqual(expectedEstimate, estimate, 5) 
+
+        # High confidence expectation triggers 0 bpm result in this section 1
+        estimate = LoopBpmEstimator(confidenceThreshold=0.95)(audio[samplePoint1:samplePoint2])            
+        self.assertEqual(0, estimate) 
+
+        # Randomly chosen points, Section 2
+        # A segment of techno_loop gives a non-ideal estimation of BPM.        
+        samplePoint1 = 22000
+        samplePoint2 = 38000
+        expectedEstimate = 100.0
+
+        # 0% confidence expectation triggers non-zero bpm close to estimate result in this section 2
+        estimate = LoopBpmEstimator(confidenceThreshold=0.0)(audio[samplePoint1:samplePoint2])             
+        self.assertAlmostEqual(expectedEstimate, estimate, 0.1) 
+
+        # 10% confidence expectation triggers non-zero bpm result in this section 2
+        estimate = LoopBpmEstimator(confidenceThreshold=0.1)(audio[samplePoint1:samplePoint2])                
+        self.assertNotEqual(0, estimate) 
+
+        # Higher than 20% confidence expectation triggers 0 bpm result in this section 2
+        estimate = LoopBpmEstimator(confidenceThreshold=0.25)(audio[samplePoint1:samplePoint2])                
+        self.assertEqual(0, estimate) 
+
+        # Higher than 50% confidence expectation triggers 0 bpm result in this section 2
+        estimate = LoopBpmEstimator(confidenceThreshold=0.55)(audio[samplePoint1:samplePoint2])                
+        self.assertEqual(0, estimate) 
+
+        # High confidence expectation triggers 0 bpm result in this section 2
+        estimate = LoopBpmEstimator(confidenceThreshold=0.95)(audio[samplePoint1:samplePoint2])            
+        self.assertEqual(0, estimate) 
+
+    # A series of assert checks on the BPM estimator for empty, zero or constant signals.
+    # LoopBpmEstimator uses the percival estimator internally.
+    # The runtime errors have their origin in that algorithm.
     def testEmpty(self):
         emptyAudio = []
         self.assertRaises(RuntimeError, lambda: LoopBpmEstimator()(emptyAudio))
@@ -59,4 +118,3 @@ suite = allTests(TestLoopBpmEstimator)
 
 if __name__ == '__main__':
     TextTestRunner(verbosity=2).run(suite)
-

--- a/test/src/unittests/rhythm/test_loopbpmestimator.py
+++ b/test/src/unittests/rhythm/test_loopbpmestimator.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2016  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Affero GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+
+from essentia_test import *
+from essentia.standard import MonoLoader, LoopBpmEstimator
+
+class TestLoopBpmEstimator(TestCase):
+
+    def testInvalidParam(self):
+        self.assertConfigureFails(LoopBpmEstimator(), { 'confidenceThreshold': -1})
+
+    def testRegression(self):
+        audio = MonoLoader(filename=join(testdata.audio_dir, 'recorded', 'techno_loop.wav'))()        
+      
+        expectedEstimate= 125
+        estimate = LoopBpmEstimator(confidenceThreshold=0.95)(audio)            
+        self.assertAlmostEqual( expectedEstimate ,estimate,0.05) 
+        
+        # Test for upperbound of confidence Threshold
+        estimate = LoopBpmEstimator(confidenceThreshold=1)(audio)     
+        self.assertAlmostEqual( expectedEstimate ,estimate,0.05)
+
+        # Test for lowerbound of confidence Threshold
+        estimate = LoopBpmEstimator(confidenceThreshold=0)(audio)    
+        self.assertAlmostEqual( expectedEstimate ,estimate,0.05)
+        
+    def testEmpty(self):
+        emptyAudio = []
+        self.assertRaises(RuntimeError, lambda: LoopBpmEstimator()(emptyAudio))
+
+    def testZero(self):
+        zeroAudio = zeros(1000)
+        self.assertRaises(RuntimeError, lambda: LoopBpmEstimator()(zeroAudio))
+
+    def testConstantInput(self):
+        onesAudio = ones(100)
+        self.assertRaises(RuntimeError, lambda: LoopBpmEstimator()(onesAudio))
+
+
+suite = allTests(TestLoopBpmEstimator)
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=2).run(suite)
+


### PR DESCRIPTION
During Unit Tests a minor issue was found was found in loopbpmconfidence.cpp, when dealing with empty incoming signals. A fix was added for this.

The "techno_loop.wav'" recording forms the basis of the tests, using the whole signal and parts of the signal for different checks.