### PR TITLE
Bug fix in line 56 for  pitchcontour segmentation

### DIFF
--- a/src/algorithms/tonal/pitchcontours.h
+++ b/src/algorithms/tonal/pitchcontours.h
@@ -77,7 +77,7 @@ class PitchContours : public Algorithm {
     declareParameter("binResolution", "salience function bin resolution [cents]", "(0,inf)", 10.0);
     declareParameter("peakFrameThreshold", "per-frame salience threshold factor (fraction of the highest peak salience in a frame)", "[0,1]", 0.9);
     declareParameter("peakDistributionThreshold", "allowed deviation below the peak salience mean over all frames (fraction of the standard deviation)", "[0,2]", 0.9);
-    declareParameter("pitchContinuity", "pitch continuity cue (maximum allowed pitch change durig 1 ms time period) [cents]", "[0,inf)", 27.5625);
+    declareParameter("pitchContinuity", "pitch continuity cue (maximum allowed pitch change during 1 ms time period) [cents]", "[0,inf)", 27.5625);
     declareParameter("timeContinuity", "time continuity cue (the maximum allowed gap duration for a pitch contour) [ms]", "(0,inf)", 100.);
     declareParameter("minDuration", "the minimum allowed contour duration [ms]", "(0,inf)", 100.);
   }

--- a/src/algorithms/tonal/pitchcontoursegmentation.cpp
+++ b/src/algorithms/tonal/pitchcontoursegmentation.cpp
@@ -52,6 +52,10 @@ void PitchContourSegmentation::reSegment() {
   // find sequences of consecutive non-zero pitch values
   startC.clear();
   endC.clear();
+
+  if (pitch.size()==0){
+     throw(EssentiaException("PitchContourSegmentation: Empty pitch values."));   
+  }
   
   if (pitch[0] > 0) {
     startC.push_back(0);


### PR DESCRIPTION
This is a minor correction for the pitchcontour segmentation CPP file.

For Unit test file please refer to python files added in the following open PR:
https://github.com/MTG/essentia/pull/1137

There are more algorithm tests included in that PR.

In this pull request there is also a tiny documentation correction in pitch contours header file ("durig"-> "during")