### PR TITLE
add small github actions script for a windows build

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,0 +1,41 @@
+name: Native Windows CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install pkg-config through chocolatey
+        run: choco install pkgconfiglite
+
+      - name: Download & build eigen lib
+        env:
+          THIRD_PARTY: packaging\win32_3rdparty
+        run: |
+          $third_party_path = "$env:GITHUB_WORKSPACE\packaging\win32_3rdparty"
+          Invoke-WebRequest -OutFile eigen.zip https://gitlab.com/libeigen/eigen/-/archive/3.3.8/eigen-3.3.8.zip
+          Expand-Archive -LiteralPath eigen.zip -DestinationPath $env:THIRD_PARTY
+          Set-Location -Path $env:THIRD_PARTY\eigen*
+          New-Item -ItemType "directory" -Path .\build
+          sl build
+          cmake -DCMAKE_INSTALL_PREFIX="${third_party_path}\" -DEIGEN_BUILD_PKGCONFIG=ON -Wno-dev ..
+          cmake --install .
+          md "${third_party_path}\lib\pkgconfig\"
+          cp "${third_party_path}\share\pkgconfig\eigen3.pc" -Destination "${third_party_path}\lib\pkgconfig\"
+          dir "${third_party_path}\lib\pkgconfig\"
+
+      - name: Configure build
+        run: |
+          python -X utf8 waf configure


### PR DESCRIPTION
This is a short working example to play around with Github actions and the Windows runner.
Currently it only builds Eigen lib and successfully configures the build.

I put the Eigen lib in `packaging\win32_3rdparty` but it seems that this dir was used for the cross-built dependencies. Should we introduce a new dir, e.g. win64?

I need to explicitly enable [UTF-8 mode](https://docs.python.org/3/using/windows.html#utf-8-mode) for python because this special character `→` could not be printed. Maybe there is a nicer solution for this? 