### PR TITLE
Implement parameters SaverFilename and SaverFilenameSet

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredict.h
+++ b/src/algorithms/machinelearning/tensorflowpredict.h
@@ -63,6 +63,10 @@ class TensorflowPredict : public Algorithm {
 
   bool _squeeze;
 
+  bool _saverFilenameSet;
+  std::string _saverFilename;
+  bool _usingSavedModel;
+
   void openGraph();
   TF_Tensor* TensorToTF(const Tensor<Real>& tensorIn);
   const Tensor<Real> TFToTensor(const TF_Tensor* tensor, TF_Output node);
@@ -101,6 +105,13 @@ class TensorflowPredict : public Algorithm {
     declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("tags", "the tags of the savedModel", "", defaultTags);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
     declareParameter("inputs", "will look for these namespaces in poolIn. Should match the names of the input nodes in the Tensorflow graph", "", Parameter::VECTOR_STRING);
     declareParameter("outputs", "will save the tensors on the graph nodes named after `outputs` to the same namespaces in the output pool. Set the first element of this list as an empty array to print all the available nodes in the graph", "", Parameter::VECTOR_STRING);
     declareParameter("isTraining", "run the model in training mode (normalized with statistics of the current batch) instead of inference mode (normalized with moving statistics). This only applies to some models", "{true,false}", false);

--- a/src/algorithms/machinelearning/tensorflowpredictcrepe.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictcrepe.cpp
@@ -123,9 +123,14 @@ void TensorflowPredictCREPE::configure() {
 
   string graphFilename = parameter("graphFilename").toString();
 
+  string saverFilename = parameter("saverFilename").toString();
+  bool saverFilenameSet = parameter("saverFilenameSet").toBool();
+
   _tensorflowPredict->configure("graphFilename", graphFilename,
                                 "inputs", vector<string>({input}),
-                                "outputs", vector<string>({output}));
+                                "outputs", vector<string>({output}),
+                                "saverFilename", saverFilename,
+                                "saverFilenameSet", saverFilenameSet);
 }
 
 } // namespace streaming
@@ -200,7 +205,9 @@ void TensorflowPredictCREPE::configure() {
                                      INHERIT("input"),
                                      INHERIT("output"),
                                      INHERIT("hopSize"),
-                                     INHERIT("batchSize"));
+                                     INHERIT("batchSize"),
+                                     INHERIT("saverFilename"),
+                                     INHERIT("saverFilenameSet"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredictcrepe.h
+++ b/src/algorithms/machinelearning/tensorflowpredictcrepe.h
@@ -63,6 +63,13 @@ class TensorflowPredictCREPE : public AlgorithmComposite {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);
     declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void declareProcessOrder() {
@@ -112,6 +119,13 @@ class TensorflowPredictCREPE : public Algorithm {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);
     declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
@@ -121,11 +121,16 @@ void TensorflowPredictMusiCNN::configure() {
   string graphFilename = parameter("graphFilename").toString();
   string savedModel = parameter("savedModel").toString();
 
+  string saverFilename = parameter("saverFilename").toString();
+  bool saverFilenameSet = parameter("saverFilenameSet").toBool();
+
   _tensorflowPredict->configure("graphFilename", graphFilename,
                                 "savedModel", savedModel,
                                 "inputs", vector<string>({input}),
                                 "outputs", vector<string>({output}),
-                                "isTrainingName", isTrainingName);
+                                "isTrainingName", isTrainingName,
+                                "saverFilename", saverFilename,
+                                "saverFilenameSet", saverFilenameSet);
 }
 
 } // namespace streaming
