### PR TITLE
Remove outdated check

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredictcrepe.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictcrepe.cpp
@@ -194,8 +194,6 @@ void TensorflowPredictCREPE::createInnerNetwork() {
 
 
 void TensorflowPredictCREPE::configure() {
-  // If no file has been specified, do not do anything.
-  if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictCREPE->configure(INHERIT("graphFilename"),
                                      INHERIT("input"),
                                      INHERIT("output"),

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
@@ -189,8 +189,6 @@ void TensorflowPredictMusiCNN::createInnerNetwork() {
 
 
 void TensorflowPredictMusiCNN::configure() {
-  // if no file has been specified, do not do anything
-  if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictMusiCNN->configure(INHERIT("graphFilename"),
                                        INHERIT("savedModel"),
                                        INHERIT("input"),

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
@@ -209,8 +209,6 @@ void TensorflowPredictTempoCNN::createInnerNetwork() {
 
 
 void TensorflowPredictTempoCNN::configure() {
-  // if no file has been specified, do not do anything
-  if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictTempoCNN->configure(INHERIT("graphFilename"),
                                         INHERIT("savedModel"),
                                         INHERIT("input"),

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
@@ -189,8 +189,6 @@ void TensorflowPredictVGGish::createInnerNetwork() {
 
 
 void TensorflowPredictVGGish::configure() {
-  // if no file has been specified, do not do anything
-  if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictVGGish->configure(INHERIT("graphFilename"),
                                       INHERIT("savedModel"),
                                       INHERIT("input"),


### PR DESCRIPTION
Now `graphFilename` defaults to an empty string, so it's always configured
and this check doesn't make sense.