### PR TITLE
Indian tonic: Fixed bug relating to use cases that produced empty peaks

### DIFF
--- a/src/algorithms/tonal/tonicindianartmusic.cpp
+++ b/src/algorithms/tonal/tonicindianartmusic.cpp
@@ -29,7 +29,7 @@ namespace standard {
 
 const char* TonicIndianArtMusic::name = "TonicIndianArtMusic";
 const char* TonicIndianArtMusic::category = "Tonal";
-const char* TonicIndianArtMusic::description = DOC("This algorithm estimates the tonic frequency of the lead artist in Indian art music. It uses multipitch representation of the audio signal (pitch salience) to compute a histogram using which the tonic is identified as one of its peak. The decision is made based on the distance between the prominent peaks, the classification is done using a decision tree.\n"
+const char* TonicIndianArtMusic::description = DOC("This algorithm estimates the tonic frequency of the lead artist in Indian art music. It uses multipitch representation of the audio signal (pitch salience) to compute a histogram using which the tonic is identified as one of its peak. The decision is made based on the distance between the prominent peaks, the classification is done using a decision tree. An empty input signal will throw an exception. An exception will also be thrown if no predominant pitch salience peaks are detected within the maxTonicFrequency to minTonicFrequency range. \n"
 "\n"
 "References:\n"
 "  [1] J. Salamon, S. Gulati, and X. Serra, \"A Multipitch Approach to Tonic\n"
@@ -198,14 +198,12 @@ void TonicIndianArtMusic::compute() {
   /*implementing the decision tree*/
 
   // Prevent segmentation fault
-  if (peak_locs.size() == 0) { 
+  if (peak_locs.size() == 0){ 
     throw EssentiaException("TonicIndianArtMusic: No peak locations"); 
   }
 
-    // Prevent segmentation fault
-  if (peak_amps.size() == 0) { 
-    throw EssentiaException("TonicIndianArtMusic: No peak amplitudes"); 
-  }
+  // Peak detection should guarantee the equal number of both types of value.
+  assert(peak_locs.size() == peak_amps.size());
   
   Real highest_peak_loc = peak_locs[0];
   Real f2 =peak_locs[1] - highest_peak_loc;

--- a/src/algorithms/tonal/tonicindianartmusic.cpp
+++ b/src/algorithms/tonal/tonicindianartmusic.cpp
@@ -95,9 +95,18 @@ void TonicIndianArtMusic::configure() {
 
 
 void TonicIndianArtMusic::compute() {
+  
+  printf("DBG0");
+  std::cout<< "DEBUGGING"<< std::endl;
   const vector<Real>& signal = _signal.get();
   Real& tonic = _tonic.get();
+  printf("DBG1");
+  // Prevent segmentation fault
+  if (signal.size() == 0) { 
+    throw EssentiaException("TonicIndianArtMusic: Empty Audio passed"); 
+  }
 
+  printf("DBG2");
   // Pre-processing
   vector<Real> frame;
   _frameCutter->input("signal").set(signal);

--- a/src/algorithms/tonal/tonicindianartmusic.cpp
+++ b/src/algorithms/tonal/tonicindianartmusic.cpp
@@ -96,31 +96,14 @@ void TonicIndianArtMusic::configure() {
 
 void TonicIndianArtMusic::compute() {
   
-  printf("DBG0 \n");
-  std::cout<< "DEBUGGING"<< std::endl;
-
-
-
-  printf("DBG0b \n");
   const vector<Real>& signal = _signal.get();
-    // Prevent segmentation fault
+  // Prevent segmentation fault
   if (signal.size() == 0) { 
     throw EssentiaException("TonicIndianArtMusic: Empty Audio passed"); 
   }
-  printf("DBG0c \n");  
-
 
   Real& tonic = _tonic.get();
-  printf("DBG1 \n");
-  if (tonic == 0) { 
-    printf("TonicIzero \n"); 
-  }
-  else
-  {
-     printf("TonicNOJNzero \n"); 
-  }
-  print("CRASH HERE!!!!!! for    x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 99.1* 2*math.pi)")
-  printf("DBG2");
+
   // Pre-processing
   vector<Real> frame;
   _frameCutter->input("signal").set(signal);
@@ -142,7 +125,6 @@ void TonicIndianArtMusic::compute() {
   _spectralPeaks->output("magnitudes").set(frameMagnitudes);
 
 
-  printf("DBG3");
   // Pitch salience contours
   vector<Real> frameSalience;
   _pitchSalienceFunction->input("frequencies").set(frameFrequencies);
@@ -155,8 +137,6 @@ void TonicIndianArtMusic::compute() {
   _pitchSalienceFunctionPeaks->output("salienceBins").set(frameSalienceBins);
   _pitchSalienceFunctionPeaks->output("salienceValues").set(frameSalienceValues);
 
-
-  printf("DBG4");
   // histogram computation
   vector<Real> histogram;
   histogram.resize(_numberBins);
@@ -216,14 +196,21 @@ void TonicIndianArtMusic::compute() {
 
   // this is the decision tree hardcoded to choose the peak in the histogram which corresponds o the tonic
   /*implementing the decision tree*/
+
+  // Prevent segmentation fault
+  if (peak_locs.size() == 0) { 
+    throw EssentiaException("TonicIndianArtMusic: No peak locations"); 
+  }
+
+    // Prevent segmentation fault
+  if (peak_amps.size() == 0) { 
+    throw EssentiaException("TonicIndianArtMusic: No peak amplitudes"); 
+  }
+  
   Real highest_peak_loc = peak_locs[0];
   Real f2 =peak_locs[1] - highest_peak_loc;
   Real f3 =peak_locs[2] - highest_peak_loc;
   Real f5 =peak_locs[4] - highest_peak_loc;
-
-  std::cout << histogram << std::endl;
-  std::cout << peak_locs << std::endl;  
-  std::cout << peak_amps << std::endl;
 
   if (f2>50){
     tonic_loc = peak_locs[0];

--- a/src/algorithms/tonal/tonicindianartmusic.cpp
+++ b/src/algorithms/tonal/tonicindianartmusic.cpp
@@ -96,16 +96,30 @@ void TonicIndianArtMusic::configure() {
 
 void TonicIndianArtMusic::compute() {
   
-  printf("DBG0");
+  printf("DBG0 \n");
   std::cout<< "DEBUGGING"<< std::endl;
+
+
+
+  printf("DBG0b \n");
   const vector<Real>& signal = _signal.get();
-  Real& tonic = _tonic.get();
-  printf("DBG1");
-  // Prevent segmentation fault
+    // Prevent segmentation fault
   if (signal.size() == 0) { 
     throw EssentiaException("TonicIndianArtMusic: Empty Audio passed"); 
   }
+  printf("DBG0c \n");  
 
+
+  Real& tonic = _tonic.get();
+  printf("DBG1 \n");
+  if (tonic == 0) { 
+    printf("TonicIzero \n"); 
+  }
+  else
+  {
+     printf("TonicNOJNzero \n"); 
+  }
+  print("CRASH HERE!!!!!! for    x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 99.1* 2*math.pi)")
   printf("DBG2");
   // Pre-processing
   vector<Real> frame;
@@ -127,6 +141,8 @@ void TonicIndianArtMusic::compute() {
   _spectralPeaks->output("frequencies").set(frameFrequencies);
   _spectralPeaks->output("magnitudes").set(frameMagnitudes);
 
+
+  printf("DBG3");
   // Pitch salience contours
   vector<Real> frameSalience;
   _pitchSalienceFunction->input("frequencies").set(frameFrequencies);
@@ -139,6 +155,8 @@ void TonicIndianArtMusic::compute() {
   _pitchSalienceFunctionPeaks->output("salienceBins").set(frameSalienceBins);
   _pitchSalienceFunctionPeaks->output("salienceValues").set(frameSalienceValues);
 
+
+  printf("DBG4");
   // histogram computation
   vector<Real> histogram;
   histogram.resize(_numberBins);
@@ -203,6 +221,10 @@ void TonicIndianArtMusic::compute() {
   Real f3 =peak_locs[2] - highest_peak_loc;
   Real f5 =peak_locs[4] - highest_peak_loc;
 
+  std::cout << histogram << std::endl;
+  std::cout << peak_locs << std::endl;  
+  std::cout << peak_amps << std::endl;
+
   if (f2>50){
     tonic_loc = peak_locs[0];
   }
@@ -241,6 +263,7 @@ void TonicIndianArtMusic::compute() {
   }
   //converting value of the tonic in cent to Hz scale
   Real _centToHertzBase = pow(2, _binResolution / 1200.0);
+
   tonic = _referenceFrequency * pow(_centToHertzBase, tonic_loc);
 }
 

--- a/test/src/unittests/tonal/test_key.py
+++ b/test/src/unittests/tonal/test_key.py
@@ -24,6 +24,18 @@ from essentia_test import *
 
 class TestKey(TestCase):
 
+    def testEmpty(self):
+        self.assertRaises(RuntimeError, lambda: Key()([]))   
+
+    def testSilence(self):
+        self.assertRaises(RuntimeError, lambda: Key()(zeros(4096)))      
+
+    def testInvalidParam(self):
+        self.assertConfigureFails(Key(), { 'numHarmonics': 0 })
+        self.assertConfigureFails(Key(), { 'pcpSize': 11 })
+        self.assertConfigureFails(Key(), { 'profileType': 'invalid'})
+        self.assertConfigureFails(Key(), { 'slope': -1 })        
+
     # This is a helper method that just runs the algorithm on a recorded wav.
     # One is able to specify the arguments passed to the Key algorithm.
     def runAlg(self, usePolyphony=True,

--- a/test/src/unittests/tonal/test_tonicindianartmusic.py
+++ b/test/src/unittests/tonal/test_tonicindianartmusic.py
@@ -25,12 +25,12 @@ from numpy import sin, float32, pi, arange, mean, log2, floor, ceil
 class TestTonicIndianArtMusic(TestCase):
 
     def testEmpty(self):
-        tonic   = TonicIndianArtMusic()([])
-        self.assertEqual(tonic, 0)
+        #FIXME -Segmentation Fault occurs despite 
+        self.assertRaises(RuntimeError, lambda: TonicIndianArtMusic()([]))
 
     def testZero(self):
-        tonic   = TonicIndianArtMusic()([0])
-        self.assertAlmostEqual(tonic, 108, 2)
+        #FIXME -Segmentation Fault occurs despite         
+        self.assertRaises(RuntimeError, lambda: TonicIndianArtMusic()([0]))
 
     def testOnes(self):
         tonic   = TonicIndianArtMusic()([1]*1024)
@@ -68,9 +68,9 @@ class TestTonicIndianArtMusic(TestCase):
         vibrato = 5 
 
         x = [f0] * 1024 +  extent * sin(2 * pi * vibrato * arange(1024) / fs)
-
-        tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
-        print(tonicEst)
+        print(x)
+        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
+        #print(tonicEst)
 
     def testFrequencyDetectionThreshold(self):
         #  TonicIndianArtMusic Min and Max default values are 3 and 8Hz so

--- a/test/src/unittests/tonal/test_tonicindianartmusic.py
+++ b/test/src/unittests/tonal/test_tonicindianartmusic.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Afextentro General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Afextentro GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+
+from essentia_test import *
+from numpy import sin, float32, pi, arange, mean, log2, floor, ceil
+
+class TestTonicIndianArtMusic(TestCase):
+
+    def testEmpty(self):
+        tonic   = TonicIndianArtMusic()([])
+        self.assertEqual(tonic, 0)
+
+    def testZero(self):
+        tonic   = TonicIndianArtMusic()([0])
+        self.assertAlmostEqual(tonic, 108, 2)
+
+    def testOnes(self):
+        tonic   = TonicIndianArtMusic()([1]*1024)
+        print(tonic)
+
+    def testNegativeInput(self):
+        # Negative vlues should be set to 0
+        tonic = TonicIndianArtMusic()([-1]*1024)
+        print(tonic)
+
+    def testInvalidParam(self):
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'binResolution': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'frameSize': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'harmonicWeight': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'hopSize': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'magnitudeCompression': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'magnitudeThreshold': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'maxTonicFrequency': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'minTonicFrequency': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'numberHarmonics': 0 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'numberSaliencePeaks': 0})
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'referenceFrequency': -1 })
+        self.assertConfigureFails(TonicIndianArtMusic(), { 'sampleRate':   -1 })
+
+    def testRegression(self):
+        audio = MonoLoader(filename = join(testdata.audio_dir, 'recorded/vignesh.wav'),
+                                           sampleRate = 44100)()
+        tonicEst = TonicIndianArtMusic()(audio)
+        print(tonicEst)
+
+    def testSyntheticTonicIndianArtMusic(self):
+        fs = 100  #Hz
+        f0 = 100  #Hz
+        extent = 5 #Hz
+        vibrato = 5 
+
+        x = [f0] * 1024 +  extent * sin(2 * pi * vibrato * arange(1024) / fs)
+
+        tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
+        print(tonicEst)
+
+    def testFrequencyDetectionThreshold(self):
+        #  TonicIndianArtMusic Min and Max default values are 3 and 8Hz so
+        #  this values shouldn't be detected.
+
+        fs = 100  #Hz
+        f0 = 100  #Hz
+        extent  = 5  #Hz
+        vibrato = 3 #Hz
+        x = [f0] * 1024 +   extent* sin(2 * pi * vibrato  * arange(1024) / fs)
+        print(x)
+        print("Segmentation fault in Freq. Detectio Threshold")
+        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
+        #self.assertEqual(0, tonicEst.all())
+
+        extent = 9 #Hz
+        x = [f0] * 1024 +  extent * sin(2 * pi * tonic * arange(1024) / fs)
+        print(x)
+        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
+        #self.assertEqual(0, tonicEst.all())
+
+
+    def testExtendDetectionThreshold(self):
+        #  Extend Min and Max default values are 50 and 250 cents so
+        #  this values  shouldn't be detected.
+        fs = 100  #Hz
+        f0 = 100  #Hz
+        x = ceil(f0 * (2**(250/1200.) -1) / (2**(250/1200.) + 1))
+        extent = 5 #Hz
+        #x2 = [f0] * 1024 +  extent * sin(2 * pi * tonic * arange(1024) / fs)
+        #print(x2)
+        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
+        #print(tonicEst)
+        #extent  = floor(f0 * (2**(50/1200.) -1) / (2**(50/1200.) + 1))
+        #x = [f0] * 1024 + extent  * sin(2 * pi * tonic * arange(1024) / fs)
+        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
+        #print(tonicEst)
+
+suite = allTests(TestTonicIndianArtMusic)
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=2).run(suite)

--- a/test/src/unittests/tonal/test_tonicindianartmusic.py
+++ b/test/src/unittests/tonal/test_tonicindianartmusic.py
@@ -59,10 +59,29 @@ class TestTonicIndianArtMusic(TestCase):
         tonic = TonicIndianArtMusic()(ones(1024))
         self.assertAlmostEqualFixedPrecision(tonic, referenceTonic, 2)
 
+    # Full reference set of values can be sourced from dataset
+    # Download https://compmusic.upf.edu/carnatic-varnam-dataset
+    # See  file "tonics.yaml" 
+    #
+    # vignesh: 138.59
+    # This tonic corresponds to the following mp3 file.
+    # "23582__gopalkoduri__carnatic-varnam-by-vignesh-in-abhogi-raaga.mp3'
+    # 
+    # 1. copy this file into essentia/test/audio/recorded.
+    # 2. Uncomment the test case below and run.
+
+    """
+    def testRegressionVignesh(self):
+        audio = MonoLoader(filename = join(testdata.audio_dir, 'recorded/223582__gopalkoduri__carnatic-varnam-by-vignesh-in-abhogi-raaga.mp3'),
+                            sampleRate = 44100)()
+
+        # Reference tonic from YAML file is 138.59.  The measured is "138.8064422607422"
+        referenceTonic = 138.59                                      
+        tonic = TonicIndianArtMusic()(audio)
+        self.assertEqual(round(tonic), round(referenceTonic))
+    """
     def testRegression(self):
-        # Full reference set of values can be sourced from dataset
-        # https://compmusic.upf.edu/carnatic-varnam-dataset
-        # See tonic yaml values
+        # Regression test using existing vignesh audio file in "essentia/test/audio/recorded"
         audio = MonoLoader(filename = join(testdata.audio_dir, 'recorded/vignesh.wav'),
                             sampleRate = 44100)()
         referenceTonic = 102.74                                       
@@ -73,8 +92,8 @@ class TestTonicIndianArtMusic(TestCase):
         # Check result is the same with appended silences of constant length
         real_audio = np.hstack([start_zero, audio, end_zero])
         tonic = TonicIndianArtMusic()(real_audio)
-        self.assertAlmostEqualFixedPrecision(tonic, referenceTonic, 2)
-    
+        self.assertAlmostEqualFixedPrecision(tonic, referenceTonic, 2)    
+
     def testMinMaxMismatch(self):
         self.assertRaises(RuntimeError, lambda: TonicIndianArtMusic(minTonicFrequency=100,maxTonicFrequency=11)(ones(4096)))
     
@@ -112,7 +131,7 @@ class TestTonicIndianArtMusic(TestCase):
         x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 124 * 2*math.pi)
         y = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 100 * 2*math.pi)
         z = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 80 * 2*math.pi)
-        chord =x+y+z
+        chord = x+y+z
 
         tiam = TonicIndianArtMusic(minTonicFrequency=50, maxTonicFrequency=111)
         tonic  = tiam(chord)         

--- a/test/src/unittests/tonal/test_tonicindianartmusic.py
+++ b/test/src/unittests/tonal/test_tonicindianartmusic.py
@@ -67,10 +67,9 @@ class TestTonicIndianArtMusic(TestCase):
     # This tonic corresponds to the following mp3 file.
     # "23582__gopalkoduri__carnatic-varnam-by-vignesh-in-abhogi-raaga.mp3'
     # 
-    # 1. copy this file into essentia/test/audio/recorded.
-    # 2. Uncomment the test case below and run.
+    #  copy this file into essentia/test/audio/recorded.
 
-    """
+   
     def testRegressionVignesh(self):
         audio = MonoLoader(filename = join(testdata.audio_dir, 'recorded/223582__gopalkoduri__carnatic-varnam-by-vignesh-in-abhogi-raaga.mp3'),
                             sampleRate = 44100)()
@@ -79,7 +78,7 @@ class TestTonicIndianArtMusic(TestCase):
         referenceTonic = 138.59                                      
         tonic = TonicIndianArtMusic()(audio)
         self.assertEqual(round(tonic), round(referenceTonic))
-    """
+    
     def testRegression(self):
         # Regression test using existing vignesh audio file in "essentia/test/audio/recorded"
         audio = MonoLoader(filename = join(testdata.audio_dir, 'recorded/vignesh.wav'),

--- a/test/src/unittests/tonal/test_tonicindianartmusic.py
+++ b/test/src/unittests/tonal/test_tonicindianartmusic.py
@@ -21,9 +21,12 @@
 
 from essentia_test import *
 from numpy import sin, float32, pi, arange, mean, log2, floor, ceil
+from numpy import *
+
 
 class TestTonicIndianArtMusic(TestCase):
 
+    """
     def testEmpty(self):
         #FIXME -Segmentation Fault occurs despite 
         self.assertRaises(RuntimeError, lambda: TonicIndianArtMusic()([]))
@@ -31,6 +34,7 @@ class TestTonicIndianArtMusic(TestCase):
     def testZero(self):
         #FIXME -Segmentation Fault occurs despite         
         self.assertRaises(RuntimeError, lambda: TonicIndianArtMusic()([0]))
+    """
 
     def testOnes(self):
         tonic   = TonicIndianArtMusic()([1]*1024)
@@ -58,37 +62,10 @@ class TestTonicIndianArtMusic(TestCase):
     def testRegression(self):
         audio = MonoLoader(filename = join(testdata.audio_dir, 'recorded/vignesh.wav'),
                                            sampleRate = 44100)()
+        referenceTonic = 102.74                                       
         tonicEst = TonicIndianArtMusic()(audio)
-        print(tonicEst)
-
-    def testSyntheticTonicIndianArtMusic(self):
-        fs = 100  #Hz
-        f0 = 100  #Hz
-        extent = 5 #Hz
-        vibrato = 5 
-
-        x = [f0] * 1024 +  extent * sin(2 * pi * vibrato * arange(1024) / fs)
-        print(x)
-        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
-        #print(tonicEst)
-
-    def testFrequencyDetectionThreshold(self):
-        #  TonicIndianArtMusic Min and Max default values are 3 and 8Hz so
-        #  this values shouldn't be detected.
-
-        fs = 100  #Hz
-        f0 = 100  #Hz
-        extent  = 5  #Hz
-        vibrato = 3 #Hz
-        x = [f0] * 1024 +   extent* sin(2 * pi * vibrato  * arange(1024) / fs)
-        print(x)
-        print("Segmentation fault in Freq. Detectio Threshold")
-        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
-        #self.assertEqual(0, tonicEst.all())
-
-        extent = 9 #Hz
-        x = [f0] * 1024 +  extent * sin(2 * pi * tonic * arange(1024) / fs)
-        print(x)
+        self.assertAlmostEqual(referenceTonic, tonicEst, 6)
+        print("PASSED")
         #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
         #self.assertEqual(0, tonicEst.all())
 
@@ -100,14 +77,67 @@ class TestTonicIndianArtMusic(TestCase):
         f0 = 100  #Hz
         x = ceil(f0 * (2**(250/1200.) -1) / (2**(250/1200.) + 1))
         extent = 5 #Hz
-        #x2 = [f0] * 1024 +  extent * sin(2 * pi * tonic * arange(1024) / fs)
-        #print(x2)
-        #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
+        tonic = 102
+        x2 = [f0] * 1024 +  extent * sin(2 * pi * tonic * arange(1024) / fs)
+        print(x2)
+        #tonicEst = TonicIndianArtMusic(sampleRate=44100)(x2.astype(float32))
         #print(tonicEst)
         #extent  = floor(f0 * (2**(50/1200.) -1) / (2**(50/1200.) + 1))
         #x = [f0] * 1024 + extent  * sin(2 * pi * tonic * arange(1024) / fs)
         #tonicEst = TonicIndianArtMusic(sampleRate=fs)(x.astype(float32))
         #print(tonicEst)
+
+
+    def testMajorScale(self):
+        # generate test signal concatenating major scale notes.
+        defaultSampleRate = 44100
+        frameSize = 2048
+        signalSize = 15 * frameSize
+        # Here are generate sine waves for each note of the scale, e.g. C3 is 130.81 Hz, etc
+
+
+        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 124 * 2*math.pi)
+
+        y = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 100 * 2*math.pi)
+
+        z = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 80 * 2*math.pi)
+        # This signal is a "major scale ladder"
+        scale = concatenate([x, y, z])
+
+        tiam = TonicIndianArtMusic()
+        tonic  = tiam(scale)        
+        print(tonic)
+
+
+    def testzReferenceFreq99(self):
+        # generate test signal concatenating major scale notes.
+        defaultSampleRate = 44100
+        frameSize = 2048
+        signalSize = 15 * frameSize
+        # Here are generate sine waves for each note of the scale, e.g. C3 is 130.81 Hz, etc
+
+        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 99* 2*math.pi)
+
+
+        tiam = TonicIndianArtMusic()
+        tonic  = tiam(x)        
+        print(tonic)
+
+
+
+    def testReferenceFreq991(self):
+        # generate test signal concatenating major scale notes.
+        defaultSampleRate = 44100
+        frameSize = 2048
+        signalSize = 15 * frameSize
+        # Here are generate sine waves for each note of the scale, e.g. C3 is 130.81 Hz, etc
+
+        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 99.1* 2*math.pi)
+
+
+        tiam = TonicIndianArtMusic()
+        tonic  = tiam(x)        
+        print(tonic)
 
 suite = allTests(TestTonicIndianArtMusic)
 


### PR DESCRIPTION
While testing tonicindianartmusic.cpp, I found a some cases where segmentation faults occur. Initially I thought that it was related to the empty audio, but on closer examination, in a test case where you send in a pure sine wave with a frequency below the configured minTonicFrequency, can produce a set of empty peaks and consequently a segmentation fault.

I added 8 test cases. They may not cover all config combinations, but catch the typical illegal ones (e.g.  min and max Tonics conflicting), but its a start to at least give good coverage to the change in the CPP file.