### PR TITLE
Fix squeeze bug

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredict.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredict.cpp
@@ -249,7 +249,7 @@ TF_Tensor* TensorflowPredict::TensorToTF(
   int dims = 1;
   vector<int64_t> shape;
 
-  // Batch dimensions is the only one allowed to be singleton
+  // With squeeze, the Batch dimension is the only one allowed to be singleton
   shape.push_back((int64_t)tensorIn.dimension(0));
 
   if (_squeeze) {
@@ -259,6 +259,13 @@ TF_Tensor* TensorflowPredict::TensorToTF(
         dims++;
       }
     }
+
+    // There should be at least 2 dimensions (batch, data)
+    if (dims == 1) {
+      shape.push_back((int64_t) 1);
+      dims++;
+    }
+
   } else {
     dims = tensorIn.rank();
     for(int i = 1; i < dims; i++) {


### PR DESCRIPTION
There should be at least 2 dimensions (batch, data)

This fixes a segmentation fault that happens when you feed a scalar input (i.e., `shape(1,1,1,1)`).
However, I didn't prepare a test because we don't have models that work with scalars. 
I could create a TensorFlow model consisting of a single identity layer expecting a scalar, but this is probably a corner case without practical applications for which we don't want to store an additional model.