@@ -198,7 +203,9 @@ void TensorflowPredictMusiCNN::configure() {
                                        INHERIT("isTrainingName"),
                                        INHERIT("patchHopSize"),
                                        INHERIT("accumulate"),
-                                       INHERIT("lastPatchMode"));
+                                       INHERIT("accumulate"),
+                                       INHERIT("saverFilename"),
+                                       INHERIT("saverFilenameSet"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
@@ -61,6 +61,13 @@ class TensorflowPredictMusiCNN : public AlgorithmComposite {
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single TensorFlow session at the end of the stream. Otherwise, a session is run for every new patch", "{true,false}", false);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void declareProcessOrder() {
@@ -113,6 +120,13 @@ class TensorflowPredictMusiCNN : public Algorithm {
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
@@ -135,11 +135,16 @@ void TensorflowPredictTempoCNN::configure() {
   string graphFilename = parameter("graphFilename").toString();
   string savedModel = parameter("savedModel").toString();
 
+  string saverFilename = parameter("saverFilename").toString();
+  bool saverFilenameSet = parameter("saverFilenameSet").toBool();
+
   _tensorflowPredict->configure("graphFilename", graphFilename,
                                 "savedModel", savedModel,
                                 "squeeze", false,
                                 "inputs", vector<string>({input}),
-                                "outputs", vector<string>({output}));
+                                "outputs", vector<string>({output}),
+                                "saverFilename", saverFilename,
+                                "saverFilenameSet", saverFilenameSet);
 }
 
 } // namespace streaming
@@ -217,7 +222,9 @@ void TensorflowPredictTempoCNN::configure() {
                                         INHERIT("output"),
                                         INHERIT("patchHopSize"),
                                         INHERIT("batchSize"),
-                                        INHERIT("lastPatchMode"));
+                                        INHERIT("lastPatchMode"),
+                                        INHERIT("saverFilename"),
+                                        INHERIT("saverFilenameSet"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
@@ -62,6 +62,13 @@ class TensorflowPredictTempoCNN : public AlgorithmComposite {
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("batchSize", "number of patches to process in parallel. Use -1 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void declareProcessOrder() {
@@ -113,6 +120,13 @@ class TensorflowPredictTempoCNN : public Algorithm {
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("batchSize", "number of patches to process in parallel. Use -1 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
@@ -120,11 +120,16 @@ void TensorflowPredictVGGish::configure() {
   string graphFilename = parameter("graphFilename").toString();
   string savedModel = parameter("savedModel").toString();
 
+  string saverFilename = parameter("saverFilename").toString();
+  bool saverFilenameSet = parameter("saverFilenameSet").toBool();
+
   _tensorflowPredict->configure("graphFilename", graphFilename,
                                 "savedModel", savedModel,
                                 "inputs", vector<string>({input}),
                                 "outputs", vector<string>({output}),
-                                "isTrainingName", isTrainingName);
+                                "isTrainingName", isTrainingName,
+                                "saverFilename", saverFilename,
+                                "saverFilenameSet", saverFilenameSet);
 }
 
 } // namespace streaming
@@ -198,7 +203,9 @@ void TensorflowPredictVGGish::configure() {
                                       INHERIT("isTrainingName"),
                                       INHERIT("patchHopSize"),
                                       INHERIT("accumulate"),
-                                      INHERIT("lastPatchMode"));
+                                      INHERIT("lastPatchMode"),
+                                      INHERIT("saverFilename"),
+                                      INHERIT("saverFilenameSet"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.h
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.h
@@ -61,6 +61,13 @@ class TensorflowPredictVGGish : public AlgorithmComposite {
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single TensorFlow session at the end of the stream. Otherwise, a session is run for every new patch", "{true,false}", false);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void declareProcessOrder() {
@@ -113,6 +120,13 @@ class TensorflowPredictVGGish : public Algorithm {
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void configure();

--- a/src/algorithms/rhythm/tempocnn.cpp
+++ b/src/algorithms/rhythm/tempocnn.cpp
@@ -73,7 +73,9 @@ void TempoCNN::configure() {
                                         INHERIT("output"),
                                         INHERIT("patchHopSize"),
                                         INHERIT("lastPatchMode"),
-                                        INHERIT("batchSize"));
+                                        INHERIT("batchSize"),
+                                        INHERIT("saverFilename"),
+                                        INHERIT("saverFilenameSet"));
 
   _aggregationMethod = parameter("aggregationMethod").toLower();
 }

--- a/src/algorithms/rhythm/tempocnn.h
+++ b/src/algorithms/rhythm/tempocnn.h
@@ -63,7 +63,13 @@ class TempoCNN : public Algorithm {
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("batchSize", "number of patches to process in parallel. Use -1 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
     declareParameter("aggregationMethod", "method used to estimate the global tempo.", "{majority,mean,median}", "majority");
-
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
   }
 
   void configure();

--- a/src/algorithms/tonal/pitchcrepe.cpp
+++ b/src/algorithms/tonal/pitchcrepe.cpp
@@ -62,7 +62,9 @@ void PitchCREPE::configure() {
                                      INHERIT("input"),
                                      INHERIT("output"),
                                      INHERIT("hopSize"),
-                                     INHERIT("batchSize"));
+                                     INHERIT("batchSize"),
+                                     INHERIT("saverFilename"),
+                                     INHERIT("saverFilenameSet"));
 
   _hopSize = parameter("hopSize").toFloat();
   // _viterbi = parameter("viterbi").toBool();

--- a/src/algorithms/tonal/pitchcrepe.h
+++ b/src/algorithms/tonal/pitchcrepe.h
@@ -71,6 +71,13 @@ class PitchCREPE : public Algorithm {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimation", "(0,inf)", 10.0);
     declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end", "[-1,inf)", -1);
+    // We have noticed that most of the SavedModels expect a `saver_filename` input tensor. While TensorFlow doesn't provide
+    // official documentation, we found that this allows to re-save the model after a modification of the parameters:
+    // https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d
+    // While we are not planning to support neither parameter modification nor model saving, we provide a functionality to set
+    // this tensor to an arbitrary string to allow inference when this tensor is required.
+    declareParameter("saverFilenameSet", "whether to set an additional `saver_filename` string input tensor with a value given by the saverFilename parameter. This option only applies for SavedModel input format.", "{true,false}", true);
+    declareParameter("saverFilename", "the value of the additional `saver_filename` string input tensor.", "", "");
     // CREPE implements temporal smoothing via Viterbi but it is not applied by default and we will leave it unimplemented for now.
     // declareParameter("viterbi", "whether to use Viterbi decoding for temporal smoothing", "{true,false}", true);
   }

--- a/test/src/unittests/machinelearning/test_tensorflowpredict.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredict.py
@@ -83,6 +83,9 @@ class TestTensorFlowPredict(TestCase):
             'outputs': ['model/Softmax'],
             'isTraining': False,
             'isTrainingName': 'model/Placeholder_1',
+            # The SavedModel version of this model was created with TensorFlow 1
+            # so it does not expect a saver_filename input.
+            'saverFilenameSet': False,
         }
 
         self.regression(parameters)
@@ -97,6 +100,9 @@ class TestTensorFlowPredict(TestCase):
             'outputs': ['model/Softmax'],
             'isTraining': False,
             'isTrainingName': 'model/Placeholder_1',
+            # The SavedModel version of this model was created with TensorFlow 1
+            # so it does not expect a saver_filename input.
+            'saverFilenameSet': False,
         }
 
         self.regression(parameters)

--- a/test/src/unittests/machinelearning/test_tensorflowpredictmusicnn.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredictmusicnn.py
@@ -45,7 +45,9 @@ class TestTensorFlowPredictMusiCNN(TestCase):
         model = join(testdata.models_dir, 'musicnn', 'genre_dortmund_musicnn_msd')
 
         audio = MonoLoader(filename=filename, sampleRate=16000)()
-        found = TensorflowPredictMusiCNN(savedModel=model)(audio)[0]
+
+        # This SavedModel was created with TensorFlow 1 so it does not expect a saver_filename input.
+        found = TensorflowPredictMusiCNN(savedModel=model, saverFilenameSet=False)(audio)[0]
 
         self.assertAlmostEqualVector(found, expected, 1e-5)
 

--- a/test/src/unittests/machinelearning/test_tensorflowpredicttempocnn.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredicttempocnn.py
@@ -102,7 +102,8 @@ class TestTensorflowPredictTempoCNN(TestCase):
         self.regression({'graphFilename': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb')})
 
     def testRegressionSavedModel(self):
-        self.regression({'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16')})
+        # This SavedModel was created with TensorFlow 1 so it does not expect a saver_filename input.
+        self.regression({'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16'), 'saverFilenameSet': False})
 
     def testEmptyInput(self):
         model = join(testdata.models_dir, 'tempocnn', 'deeptemp_k16.pb')

--- a/test/src/unittests/machinelearning/test_tensorflowpredictvggish.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredictvggish.py
@@ -47,7 +47,9 @@ class TestTensorFlowPredictVGGish(TestCase):
         model = join(testdata.models_dir, 'vggish', 'small_vggish_init')
 
         audio = MonoLoader(filename=filename, sampleRate=16000)()
-        found = TensorflowPredictVGGish(savedModel=model, patchHopSize=0)(audio)
+
+        # This SavedModel was created with TensorFlow 1 so it does not expect a saver_filename input.
+        found = TensorflowPredictVGGish(savedModel=model, patchHopSize=0, saverFilenameSet=False)(audio)
         found = numpy.mean(found, axis=0)
 
         # Setting a high tolerance value due to the mismatch between the

--- a/test/src/unittests/rhythm/test_tempocnn.py
+++ b/test/src/unittests/rhythm/test_tempocnn.py
@@ -64,6 +64,8 @@ class TestTempoCNN(TestCase):
         parameters = {
             'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16'),
             'aggregationMethod':'majority',
+            # This SavedModel was created with TensorFlow 1 so it does not expect a saver_filename input.
+            'saverFilenameSet': False,
         }
         self.regression(parameters)
 
@@ -71,6 +73,8 @@ class TestTempoCNN(TestCase):
         parameters = {
             'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16'),
             'aggregationMethod':'mean',
+            # This SavedModel was created with TensorFlow 1 so it does not expect a saver_filename input.
+            'saverFilenameSet': False,
         }
         self.regression(parameters)
 
@@ -78,6 +82,8 @@ class TestTempoCNN(TestCase):
         parameters = {
             'savedModel': join(testdata.models_dir, 'tempocnn', 'deeptemp_k16'),
             'aggregationMethod':'median',
+            # This SavedModel was created with TensorFlow 1 so it does not expect a saver_filename input.
+            'saverFilenameSet': False,
         }
         self.regression(parameters)
 


### PR DESCRIPTION
This PR is a follow-up to #1161 that extends the support of TensorFlow `SavedModel` format.
While #1161 allowed reading `SavedModel`s, we found that sometimes those models require a `saver_filename` input tensor.
We found that this tensor is required when the `SavedModel` is created via:
- TensorFlow 2.X/Keras APIs (https://www.tensorflow.org/tutorials/keras/save_and_load)
- ONNX-TF backend (https://github.com/onnx/onnx-tensorflow)

However, we found that TensorFlow 1.X offers the possibility to transform a frozen model (.pb) to `SavedModel` and in this case `saver_filename` is not required.

According to [this blog](https://towardsdatascience.com/include-training-operations-in-saved-models-with-tensorflow-2-6494d304036d), the goal of `saver_filename` is to provide `SavelModel`s with a capability to be saved from low level APIs, but as it is not documented this feature would be probably changed or removed in the future.

For now, we are not interested in having model saving capabilities (as we don't support any way to modify the weights), so we will just pass the model a `saver_filename` input tensor string when needed to be able to do inference.
The value of this string can be modified with  the `saverFilename` parameter, but this won't have any effect for now, and it is only there considering the case in which we want to support model finetuning/saving in the future.
To support all the known scenarios, we provide a boolean parameter `saverFilenameSet` to  prevent passing `saver_filename` to the model when needed (e.g., in the `SavedModel`s we created from our .pbs for testing purposes).
 