### PR TITLE
Support Tensorflow models in SavedModel format

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredict.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredict.cpp
@@ -48,11 +48,8 @@ static void DeallocateBuffer(void* data, size_t) {
 
 
 void TensorflowPredict::configure() {
-  _savedModel = "";
-  _graphFilename = "";
-
-  if (parameter("savedModel").isConfigured()) _savedModel = parameter("savedModel").toString();
-  if (parameter("graphFilename").isConfigured()) _graphFilename = parameter("graphFilename").toString();
+  _savedModel = parameter("savedModel").toString();
+  _graphFilename = parameter("graphFilename").toString();
 
   // Do not do anything if we did not get a non-empty model name.
   if ((_savedModel.empty()) and (_graphFilename.empty())) return;

--- a/src/algorithms/machinelearning/tensorflowpredict.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredict.cpp
@@ -128,6 +128,8 @@ void TensorflowPredict::openGraph() {
     TF_LoadSessionFromSavedModel(_sessionOptions, _runOptions,
       _savedModel.c_str(), &tags_c[0], (int)tags_c.size(),
       _graph, NULL, _status);
+
+    E_INFO("Successfully loaded SavedModel: `" << _savedModel << "`");
     return;
   }
 
@@ -166,6 +168,8 @@ void TensorflowPredict::openGraph() {
     if (TF_GetCode(_status) != TF_OK) {
       throw EssentiaException("TensorflowPredict: Error importing graph. ", TF_Message(_status));
     }
+
+    E_INFO("Successfully loaded graph file: `" << _graphFilename << "`");
   }
 }
 

--- a/src/algorithms/machinelearning/tensorflowpredict.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredict.cpp
@@ -48,10 +48,14 @@ static void DeallocateBuffer(void* data, size_t) {
 
 
 void TensorflowPredict::configure() {
-  // If no file has been specified, do not do anything
+  _savedModel = "";
+  _graphFilename = "";
+
   if (parameter("savedModel").isConfigured()) _savedModel = parameter("savedModel").toString();
-  else if (parameter("graphFilename").isConfigured()) _graphFilename = parameter("graphFilename").toString();
-  else return;
+  if (parameter("graphFilename").isConfigured()) _graphFilename = parameter("graphFilename").toString();
+
+  // Do not do anything if we did not get a non-empty model name.
+  if ((_savedModel.empty()) and (_graphFilename.empty())) return;
 
   _tags = parameter("tags").toVectorString();
 

--- a/src/algorithms/machinelearning/tensorflowpredict.h
+++ b/src/algorithms/machinelearning/tensorflowpredict.h
@@ -53,6 +53,11 @@ class TensorflowPredict : public Algorithm {
   TF_SessionOptions* _sessionOptions;
   TF_Session* _session;
 
+  std::string _savedModel;
+  std::vector<std::string> _tags;
+  TF_Buffer* _runOptions;
+  TF_Buffer* _metaGraphDef;
+
   bool _isTraining;
   bool _isTrainingSet;
   std::string _isTrainingName;
@@ -75,7 +80,7 @@ class TensorflowPredict : public Algorithm {
  public:
   TensorflowPredict() : _graph(TF_NewGraph()), _status(TF_NewStatus()),
       _options(TF_NewImportGraphDefOptions()), _sessionOptions(TF_NewSessionOptions()),
-      _session(TF_NewSession(_graph, _sessionOptions, _status)) {
+      _session(TF_NewSession(_graph, _sessionOptions, _status)), _runOptions(NULL) {
     declareInput(_poolIn, "poolIn", "the pool where to get the feature tensors");
     declareOutput(_poolOut, "poolOut", "the pool where to store the output tensors");
   }
@@ -87,10 +92,16 @@ class TensorflowPredict : public Algorithm {
     TF_DeleteImportGraphDefOptions(_options);
     TF_DeleteStatus(_status);
     TF_DeleteGraph(_graph);
+    TF_DeleteBuffer(_runOptions);
   }
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file from which to read the Tensorflow graph", "", Parameter::STRING);
+    const char* defaultTagsC[] = { "serve" };
+    std::vector<std::string> defaultTags = arrayToVector<std::string>(defaultTagsC);
+
+    declareParameter("graphFilename", "the name of the file from which to read the TensorFlow graph", "", Parameter::STRING);
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", Parameter::STRING);
+    declareParameter("tags", "the tags of the savedModel", "", defaultTags);
     declareParameter("inputs", "will look for these namespaces in poolIn. Should match the names of the input nodes in the Tensorflow graph", "", Parameter::VECTOR_STRING);
     declareParameter("outputs", "will save the tensors on the graph nodes named after `outputs` to the same namespaces in the output pool. Set the first element of this list as an empty array to print all the available nodes in the graph", "", Parameter::VECTOR_STRING);
     declareParameter("isTraining", "run the model in training mode (normalized with statistics of the current batch) instead of inference mode (normalized with moving statistics). This only applies to some models", "{true,false}", false);

--- a/src/algorithms/machinelearning/tensorflowpredict.h
+++ b/src/algorithms/machinelearning/tensorflowpredict.h
@@ -99,8 +99,8 @@ class TensorflowPredict : public Algorithm {
     const char* defaultTagsC[] = { "serve" };
     std::vector<std::string> defaultTags = arrayToVector<std::string>(defaultTagsC);
 
-    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", Parameter::STRING);
-    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("tags", "the tags of the savedModel", "", defaultTags);
     declareParameter("inputs", "will look for these namespaces in poolIn. Should match the names of the input nodes in the Tensorflow graph", "", Parameter::VECTOR_STRING);
     declareParameter("outputs", "will save the tensors on the graph nodes named after `outputs` to the same namespaces in the output pool. Set the first element of this list as an empty array to print all the available nodes in the graph", "", Parameter::VECTOR_STRING);

--- a/src/algorithms/machinelearning/tensorflowpredict.h
+++ b/src/algorithms/machinelearning/tensorflowpredict.h
@@ -99,7 +99,7 @@ class TensorflowPredict : public Algorithm {
     const char* defaultTagsC[] = { "serve" };
     std::vector<std::string> defaultTags = arrayToVector<std::string>(defaultTagsC);
 
-    declareParameter("graphFilename", "the name of the file from which to read the TensorFlow graph", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", Parameter::STRING);
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", Parameter::STRING);
     declareParameter("tags", "the tags of the savedModel", "", defaultTags);
     declareParameter("inputs", "will look for these namespaces in poolIn. Should match the names of the input nodes in the Tensorflow graph", "", Parameter::VECTOR_STRING);

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
@@ -118,10 +118,6 @@ void TensorflowPredictMusiCNN::configure() {
 
   _poolToTensor->configure("namespace", output);
 
-  Parameter graphFilenameParam = parameter("graphFilename");
-  // if no file has been specified, do not do anything else
-  if (!graphFilenameParam.isConfigured()) return;
-
   string graphFilename = parameter("graphFilename").toString();
 
   _tensorflowPredict->configure("graphFilename", graphFilename,

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
@@ -119,8 +119,10 @@ void TensorflowPredictMusiCNN::configure() {
   _poolToTensor->configure("namespace", output);
 
   string graphFilename = parameter("graphFilename").toString();
+  string savedModel = parameter("savedModel").toString();
 
   _tensorflowPredict->configure("graphFilename", graphFilename,
+                                "savedModel", savedModel,
                                 "inputs", vector<string>({input}),
                                 "outputs", vector<string>({output}),
                                 "isTrainingName", isTrainingName);
@@ -190,6 +192,7 @@ void TensorflowPredictMusiCNN::configure() {
   // if no file has been specified, do not do anything
   if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictMusiCNN->configure(INHERIT("graphFilename"),
+                                       INHERIT("savedModel"),
                                        INHERIT("input"),
                                        INHERIT("output"),
                                        INHERIT("isTrainingName"),

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
@@ -53,7 +53,7 @@ class TensorflowPredictMusiCNN : public AlgorithmComposite {
   ~TensorflowPredictMusiCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
@@ -104,7 +104,7 @@ class TensorflowPredictMusiCNN : public Algorithm {
   ~TensorflowPredictMusiCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
     declareParameter("input", "the name of the input nodes in the Tensorflow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
@@ -54,6 +54,7 @@ class TensorflowPredictMusiCNN : public AlgorithmComposite {
 
   void declareParameters() {
     declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
@@ -105,6 +106,7 @@ class TensorflowPredictMusiCNN : public Algorithm {
 
   void declareParameters() {
     declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input nodes in the Tensorflow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
@@ -53,7 +53,7 @@ class TensorflowPredictMusiCNN : public AlgorithmComposite {
   ~TensorflowPredictMusiCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
@@ -105,7 +105,7 @@ class TensorflowPredictMusiCNN : public Algorithm {
   ~TensorflowPredictMusiCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input nodes in the Tensorflow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
@@ -132,10 +132,6 @@ void TensorflowPredictTempoCNN::configure() {
 
   _poolToTensor->configure("namespace", output);
 
-  Parameter graphFilenameParam = parameter("graphFilename");
-  // if no file has been specified, do not do anything else
-  if (!graphFilenameParam.isConfigured()) return;
-
   string graphFilename = parameter("graphFilename").toString();
 
   _tensorflowPredict->configure("graphFilename", graphFilename,

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
@@ -133,8 +133,10 @@ void TensorflowPredictTempoCNN::configure() {
   _poolToTensor->configure("namespace", output);
 
   string graphFilename = parameter("graphFilename").toString();
+  string savedModel = parameter("savedModel").toString();
 
   _tensorflowPredict->configure("graphFilename", graphFilename,
+                                "savedModel", savedModel,
                                 "squeeze", false,
                                 "inputs", vector<string>({input}),
                                 "outputs", vector<string>({output}));
@@ -210,11 +212,12 @@ void TensorflowPredictTempoCNN::configure() {
   // if no file has been specified, do not do anything
   if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictTempoCNN->configure(INHERIT("graphFilename"),
-                                       INHERIT("input"),
-                                       INHERIT("output"),
-                                       INHERIT("patchHopSize"),
-                                       INHERIT("batchSize"),
-                                       INHERIT("lastPatchMode"));
+                                        INHERIT("savedModel"),
+                                        INHERIT("input"),
+                                        INHERIT("output"),
+                                        INHERIT("patchHopSize"),
+                                        INHERIT("batchSize"),
+                                        INHERIT("lastPatchMode"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
@@ -56,6 +56,7 @@ class TensorflowPredictTempoCNN : public AlgorithmComposite {
 
   void declareParameters() {
     declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
@@ -106,6 +107,7 @@ class TensorflowPredictTempoCNN : public Algorithm {
 
   void declareParameters() {
     declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input nodes in the Tensorflow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
@@ -55,7 +55,7 @@ class TensorflowPredictTempoCNN : public AlgorithmComposite {
   ~TensorflowPredictTempoCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
@@ -105,7 +105,7 @@ class TensorflowPredictTempoCNN : public Algorithm {
   ~TensorflowPredictTempoCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
     declareParameter("input", "the name of the input nodes in the Tensorflow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
@@ -55,7 +55,7 @@ class TensorflowPredictTempoCNN : public AlgorithmComposite {
   ~TensorflowPredictTempoCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
@@ -106,7 +106,7 @@ class TensorflowPredictTempoCNN : public Algorithm {
   ~TensorflowPredictTempoCNN();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input nodes in the Tensorflow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
@@ -117,10 +117,6 @@ void TensorflowPredictVGGish::configure() {
 
   _poolToTensor->configure("namespace", output);
 
-  Parameter graphFilenameParam = parameter("graphFilename");
-  // if no file has been specified, do not do anything else
-  if (!graphFilenameParam.isConfigured()) return;
-
   string graphFilename = parameter("graphFilename").toString();
 
   _tensorflowPredict->configure("graphFilename", graphFilename,

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
@@ -118,8 +118,10 @@ void TensorflowPredictVGGish::configure() {
   _poolToTensor->configure("namespace", output);
 
   string graphFilename = parameter("graphFilename").toString();
+  string savedModel = parameter("savedModel").toString();
 
   _tensorflowPredict->configure("graphFilename", graphFilename,
+                                "savedModel", savedModel,
                                 "inputs", vector<string>({input}),
                                 "outputs", vector<string>({output}),
                                 "isTrainingName", isTrainingName);
@@ -190,6 +192,7 @@ void TensorflowPredictVGGish::configure() {
   // if no file has been specified, do not do anything
   if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictVGGish->configure(INHERIT("graphFilename"),
+                                      INHERIT("savedModel"),
                                       INHERIT("input"),
                                       INHERIT("output"),
                                       INHERIT("isTrainingName"),

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.h
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.h
@@ -53,7 +53,7 @@ class TensorflowPredictVGGish : public AlgorithmComposite {
   ~TensorflowPredictVGGish();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
@@ -105,7 +105,7 @@ class TensorflowPredictVGGish : public Algorithm {
   ~TensorflowPredictVGGish();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the Tensorflow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.h
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.h
@@ -54,6 +54,7 @@ class TensorflowPredictVGGish : public AlgorithmComposite {
 
   void declareParameters() {
     declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
@@ -105,6 +106,7 @@ class TensorflowPredictVGGish : public Algorithm {
 
   void declareParameters() {
     declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the Tensorflow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.h
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.h
@@ -53,7 +53,7 @@ class TensorflowPredictVGGish : public AlgorithmComposite {
   ~TensorflowPredictVGGish();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
@@ -104,7 +104,7 @@ class TensorflowPredictVGGish : public Algorithm {
   ~TensorflowPredictVGGish();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
     declareParameter("input", "the name of the input node in the Tensorflow graph", "", "model/Placeholder");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/Sigmoid");
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");

--- a/src/algorithms/rhythm/tempocnn.cpp
+++ b/src/algorithms/rhythm/tempocnn.cpp
@@ -68,6 +68,7 @@ const Real _BPMOffset = 30.f;
 
 void TempoCNN::configure() {
   _tensorflowPredictTempoCNN->configure(INHERIT("graphFilename"),
+                                        INHERIT("savedModel"),
                                         INHERIT("input"),
                                         INHERIT("output"),
                                         INHERIT("patchHopSize"),

--- a/src/algorithms/rhythm/tempocnn.h
+++ b/src/algorithms/rhythm/tempocnn.h
@@ -55,7 +55,7 @@ class TempoCNN : public Algorithm {
   }
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the tempo bins activations", "", "output");

--- a/src/algorithms/rhythm/tempocnn.h
+++ b/src/algorithms/rhythm/tempocnn.h
@@ -55,7 +55,7 @@ class TempoCNN : public Algorithm {
   }
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the tempo bins activations", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);

--- a/src/algorithms/rhythm/tempocnn.h
+++ b/src/algorithms/rhythm/tempocnn.h
@@ -56,6 +56,7 @@ class TempoCNN : public Algorithm {
 
   void declareParameters() {
     declareParameter("graphFilename", "the name of the file containing the model to use", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "input");
     declareParameter("output", "the name of the node from which to retrieve the tempo bins activations", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);

--- a/test/src/unittests/essentia_test.py
+++ b/test/src/unittests/essentia_test.py
@@ -187,6 +187,18 @@ class TestCase(BaseTestCase):
         conf = lambda: algo.configure(**params)
         self.assertRaises(EssentiaException, conf)
 
+    def assertConfigureSuccess(self, algo, params):
+        try:
+            algo.configure(**params)
+        except EssentiaException:
+            self.fail()
+
+    def assertComputeSuccess(self, algo, params):
+        try:
+            algo.compute(**params)
+        except EssentiaException:
+            self.fail()
+
     def assertComputeFails(self, algo, *args):
         comp = lambda: algo.compute(*args)
         self.assertRaises(EssentiaException, comp)

--- a/test/src/unittests/machinelearning/test_tensorflowpredict.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredict.py
@@ -87,7 +87,7 @@ class TestTensorFlowPredict(TestCase):
 
         self.regression(parameters)
 
-    def testSavedModelPreferecce(self):
+    def testSavedModelOverridesGraphFilename(self):
         # When both are specified, `savedModel` should be preferred.
         # Test this by setting an invalid `graphFilename` that should be ignored.
         parameters = {

--- a/test/src/unittests/machinelearning/test_tensorflowpredict.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredict.py
@@ -103,16 +103,32 @@ class TestTensorFlowPredict(TestCase):
 
     def testEmptyModelName(self):
         # With empty model names the algorithm should skip the configuration without errors.
-        TensorflowPredict()
-        TensorflowPredict(graphFilename='')
-        TensorflowPredict(graphFilename='', inputs=[''])
-        TensorflowPredict(graphFilename='', inputs=['wrong_input'])
-        TensorflowPredict(savedModel='')
-        TensorflowPredict(savedModel='', inputs=[''])
-        TensorflowPredict(savedModel='', inputs=['wrong_input'])
-        TensorflowPredict(graphFilename='', savedModel='')
-        TensorflowPredict(graphFilename='', savedModel='', inputs=[''])
-        TensorflowPredict(graphFilename='', savedModel='', inputs=['wrong_input'])
+        self.assertConfigureSuccess(TensorflowPredict(), {})
+        self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': ''})
+        self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': '',
+                                                          'inputs': ['']
+                                                         })
+        self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': '',
+                                                          'inputs': ['wrong_input']
+                                                         })
+        self.assertConfigureSuccess(TensorflowPredict(), {'savedModel': ''})
+        self.assertConfigureSuccess(TensorflowPredict(), {'savedModel': '',
+                                                          'inputs':['']
+                                                         })
+        self.assertConfigureSuccess(TensorflowPredict(), {'savedModel': '',
+                                                          'inputs':['wrong_input']
+                                                         })
+        self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': '',
+                                                          'savedModel':''
+                                                         })
+        self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': '',
+                                                          'savedModel':'',
+                                                          'inputs': ['']
+                                                         })
+        self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': '',
+                                                          'savedModel':'',
+                                                          'inputs': ['wrong_input']
+                                                         })
     
     def testInvalidParam(self):
         model = join(testdata.models_dir, 'vgg', 'vgg4.pb')

--- a/test/src/unittests/machinelearning/test_tensorflowpredictmusicnn.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredictmusicnn.py
@@ -50,18 +50,35 @@ class TestTensorFlowPredictMusiCNN(TestCase):
         self.assertAlmostEqualVector(found, expected, 1e-5)
 
     def testEmptyModelName(self):
-        # With empty or undefined model names the algorithm should skip the configuration without errors.
-        TensorflowPredictMusiCNN()
-        TensorflowPredictMusiCNN(graphFilename='')
-        TensorflowPredictMusiCNN(graphFilename='', input='')
-        TensorflowPredictMusiCNN(graphFilename='', input='wrong_input')
-        TensorflowPredictMusiCNN(savedModel='')
-        TensorflowPredictMusiCNN(savedModel='', input='')
-        TensorflowPredictMusiCNN(savedModel='', input='wrong_input')
-        TensorflowPredictMusiCNN(graphFilename='', savedModel='')
-        TensorflowPredictMusiCNN(graphFilename='', savedModel='', input='')
-        TensorflowPredictMusiCNN(graphFilename='', savedModel='', input='wrong_input')
-    
+        # With empty model names the algorithm should skip the configuration without errors.
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {})
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'graphFilename': ''})
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'graphFilename': '',
+                                                                 'input': '',
+                                                                })
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'graphFilename': '',
+                                                                 'input': 'wrong_input'
+                                                                })
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'savedModel': ''})
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'savedModel': '',
+                                                                 'input':'',
+                                                                })
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'savedModel': '',
+                                                                 'input':'wrong_input',
+                                                                })
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'graphFilename': '',
+                                                                 'savedModel':'',
+                                                                })
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'graphFilename': '',
+                                                                 'savedModel':'',
+                                                                 'input': '',
+                                                                })
+        self.assertConfigureSuccess(TensorflowPredictMusiCNN(), {'graphFilename': '',
+                                                                 'savedModel':'',
+                                                                 'input': 'wrong_input',
+                                                                })
+
+
     def testInvalidParam(self):
         model = join(testdata.models_dir, 'vgg', 'vgg4.pb')
         self.assertConfigureFails(TensorflowPredictMusiCNN(), {'graphFilename': model,

--- a/test/src/unittests/machinelearning/test_tensorflowpredictmusicnn.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredictmusicnn.py
@@ -25,7 +25,7 @@ import os
 
 class TestTensorFlowPredictMusiCNN(TestCase):
 
-    def testRegression(self):
+    def testRegressionFrozenModel(self):
         expected = [0.00893995, 0.650628, 0.0017924, 0.10297492, 0.15139213,
                     0.13975027, 0.07960042, 0.01067388, 0.04935676]
 
@@ -35,8 +35,43 @@ class TestTensorFlowPredictMusiCNN(TestCase):
         audio = MonoLoader(filename=filename, sampleRate=16000)()
         found = TensorflowPredictMusiCNN(graphFilename=model)(audio)[0]
 
-        self.assertAlmostEqualVector(found, expected, 1e-6)
+        self.assertAlmostEqualVector(found, expected, 1e-5)
 
+    def testRegressionSavedModel(self):
+        expected = [0.00893995, 0.650628, 0.0017924, 0.10297492, 0.15139213,
+                    0.13975027, 0.07960042, 0.01067388, 0.04935676]
+
+        filename = join(testdata.audio_dir, 'recorded', 'vignesh.wav')
+        model = join(testdata.models_dir, 'musicnn', 'genre_dortmund_musicnn_msd')
+
+        audio = MonoLoader(filename=filename, sampleRate=16000)()
+        found = TensorflowPredictMusiCNN(savedModel=model)(audio)[0]
+
+        self.assertAlmostEqualVector(found, expected, 1e-5)
+
+    def testEmptyModelName(self):
+        # With empty or undefined model names the algorithm should skip the configuration without errors.
+        TensorflowPredictMusiCNN()
+        TensorflowPredictMusiCNN(graphFilename='')
+        TensorflowPredictMusiCNN(graphFilename='', input='')
+        TensorflowPredictMusiCNN(graphFilename='', input='wrong_input')
+        TensorflowPredictMusiCNN(savedModel='')
+        TensorflowPredictMusiCNN(savedModel='', input='')
+        TensorflowPredictMusiCNN(savedModel='', input='wrong_input')
+        TensorflowPredictMusiCNN(graphFilename='', savedModel='')
+        TensorflowPredictMusiCNN(graphFilename='', savedModel='', input='')
+        TensorflowPredictMusiCNN(graphFilename='', savedModel='', input='wrong_input')
+    
+    def testInvalidParam(self):
+        model = join(testdata.models_dir, 'vgg', 'vgg4.pb')
+        self.assertConfigureFails(TensorflowPredictMusiCNN(), {'graphFilename': model,
+                                                               'input': 'wrong_input_name',
+                                                               'output': 'model/Softmax',
+                                                               })  # input do not exist in the model
+        self.assertConfigureFails(TensorflowPredictMusiCNN(), {'graphFilename': 'wrong_model_name',
+                                                               'input': 'model/Placeholder',
+                                                               'output': 'model/Softmax',
+                                                               })  # the model does not exist
 
 suite = allTests(TestTensorFlowPredictMusiCNN)
 

--- a/test/src/unittests/machinelearning/test_tensorflowpredicttempocnn.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredicttempocnn.py
@@ -22,7 +22,7 @@ from essentia_test import *
 
 class TestTensorflowPredictTempoCNN(TestCase):
 
-    def testRegression(self):
+    def regression(self, parameters):
         # The expected values were self-generated with TensorflowPredictTempoCNN
         # from commit deb334ba01f849e74b0e6e8554b2e17d73bc6966
         expected = [6.81436131e-06, 5.18454181e-06, 5.18454181e-06, 5.18454181e-06,
@@ -91,13 +91,18 @@ class TestTensorflowPredictTempoCNN(TestCase):
                     5.18454181e-06, 5.18454181e-06, 5.18454181e-06, 5.18454181e-06]
 
         filename = join(testdata.audio_dir, 'recorded', 'techno_loop.wav')
-        model = join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb')
 
         audio = MonoLoader(filename=filename, sampleRate=11025)()
-        found = TensorflowPredictTempoCNN(graphFilename=model)(audio)
+        found = TensorflowPredictTempoCNN(**parameters)(audio)
         found = numpy.mean(found, axis=0)
 
-        self.assertAlmostEqualVector(found, expected, 1e-6)
+        self.assertAlmostEqualVector(found, expected, 1e-5)
+
+    def testRegressionGraphFilename(self):
+        self.regression({'graphFilename': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb')})
+
+    def testRegressionSavedModel(self):
+        self.regression({'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16')})
 
     def testEmptyInput(self):
         model = join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb')
@@ -114,6 +119,19 @@ class TestTensorflowPredictTempoCNN(TestCase):
                                                                 'output': 'non_existing'})
         self.assertConfigureFails(TensorflowPredictTempoCNN(), {'graphFilename': 'non_existing_model.pb',
                                                                 'output': 'non_existing'})
+
+    def testEmptyModelName(self):
+        # With empty or undefined model names the algorithm should skip the configuration without errors.
+        TensorflowPredictTempoCNN()
+        TensorflowPredictTempoCNN(graphFilename='')
+        TensorflowPredictTempoCNN(graphFilename='', input='')
+        TensorflowPredictTempoCNN(graphFilename='', input='wrong_input')
+        TensorflowPredictTempoCNN(savedModel='')
+        TensorflowPredictTempoCNN(savedModel='', input='')
+        TensorflowPredictTempoCNN(savedModel='', input='wrong_input')
+        TensorflowPredictTempoCNN(graphFilename='', savedModel='')
+        TensorflowPredictTempoCNN(graphFilename='', savedModel='', input='')
+        TensorflowPredictTempoCNN(graphFilename='', savedModel='', input='wrong_input')
 
 suite = allTests(TestTensorflowPredictTempoCNN)
 

--- a/test/src/unittests/machinelearning/test_tensorflowpredicttempocnn.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredicttempocnn.py
@@ -121,17 +121,33 @@ class TestTensorflowPredictTempoCNN(TestCase):
                                                                 'output': 'non_existing'})
 
     def testEmptyModelName(self):
-        # With empty or undefined model names the algorithm should skip the configuration without errors.
-        TensorflowPredictTempoCNN()
-        TensorflowPredictTempoCNN(graphFilename='')
-        TensorflowPredictTempoCNN(graphFilename='', input='')
-        TensorflowPredictTempoCNN(graphFilename='', input='wrong_input')
-        TensorflowPredictTempoCNN(savedModel='')
-        TensorflowPredictTempoCNN(savedModel='', input='')
-        TensorflowPredictTempoCNN(savedModel='', input='wrong_input')
-        TensorflowPredictTempoCNN(graphFilename='', savedModel='')
-        TensorflowPredictTempoCNN(graphFilename='', savedModel='', input='')
-        TensorflowPredictTempoCNN(graphFilename='', savedModel='', input='wrong_input')
+        # With empty model names the algorithm should skip the configuration without errors.
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {})
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'graphFilename': ''})
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'graphFilename': '',
+                                                                  'input': '',
+                                                                 })
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'graphFilename': '',
+                                                                  'input': 'wrong_input'
+                                                                 })
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'savedModel': ''})
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'savedModel': '',
+                                                                  'input':'',
+                                                                 })
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'savedModel': '',
+                                                                  'input':'wrong_input',
+                                                                 })
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'graphFilename': '',
+                                                                  'savedModel':'',
+                                                                 })
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'graphFilename': '',
+                                                                  'savedModel':'',
+                                                                  'input': '',
+                                                                 })
+        self.assertConfigureSuccess(TensorflowPredictTempoCNN(), {'graphFilename': '',
+                                                                  'savedModel':'',
+                                                                  'input': 'wrong_input',
+                                                                 })
 
 suite = allTests(TestTensorflowPredictTempoCNN)
 

--- a/test/src/unittests/machinelearning/test_tensorflowpredictvggish.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredictvggish.py
@@ -56,17 +56,33 @@ class TestTensorFlowPredictVGGish(TestCase):
         self.assertAlmostEqualVector(found, expected, 1e-2)
 
     def testEmptyModelName(self):
-        # With empty or undefined model names the algorithm should skip the configuration without errors.
-        TensorflowPredictVGGish()
-        TensorflowPredictVGGish(graphFilename='')
-        TensorflowPredictVGGish(graphFilename='', input='')
-        TensorflowPredictVGGish(graphFilename='', input='wrong_input')
-        TensorflowPredictVGGish(savedModel='')
-        TensorflowPredictVGGish(savedModel='', input='')
-        TensorflowPredictVGGish(savedModel='', input='wrong_input')
-        TensorflowPredictVGGish(graphFilename='', savedModel='')
-        TensorflowPredictVGGish(graphFilename='', savedModel='', input='')
-        TensorflowPredictVGGish(graphFilename='', savedModel='', input='wrong_input')
+        # With empty model names the algorithm should skip the configuration without errors.
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {})
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'graphFilename': ''})
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'graphFilename': '',
+                                                                'input': '',
+                                                               })
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'graphFilename': '',
+                                                                'input': 'wrong_input'
+                                                               })
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'savedModel': ''})
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'savedModel': '',
+                                                                'input':'',
+                                                               })
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'savedModel': '',
+                                                                'input':'wrong_input',
+                                                               })
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'graphFilename': '',
+                                                                'savedModel':'',
+                                                               })
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'graphFilename': '',
+                                                                'savedModel':'',
+                                                                'input': '',
+                                                               })
+        self.assertConfigureSuccess(TensorflowPredictVGGish(), {'graphFilename': '',
+                                                                'savedModel':'',
+                                                                'input': 'wrong_input',
+                                                               })
     
     def testInvalidParam(self):
         model = join(testdata.models_dir, 'vgg', 'vgg4.pb')

