### PR TITLE
Support SavedModels in Crepe

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredictcrepe.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictcrepe.cpp
@@ -117,13 +117,12 @@ void TensorflowPredictCREPE::configure() {
 
   _poolToTensor->configure("namespace", output);
 
-  Parameter graphFilenameParam = parameter("graphFilename");
-  // if no file has been specified, do not do anything else
-  if (!graphFilenameParam.isConfigured()) return;
 
   string graphFilename = parameter("graphFilename").toString();
+  string savedModel = parameter("savedModel").toString();
 
   _tensorflowPredict->configure("graphFilename", graphFilename,
+                                "savedModel", savedModel,
                                 "inputs", vector<string>({input}),
                                 "outputs", vector<string>({output}));
 }
@@ -197,6 +196,7 @@ void TensorflowPredictCREPE::configure() {
   // If no file has been specified, do not do anything.
   if (!parameter("graphFilename").isConfigured()) return;
   _tensorflowPredictCREPE->configure(INHERIT("graphFilename"),
+                                     INHERIT("savedModel"),
                                      INHERIT("input"),
                                      INHERIT("output"),
                                      INHERIT("hopSize"),

--- a/src/algorithms/machinelearning/tensorflowpredictcrepe.h
+++ b/src/algorithms/machinelearning/tensorflowpredictcrepe.h
@@ -58,7 +58,8 @@ class TensorflowPredictCREPE : public AlgorithmComposite {
   ~TensorflowPredictCREPE();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);
@@ -107,7 +108,8 @@ class TensorflowPredictCREPE : public Algorithm {
   ~TensorflowPredictCREPE();
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);

--- a/src/algorithms/tonal/pitchcrepe.cpp
+++ b/src/algorithms/tonal/pitchcrepe.cpp
@@ -59,6 +59,7 @@ const char* PitchCREPE::description = DOC(
 
 void PitchCREPE::configure() {
   _tensorflowPredictCREPE->configure(INHERIT("graphFilename"),
+                                     INHERIT("savedModel"),
                                      INHERIT("input"),
                                      INHERIT("output"),
                                      INHERIT("hopSize"),

--- a/src/algorithms/tonal/pitchcrepe.h
+++ b/src/algorithms/tonal/pitchcrepe.h
@@ -66,7 +66,8 @@ class PitchCREPE : public Algorithm {
   }
 
   void declareParameters() {
-    declareParameter("graphFilename", "the name of the file containing the model to use", "", Parameter::STRING);
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimation", "(0,inf)", 10.0);

--- a/test/src/unittests/machinelearning/test_tensorflowpredictcrepe.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredictcrepe.py
@@ -22,7 +22,7 @@ from essentia_test import *
 
 class TestTensorflowPredictCREPE(TestCase):
 
-    def testRegression(self):
+    def regression(self, parameters):
         expected_activations = numpy.load(
             join(filedir(),
             'tensorflowpredict_crepe',
@@ -33,9 +33,17 @@ class TestTensorflowPredictCREPE(TestCase):
         model = join(testdata.models_dir, 'crepe', 'crepe-tiny-1.pb')
 
         audio = MonoLoader(filename=filename, sampleRate=16000)()
-        activations = TensorflowPredictCREPE(graphFilename=model)(audio)
+        activations = TensorflowPredictCREPE(**parameters)(audio)
 
         self.assertAlmostEqualMatrix(activations, expected_activations, 1e-2)
+
+
+    def testRegressionGraphFilename(self):
+        self.regression({'graphFilename': join(testdata.models_dir, 'crepe', 'crepe-tiny-1.pb')})
+
+    def testRegressionSavedModel(self):
+        self.regression({'savedModel': join(testdata.models_dir, 'crepe', 'crepe-tiny-1')})
+
 
     def testEmptyModelName(self):
         # With empty or undefined model names the algorithm should skip the configuration


### PR DESCRIPTION
This change makes this algorithm consistent with other algorithms from the TensorflowPredict* family
(Remake of #1216)