### PR TITLE
Handle unsuccessful load of savedModel

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredict.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredict.cpp
@@ -129,6 +129,10 @@ void TensorflowPredict::openGraph() {
       _savedModel.c_str(), &tags_c[0], (int)tags_c.size(),
       _graph, NULL, _status);
 
+      if (TF_GetCode(_status) != TF_OK) {
+        throw EssentiaException("TensorflowPredict: Error importing SavedModel. ", TF_Message(_status));
+      }
+
     E_INFO("Successfully loaded SavedModel: `" << _savedModel << "`");
     return;
   }

--- a/src/algorithms/machinelearning/tensorflowpredict.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredict.cpp
@@ -130,7 +130,7 @@ void TensorflowPredict::openGraph() {
       _graph, NULL, _status);
 
       if (TF_GetCode(_status) != TF_OK) {
-        throw EssentiaException("TensorflowPredict: Error importing SavedModel. ", TF_Message(_status));
+        throw EssentiaException("TensorflowPredict: Error importing SavedModel specified in the `savedModel` parameter. ", TF_Message(_status));
       }
 
     E_INFO("Successfully loaded SavedModel: `" << _savedModel << "`");

--- a/test/src/unittests/machinelearning/test_tensorflowpredict.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredict.py
@@ -102,7 +102,7 @@ class TestTensorFlowPredict(TestCase):
         self.regression(parameters)
 
     def testEmptyModelName(self):
-        # With empty model names the algorithm should skip the configuration without errors.
+        # With empty model name the algorithm should skip the configuration without errors.
         self.assertConfigureSuccess(TensorflowPredict(), {})
         self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': ''})
         self.assertConfigureSuccess(TensorflowPredict(), {'graphFilename': '',
@@ -141,6 +141,21 @@ class TestTensorFlowPredict(TestCase):
                                                         'outputs': ['model/Softmax'],
                                                         })  # input does not exist in the model
         self.assertConfigureFails(TensorflowPredict(), {'graphFilename': 'wrong_model_name',
+                                                        'inputs': ['model/Placeholder'],
+                                                        'outputs': ['model/Softmax'],
+                                                        })  # the model does not exist
+        
+        # Repeat tests for savedModel format.
+        model = join(testdata.models_dir, 'vgg', 'vgg4/')
+        self.assertConfigureFails(TensorflowPredict(), {'savedModel': model})  # inputs and outputs are not defined
+        self.assertConfigureFails(TensorflowPredict(), {'savedModel': model,
+                                                        'inputs': ['model/Placeholder'],
+                                                       })  # outputs are not defined
+        self.assertConfigureFails(TensorflowPredict(), {'savedModel': model,
+                                                        'inputs': ['wrong_input_name'],
+                                                        'outputs': ['model/Softmax'],
+                                                        })  # input does not exist in the model
+        self.assertConfigureFails(TensorflowPredict(), {'savedModel': 'wrong_model_name',
                                                         'inputs': ['model/Placeholder'],
                                                         'outputs': ['model/Softmax'],
                                                         })  # the model does not exist


### PR DESCRIPTION
Throw an exception if a `savedModel` is not loaded successfully.
This solution mimics the way we handle unsuccessful load of protocol buffers (`graphFilename`)