--- a/test/src/unittests/rhythm/test_tempocnn.py
+++ b/test/src/unittests/rhythm/test_tempocnn.py
@@ -22,7 +22,7 @@ from essentia_test import *
 
 class TestTempoCNN(TestCase):
 
-    def regression(self, aggregation_method='majority'):
+    def regression(self, parameters, aggregation_method='majority'):
         # The expected values were self-generated with TempoCNN
         # from commit deb334ba01f849e74b0e6e8554b2e17d73bc6966
         # The retrieved tempo values were manually validated (Pablo Alonso)
@@ -31,24 +31,55 @@ class TestTempoCNN(TestCase):
         expected_local_probs = [0.9679363, 0.9600502, 0.9681525, 0.9627014]
 
         filename = join(testdata.audio_dir, 'recorded', 'techno_loop.wav')
-        model = join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb')
 
         audio = MonoLoader(filename=filename, sampleRate=11025)()
-        global_tempo, local_tempo, local_probs = TempoCNN(graphFilename=model,
-                                                          aggregationMethod=aggregation_method)(audio)
+        global_tempo, local_tempo, local_probs = TempoCNN(**parameters)(audio)
 
         self.assertEqual(global_tempo, expected_global_tempo)
         self.assertEqualVector(local_tempo, expected_local_tempo)
         self.assertAlmostEqualVector(local_probs, expected_local_probs, 1e-6)
 
     def testMajorityVotingRegression(self):
