### PR TITLE
Remove metaGraphDef variable

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredict.h
+++ b/src/algorithms/machinelearning/tensorflowpredict.h
@@ -56,7 +56,6 @@ class TensorflowPredict : public Algorithm {
   std::string _savedModel;
   std::vector<std::string> _tags;
   TF_Buffer* _runOptions;
-  TF_Buffer* _metaGraphDef;
 
   bool _isTraining;
   bool _isTrainingSet;


### PR DESCRIPTION
Small PR to remove unused `metaGraphDef` variable from `TensorflowPredict`