### PR TITLE
Monolithic build of Tensorflow 2.5

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -58,7 +58,7 @@ Note that [Bazel](https://bazel.build/) has to be installed to build TensorFlow.
 For simplicity, we recommend to get Bazel through [Bazelisk](https://docs.bazel.build/versions/main/install-bazelisk.html).
 To build TensorFlow with GPU support [CUDA](https://developer.nvidia.com/cuda-toolkit) and [cuDNN](https://developer.nvidia.com/cudnn) have to be installed.
 Otherwise, GPU support can be deactivated by setting ```export TF_NEED_CUDA=0``` before building TensorFlow.
-More TensorFlow related configuration is available in the [build configuration file](https://github.com/MTG/essentia/blob/master/packaging/build_config.sh).
+More TensorFlow-related configuration is available in the [build configuration file](https://github.com/MTG/essentia/blob/master/packaging/build_config.sh).
 
 Alternatively, you can build each dependency apart running the corresponding scripts inside ```packaging/debian_3rdparty``` folder:
 ```

--- a/FAQ.md
+++ b/FAQ.md
@@ -54,6 +54,12 @@ Use ```--with-gaia``` flag to include Gaia.
 
 Use ```--with-tensorflow``` flag to include TensorFlow.
 
+Note that [Bazel](https://bazel.build/) has to be installed to build TensorFlow.
+For simplicity, we recommend to get Bazel through [Bazelisk](https://docs.bazel.build/versions/main/install-bazelisk.html).
+To build TensorFlow with GPU support [CUDA](https://developer.nvidia.com/cuda-toolkit) and [cuDNN](https://developer.nvidia.com/cudnn) have to be installed.
+Otherwise, GPU support can be deactivated by setting ```export TF_NEED_CUDA=0``` before building TensorFlow.
+More TensorFlow related configuration is available in the [build configuration file](https://github.com/MTG/essentia/blob/master/packaging/build_config.sh).
+
 Alternatively, you can build each dependency apart running the corresponding scripts inside ```packaging/debian_3rdparty``` folder:
 ```
 cd packaging/debian_3rdparty

--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -27,7 +27,7 @@ LIBYAML_VERSION=yaml-0.1.5
 CHROMAPRINT_VERSION=1.4.3
 QT_SOURCE_URL=https://download.qt.io/archive/qt/4.8/4.8.4/qt-everywhere-opensource-src-4.8.4.tar.gz
 GAIA_VERSION=2.4.6-86-ged433ed
-TENSORFLOW_VERSION=1.15.0
+TENSORFLOW_VERSION=2.5.0
 
 
 FFMPEG_AUDIO_FLAGS="

--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -284,25 +284,27 @@ TENSORFLOW_FLAGS="
 # The only known alternative to the interactive TensorFlow configuration is
 # through env variables:
 # https://github.com/tensorflow/tensorflow/issues/8527#issuecomment-289272898
+#
+# Set the required TensorFlow build env variables with CUDA support if they
+# were not cofigured yet:
+export PYTHON_BIN_PATH="${PYTHON_BIN_PATH:-python3}"
+export USE_DEFAULT_PYTHON_LIB_PATH="${USE_DEFAULT_PYTHON_LIB_PATH:-1}"
+export BAZEL_LINKLIBS="${BAZEL_LINKLIBS:--l%:libstdc++.a}"
 
-# TensorFlow build options
-export BAZEL_LINKLIBS=-l%:libstdc++.a
-
-# export CC_OPT_FLAGS="--copt=-mavx --copt=-mavx2 --copt=-mfma --copt=-msse4.2 --copt=-mfpmath=both --config=cuda"
-export TF_NEED_JEMALLOC=1
-export TF_NEED_GCP=0
-export TF_NEED_HDFS=0
-export TF_ENABLE_XLA=0
-export TF_NEED_OPENCL=0
+export TF_NEED_JEMALLOC="${TF_NEED_JEMALLOC:-1}"
+export TF_NEED_GCP="${TF_NEED_GCP:-0}"
+export TF_NEED_HDFS="${TF_NEED_HDFS:-0}"
+export TF_ENABLE_XLA="${TF_ENABLE_XLA:-0}"
+export TF_NEED_OPENCL="${TF_NEED_OPENCL:-0}"
 
 # TensorFlow CUDA versions intended for TensorFlow 2.5
 # For future updates check the GPU compatibility chart:
 # https://www.tensorflow.org/install/source#gpu
-export TF_NEED_CUDA=1
-export TF_CUDA_VERSION=11.2
-export TF_CUDNN_VERSION=8.1
-export CUDA_TOOLKIT_PATH=/usr/local/cuda
-export CUDNN_INSTALL_PATH=/usr/local/cuda
+export TF_NEED_CUDA="${TF_NEED_CUDA:-1}"
+export TF_CUDA_VERSION="${TF_CUDA_VERSION:-11.2}"
+export TF_CUDNN_VERSION="${TF_CUDNN_VERSION:-8.1}"
+export CUDA_TOOLKIT_PATH="${CUDA_TOOLKIT_PATH:-/usr/local/cuda}"
+export CUDNN_INSTALL_PATH="${CUDNN_INSTALL_PATH:-/usr/local/cuda}"
 
 # The compute capabilities define which GPUs can be used:
 # https://developer.nvidia.com/cuda-gpus#compute
@@ -313,7 +315,4 @@ export CUDNN_INSTALL_PATH=/usr/local/cuda
 # 5.2: Geforce GTX TITAN X
 # 7.5: Geforce RTX 2080 (Ti)
 # 8.6: Geforce RTX 30XX
-export TF_CUDA_COMPUTE_CAPABILITIES=3.5,5.2,7.5,8.6
-
-# TensorFlow Python options
-# export USE_DEFAULT_PYTHON_LIB_PATH=1
+export TF_CUDA_COMPUTE_CAPABILITIES="${TF_CUDA_COMPUTE_CAPABILITIES:-3.5,5.2,7.5,8.6}"

--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -271,3 +271,49 @@ QT_FLAGS="
     -nomake tools
     -nomake translations
 "
+
+TENSORFLOW_FLAGS="
+    --config=opt
+    --config=monolithic
+    --config=v2
+    --config=noaws
+    --config=nohdfs
+    --config=nonccl
+"
+
+# The only known alternative to the interactive TensorFlow configuration is
+# through env variables:
+# https://github.com/tensorflow/tensorflow/issues/8527#issuecomment-289272898
+
+# TensorFlow build options
+export BAZEL_LINKLIBS=-l%:libstdc++.a
+
+# export CC_OPT_FLAGS="--copt=-mavx --copt=-mavx2 --copt=-mfma --copt=-msse4.2 --copt=-mfpmath=both --config=cuda"
+export TF_NEED_JEMALLOC=1
+export TF_NEED_GCP=0
+export TF_NEED_HDFS=0
+export TF_ENABLE_XLA=0
+export TF_NEED_OPENCL=0
+
+# TensorFlow CUDA versions intended for TensorFlow 2.5
+# For future updates check the GPU compatibility chart:
+# https://www.tensorflow.org/install/source#gpu
+export TF_NEED_CUDA=1
+export TF_CUDA_VERSION=11.2
+export TF_CUDNN_VERSION=8.1
+export CUDA_TOOLKIT_PATH=/usr/local/cuda
+export CUDNN_INSTALL_PATH=/usr/local/cuda
+
+# The compute capabilities define which GPUs can be used:
+# https://developer.nvidia.com/cuda-gpus#compute
+# Supporting more versions increases the library size, so
+# for the moment it is set to a conservative number that
+# covers some of the most popular dee'p learning GPUs:
+# 3.5: Geforce GT XXX
+# 5.2: Geforce GTX TITAN X
+# 7.5: Geforce RTX 2080 (Ti)
+# 8.6: Geforce RTX 30XX
+export TF_CUDA_COMPUTE_CAPABILITIES=3.5,5.2,7.5,8.6
+
+# TensorFlow Python options
+# export USE_DEFAULT_PYTHON_LIB_PATH=1

--- a/packaging/debian_3rdparty/build_tensorflow.sh
+++ b/packaging/debian_3rdparty/build_tensorflow.sh
@@ -32,8 +32,8 @@ sed -i 's/ -ltensorflow_framework//' tensorflow.pc
 cp tensorflow.pc ${PREFIX}/lib/pkgconfig/
 
 # Clean Bazel's cache (~9GB)
-bazel clean
+bazel clean --expunge
+rm -rf /root/.cache/bazel*
 
 cd ../..
 rm -r tmp
-

--- a/packaging/debian_3rdparty/build_tensorflow.sh
+++ b/packaging/debian_3rdparty/build_tensorflow.sh
@@ -27,7 +27,7 @@ tar xzf bazel-bin/tensorflow/tools/lib_package/libtensorflow.tar.gz -C ${PREFIX}
 
 # Patch the pkg-config file to remove the dependency on libtensorflow_framework.so,
 # which is not required in monolithic builds.
-sed 's/ -ltensorflow_framework//' tensorflow.pc
+sed -i 's/ -ltensorflow_framework//' tensorflow.pc
 
 cp tensorflow.pc ${PREFIX}/lib/pkgconfig/
 

--- a/packaging/debian_3rdparty/build_tensorflow.sh
+++ b/packaging/debian_3rdparty/build_tensorflow.sh
@@ -10,75 +10,27 @@ cd tmp
 
 echo "Building Tensorflow $TENSORFLOW_VERSION"
 
+# NumPy is required by Bazel
+${PYTHON_BIN_PATH} -m pip install numpy
 
 curl -SLO https://github.com/tensorflow/tensorflow/archive/v$TENSORFLOW_VERSION.tar.gz
 tar -xf v$TENSORFLOW_VERSION.tar.gz
 cd tensorflow-$TENSORFLOW_VERSION
 
+yes '' | ./configure
 
-# Force using curl for the dependencies download
-sed -i 's/\[\[ \"\$OSTYPE\" == \"darwin\"\* \]\]/true/g' tensorflow/contrib/makefile/download_dependencies.sh
+bazel build //tensorflow/tools/lib_package:libtensorflow ${TENSORFLOW_FLAGS}
 
-tensorflow/contrib/makefile/download_dependencies.sh
+tar xzf bazel-bin/tensorflow/tools/lib_package/libtensorflow.tar.gz -C ${PREFIX}
 
-# Add fPIC, otherwise nsync won't compile
-sed -i 's/PLATFORM_CFLAGS=-std=c++11 -Werror -Wall -Wextra -pedantic/PLATFORM_CFLAGS=-std=c++11 -Wall -Wextra -pedantic -fPIC/g' tensorflow/contrib/makefile/compile_nsync.sh
+./tensorflow/c/generate-pc.sh -p ${PREFIX} -v $TENSORFLOW_VERSION
 
-# Compile the C API as it's curretly the recomended way to interface Tensorflow
-sed -i 's/CORE_CC_ALL_SRCS := \\/&\n\$(wildcard tensorflow\/c\/c_api.cc) \\/' tensorflow/contrib/makefile/Makefile
+# Patch the pkg-config file to remove the dependency on libtensorflow_framework.so,
+# which is not required in monolithic builds.
+sed 's/ -ltensorflow_framework//' tensorflow.pc
 
-# Define android to prevent errors in the Andrid API. Why?
-sed -i 's/#ifndef __ANDROID__/#define __ANDROID__ 1\n&/' tensorflow/c/c_api.cc
-
-# Use relative paths to prevent too long lines.
-sed -i 's/"\$(cd "\$(dirname "\${BASH_SOURCE\[0]}")" \&\& pwd)"/"\$(dirname "\${BASH_SOURCE\[0]}")"/' tensorflow/contrib/makefile/build_all_linux.sh tensorflow/contrib/makefile/build_all_linux.sh
-
-# We don't want to re-download dependencies on the build script as it would undo the previous patches
-sed -i 's/rm -rf tensorflow\/contrib\/makefile\/downloads/# &/' tensorflow/contrib/makefile/build_all_linux.sh
-sed -i 's/tensorflow\/contrib\/makefile\/download_dependencies.sh/# &/' tensorflow/contrib/makefile/build_all_linux.sh
-
-# Add -lrt flag.
-sed -i 's/HOST_CXXFLAGS=\"--std=c++11 -march=native\" \\/HOST_CXXFLAGS=\"--std=c++11 -march=native -lrt\" \\/' tensorflow/contrib/makefile/build_all_linux.sh
-
-# Prevent compiling the example.
-sed -i 's/all: \$(LIB_PATH) \$(BENCHMARK_NAME)/all: \$(LIB_PATH)/' tensorflow/contrib/makefile/Makefile
-
-# The matmul_op_fused op is required by some of our supported models.
-# We could also create a custom tf_op_files.txt discarding any op that is not
-# relevant to our models to create lightweight extractors.
-echo 'tensorflow/core/kernels/matmul_op_fused.cc' >> tensorflow/contrib/makefile/tf_op_files.txt
-
-tensorflow/contrib/makefile/build_all_linux.sh
-
-PREFIX_LIB=${PREFIX}/lib/tensorflow
-PREFIX_INCLUDE=${PREFIX}/include/tensorflow/c
-
-mkdir ${PREFIX_LIB}
-mkdir -p ${PREFIX_INCLUDE}
-
-cp tensorflow/contrib/makefile/gen/lib/libtensorflow-core.a ${PREFIX_LIB}
-cp tensorflow/contrib/makefile/gen/protobuf/lib/libprotobuf.a ${PREFIX_LIB}
-cp tensorflow/contrib/makefile/downloads/nsync/builds/default.linux.c++11/libnsync.a ${PREFIX_LIB}
-
-cp tensorflow/c/c_api.h ${PREFIX_INCLUDE}
-
-./tensorflow/c/generate-pc.sh -p ${PREFIX} -l ${PREFIX_LIB} -v $TENSORFLOW_VERSION
-
-echo "Generating pkgconfig file for TensorFlow $TENSORFLOW_VERSION in ${PREFIX}"
-
-cat << EOF > ${PREFIX}/lib/pkgconfig/tensorflow.pc
-prefix=${PREFIX}
-exec_prefix=\${prefix}
-libdir=\${prefix}/lib/tensorflow
-includedir=\${prefix}/include/tensorflow/c
-Name: TensorFlow
-Version: ${TENSORFLOW_VERSION}
-Description: Library for computation using data flow graphs for scalable machine learning
-Requires:
-Libs: -L\${libdir} -Wl,--allow-multiple-definition -Wl,--whole-archive,-ltensorflow-core,--no-whole-archive -lprotobuf -lnsync
-Libs.private: -lz -lm -ldl -lpthread
-Cflags: -I\${includedir}
-EOF
+cp tensorflow.pc ${PREFIX}/lib/pkgconfig/
 
 cd ../..
 rm -r tmp
+

--- a/packaging/debian_3rdparty/build_tensorflow.sh
+++ b/packaging/debian_3rdparty/build_tensorflow.sh
@@ -31,6 +31,9 @@ sed -i 's/ -ltensorflow_framework//' tensorflow.pc
 
 cp tensorflow.pc ${PREFIX}/lib/pkgconfig/
 
+# Clean Bazel's cache (~9GB)
+bazel clean
+
 cd ../..
 rm -r tmp
 

--- a/packaging/debian_3rdparty/build_tensorflow.sh
+++ b/packaging/debian_3rdparty/build_tensorflow.sh
@@ -10,9 +10,6 @@ cd tmp
 
 echo "Building Tensorflow $TENSORFLOW_VERSION"
 
-# NumPy is required by Bazel
-${PYTHON_BIN_PATH} -m pip install numpy
-
 curl -SLO https://github.com/tensorflow/tensorflow/archive/v$TENSORFLOW_VERSION.tar.gz
 tar -xf v$TENSORFLOW_VERSION.tar.gz
 cd tensorflow-$TENSORFLOW_VERSION

--- a/setup.py
+++ b/setup.py
@@ -109,14 +109,7 @@ install_requires = setup_requires + ['pyyaml']
 # We are using version 2.5.0 as it is the newest version supported by the C API
 # https://www.tensorflow.org/guide/versions
 if project_name == 'essentia-tensorflow':
-    tensorflow_version = '2.5.0'
     description += ', with TensorFlow support'
-
-    var_tensorflow_version = 'ESSENTIA_TENSORFLOW_VERSION'
-    if var_tensorflow_version in os.environ:
-        tensorflow_version = os.environ[var_tensorflow_version]
-
-    setup_requires.append('tensorflow=={}'.format(tensorflow_version))
 
 module = Extension('name', sources=[])
 

--- a/setup.py
+++ b/setup.py
@@ -106,10 +106,10 @@ setup_requires = ['numpy>=1.8.2', 'six']
 install_requires = setup_requires + ['pyyaml']
 
 # Require tensorflow for the package essentia-tensorflow
-# We are using version 1.15.0 as it is the newest version supported by the C API
+# We are using version 2.5.0 as it is the newest version supported by the C API
 # https://www.tensorflow.org/guide/versions
 if project_name == 'essentia-tensorflow':
-    tensorflow_version = '1.15.0'
+    tensorflow_version = '2.5.0'
     description += ', with TensorFlow support'
 
     var_tensorflow_version = 'ESSENTIA_TENSORFLOW_VERSION'

--- a/src/3rdparty/tensorflow/setup_from_libtensorflow.sh
+++ b/src/3rdparty/tensorflow/setup_from_libtensorflow.sh
@@ -8,7 +8,7 @@ PYTHON=python3
 MODE=libtensorflow
 PLATFORM=linux
 CONTEXT=/usr/local/  # run as sudo if the context directory is not owned
-VERSION=1.15.0
+VERSION=2.5.0
 
 # setup
 $PYTHON setup_tensorflow.py -m $MODE -p $PLATFORM -c $CONTEXT -v $VERSION

--- a/travis/build_wheels.sh
+++ b/travis/build_wheels.sh
@@ -96,8 +96,7 @@ for PYBIN in /opt/python/cp3*/bin; do
     fi
 
     ESSENTIA_WHEEL_SKIP_3RDPARTY=1 ESSENTIA_WHEEL_ONLY_PYTHON=1 \
-    ESSENTIA_PROJECT_NAME="${PROJECT_NAME}" ESSENTIA_TENSORFLOW_VERSION="${TENSORFLOW_VERSION}" \
-    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    ESSENTIA_PROJECT_NAME="${PROJECT_NAME}" "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 
     # Bundle external shared libraries into the essentia wheel now because
     # the tensorflow libraries are especific for each package version

--- a/travis/build_wheels.sh
+++ b/travis/build_wheels.sh
@@ -46,7 +46,7 @@ for PYBIN in /opt/python/cp3*/bin; do
     # https://github.com/MacPython/scikit-learn-wheels/blob/master/.travis.yml
 
     # Python 2.7
-    NUMPY_VERSION=1.8.2
+    # NUMPY_VERSION=1.8.2
 
     # Python 3.x
     if [[ $PYBIN == *"cp39"* ]]; then
@@ -57,8 +57,8 @@ for PYBIN in /opt/python/cp3*/bin; do
         NUMPY_VERSION=1.14.5
     elif [[ $PYBIN == *"cp36"* ]]; then
         NUMPY_VERSION=1.11.3
-    elif [[ $PYBIN == *"cp34"* ]] || [[ $PYBIN == *"cp35"* ]]; then
-        NUMPY_VERSION=1.9.3
+    # elif [[ $PYBIN == *"cp34"* ]] || [[ $PYBIN == *"cp35"* ]]; then
+    #     NUMPY_VERSION=1.9.3
     fi
 
     "${PYBIN}/pip" install numpy==$NUMPY_VERSION

--- a/travis/build_wheels.sh
+++ b/travis/build_wheels.sh
@@ -25,16 +25,7 @@ PYBIN=/opt/python/cp36-cp36m/bin/
 cd /io
 
 if [[ $WITH_TENSORFLOW ]]; then
-# Build essentia with tensorflow support using tensorflow 2.5.0 as it is the
-# newest version supported by the C API. It is backwards compatible for 1.X.X
-# https://www.tensorflow.org/guide/versions
-# Tensroflow >= 2.0 do not support libtensorflow for now
-# https://www.tensorflow.org/install/lang_c
     PROJECT_NAME='essentia-tensorflow'
-    TENSORFLOW_VERSION=2.5.0
-
-    "${PYBIN}/pip" install tensorflow==$TENSORFLOW_VERSION
-    "${PYBIN}/python" src/3rdparty/tensorflow/setup_tensorflow.py -m python -c "${PREFIX}"
     "${PYBIN}/python" waf configure --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path="${PKG_CONFIG_PATH}"
 else
     PROJECT_NAME='essentia'
@@ -47,59 +38,35 @@ cd -
 
 # Compile wheels
 for PYBIN in /opt/python/cp3*/bin; do
-    # Don't build for python 3.8 while tensorflow doesn't create wheels for it
-    # https://github.com/tensorflow/addons/issues/744
-    if [[ $WITH_TENSORFLOW ]] && [[ $PYBIN == *"cp38"* ]]; then break; fi
-    if [[ $WITH_TENSORFLOW ]] && [[ $PYBIN == *"cp39"* ]]; then break; fi
-
-    if [[ $WITH_TENSORFLOW ]]; then
-    # The minimum numpy version required by tensorflow is always greater than
-    # the installed one. Install the oldest numpy supported by each tensorflow
-    # to get the maximum fordwards compatibility
-        NUMPY_VERSION=$( "${PYBIN}/pip" check tensorflow |grep tensorflow |grep numpy |grep ">=" |awk -F"[>=',]+" '//{print $2}' )
-
-        if [[ ${NUMPY_VERSION} ]]; then
-            echo "Got numpy ${NUMPY_VERSION} from the Tensorflow requirements"
-            "${PYBIN}/pip" install numpy==$NUMPY_VERSION
-        fi
-
-        "${PYBIN}/pip" install tensorflow==$TENSORFLOW_VERSION
-
-        # Make the tensorflow symbolic links point to the shared libraries
-        # installed with the tensorflow wheel
-        "${PYBIN}/python" /io/src/3rdparty/tensorflow/setup_tensorflow.py -m python -c "${PREFIX}"
-
-    else
     # Use the oldest version of numpy for each Python version
     # for backwards compatibility of its C API
     # https://github.com/numpy/numpy/issues/5888
     # Build numpy versions used by scikit-learn:
     # https://github.com/MacPython/scikit-learn-wheels/blob/master/.travis.yml
 
-        # Python 2.7
-        NUMPY_VERSION=1.8.2
+    # Python 2.7
+    NUMPY_VERSION=1.8.2
 
-        # Python 3.x
-        if [[ $PYBIN == *"cp39"* ]]; then
-            NUMPY_VERSION=1.19.3
-        elif [[ $PYBIN == *"cp38"* ]]; then
-            NUMPY_VERSION=1.17.4
-        elif [[ $PYBIN == *"cp37"* ]]; then
-            NUMPY_VERSION=1.14.5
-        elif [[ $PYBIN == *"cp36"* ]]; then
-            NUMPY_VERSION=1.11.3
-        elif [[ $PYBIN == *"cp34"* ]] || [[ $PYBIN == *"cp35"* ]]; then
-            NUMPY_VERSION=1.9.3
-        fi
-
-        "${PYBIN}/pip" install numpy==$NUMPY_VERSION
+    # Python 3.x
+    if [[ $PYBIN == *"cp39"* ]]; then
+        NUMPY_VERSION=1.19.3
+    elif [[ $PYBIN == *"cp38"* ]]; then
+        NUMPY_VERSION=1.17.4
+    elif [[ $PYBIN == *"cp37"* ]]; then
+        NUMPY_VERSION=1.14.5
+    elif [[ $PYBIN == *"cp36"* ]]; then
+        NUMPY_VERSION=1.11.3
+    elif [[ $PYBIN == *"cp34"* ]] || [[ $PYBIN == *"cp35"* ]]; then
+        NUMPY_VERSION=1.9.3
     fi
+
+    "${PYBIN}/pip" install numpy==$NUMPY_VERSION
 
     ESSENTIA_WHEEL_SKIP_3RDPARTY=1 ESSENTIA_WHEEL_ONLY_PYTHON=1 \
     ESSENTIA_PROJECT_NAME="${PROJECT_NAME}" "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 
     # Bundle external shared libraries into the essentia wheel now because
-    # the tensorflow libraries are especific for each package version
+    # the tensorflow libraries are specific for each package version
     for whl in wheelhouse/*.whl; do
         PYVERSION=$( echo "$PYBIN" |cut -d/ -f4 )
 
@@ -128,12 +95,11 @@ done
 
 # Install and test
 for PYBIN in /opt/python/cp3*/bin/; do
-    # Skip essentia-tensorflow until it is available for Python 3.8
-    if [[ $WITH_TENSORFLOW ]] && [[ $PYBIN == *"cp38"* ]]; then break; fi
-
     "${PYBIN}/pip" install "${PROJECT_NAME}" --no-index -f /io/wheelhouse
     if [[ $WITH_TENSORFLOW ]]; then
-    # Test that essentia can be imported along with tensorflow
+    # Test that essentia can be imported along with TensorFlow
+        TENSORFLOW_VERSION=2.5.0
+        "${PYBIN}/pip" install tensorflow==${TENSORFLOW_VERSION}
         (cd "$HOME"; ${PYBIN}/python -c 'import essentia; import essentia.standard; import essentia.streaming; import tensorflow')
     else
         (cd "$HOME"; ${PYBIN}/python -c 'import essentia; import essentia.standard; import essentia.streaming')

--- a/travis/build_wheels.sh
+++ b/travis/build_wheels.sh
@@ -17,6 +17,7 @@ set -e -x
 # We are dropping support for Python 3.4 since PyYaml is not supporting it anymore.
 # We can just remove the Python3.4 folder until ManyLinux1 drops the support too.
 rm -rf /opt/python/cp34-cp34m
+rm -rf /opt/python/cp35-cp35m
 
 # Build static libessentia.a library
 # Use Python3.6. CentOS 5's native python is too old...

--- a/travis/build_wheels.sh
+++ b/travis/build_wheels.sh
@@ -25,13 +25,13 @@ PYBIN=/opt/python/cp36-cp36m/bin/
 cd /io
 
 if [[ $WITH_TENSORFLOW ]]; then
-# Build essentia with tensorflow support using tensorflow 1.15.0 as it is the
+# Build essentia with tensorflow support using tensorflow 2.5.0 as it is the
 # newest version supported by the C API. It is backwards compatible for 1.X.X
 # https://www.tensorflow.org/guide/versions
 # Tensroflow >= 2.0 do not support libtensorflow for now
 # https://www.tensorflow.org/install/lang_c
     PROJECT_NAME='essentia-tensorflow'
-    TENSORFLOW_VERSION=1.15.0
+    TENSORFLOW_VERSION=2.5.0
 
     "${PYBIN}/pip" install tensorflow==$TENSORFLOW_VERSION
     "${PYBIN}/python" src/3rdparty/tensorflow/setup_tensorflow.py -m python -c "${PREFIX}"


### PR DESCRIPTION
Update the `build_tensorflow.sh` and TensorFlow dependency version.

Now TensorFlow is built with Bazel on its monolithic configuration. This is a shared library with an almost static behavior.
Critically, the monolithic version of `libtensorflow.so` does not depend on `framework_tensorflow.so` which contains the capability to register ops from outside the library and was the cause of the clash with the TensorFlow wheel.

Also, the `essentia-tensorflow` wheels are linked against our TensorFlow build, so TensorFlow is not a Python setup dependency anymore.

This approach gives us the capability to make `essentia-tensorflow` wheels up to the latest Python version (3.9 at the moment).