-        self.regression(aggregation_method='majority')
+        parameters = {
+            'graphFilename': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb'),
+            'aggregationMethod':'majority',
+        }
+        self.regression(parameters)
 
     def testMeanRegression(self):
-        self.regression(aggregation_method='mean')
+        parameters = {
+            'graphFilename': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb'),
+            'aggregationMethod':'mean',
+        }
+        self.regression(parameters)
 
     def testMedianRegression(self):
-        self.regression(aggregation_method='median')
+        parameters = {
+            'graphFilename': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb'),
+            'aggregationMethod':'median',
+        }
+        self.regression(parameters)
+
+    def testMajorityVotingRegressionSavedModel(self):
+        parameters = {
+            'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16'),
+            'aggregationMethod':'majority',
+        }
+        self.regression(parameters)
+
+    def testMeanRegressionSavedModel(self):
+        parameters = {
+            'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16'),
+            'aggregationMethod':'mean',
+        }
+        self.regression(parameters)
+
+    def testMedianRegressionSavedModel(self):
+        parameters = {
+            'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16'),
+            'aggregationMethod':'median',
+        }
+        self.regression(parameters)
 
     def testAggregationMethods(self):
         # Load an audio file without a clear rhythmic sense as we want


### PR DESCRIPTION
This PR gives `TensorflowPredict` and derivate algorithms the capability to run Tensorflow SavedModels.
When both `savedModel` and `graphFilename` are specified, the first one is preferred

Additionally, it modifies `TensorflowPredict`'s behavior so that the configuration is skipped  when `graphFilename` or/and `savedModel` are set to an empty string ("").
The main benefit is that algorithms depending on `TensorflowPredict` can default `graphFilename` and `savedModel` to an empty string and leverage the skip-configuration logic implemented on `TensorflowPredict`.
This also simplifies the logic required to choose between the `graphFilename` and `savedModel` when both are specified.