### PR TITLE
Add patchSize parameter

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
@@ -91,6 +91,7 @@ void TensorflowPredictMusiCNN::configure() {
   int patchHopSize = parameter("patchHopSize").toInt();
   string lastPatchMode = parameter("lastPatchMode").toString();
   bool accumulate = parameter("accumulate").toBool();
+  int patchSize = parameter("patchSize").toInt();
 
   int batchSize = accumulate ? -1 : 1;
 
@@ -98,7 +99,6 @@ void TensorflowPredictMusiCNN::configure() {
   // https://github.com/jordipons/musicnn-training/blob/master/src/config_file.py
   int frameSize = 512;
   int hopSize = 256;
-  int patchSize = 187;
   int numberBands = 96;
   vector<int> inputShape({batchSize, 1, patchSize, numberBands});
 
@@ -196,7 +196,8 @@ void TensorflowPredictMusiCNN::configure() {
                                        INHERIT("isTrainingName"),
                                        INHERIT("patchHopSize"),
                                        INHERIT("accumulate"),
-                                       INHERIT("lastPatchMode"));
+                                       INHERIT("lastPatchMode"),
+                                       INHERIT("patchSize"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
@@ -61,6 +61,7 @@ class TensorflowPredictMusiCNN : public AlgorithmComposite {
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single TensorFlow session at the end of the stream. Otherwise, a session is run for every new patch", "{true,false}", false);
+    declareParameter("patchSize", "number of frames to feed to the model on each call. This parameter should match the model's expected input shape.", "[0,inf)", 187);
   }
 
   void declareProcessOrder() {
@@ -113,6 +114,7 @@ class TensorflowPredictMusiCNN : public Algorithm {
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("patchSize", "number of frames to feed to the model on each call. This parameter should match the model's expected input shape.", "[0,inf)", 187);
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
@@ -90,6 +90,7 @@ void TensorflowPredictVGGish::configure() {
   int patchHopSize = parameter("patchHopSize").toInt();
   string lastPatchMode = parameter("lastPatchMode").toString();
   bool accumulate = parameter("accumulate").toBool();
+  int patchSize = parameter("patchSize").toInt();
 
   int batchSize = accumulate ? -1 : 1;
 
@@ -97,7 +98,6 @@ void TensorflowPredictVGGish::configure() {
   // https://github.com/tensorflow/models/blob/master/research/audioset/vggish/mel_features.py
   int frameSize = 400;
   int hopSize = 160;
-  int patchSize = 96;
   int numberBands = 64;
   vector<int> inputShape({batchSize, 1, patchSize, numberBands});
 
@@ -196,7 +196,8 @@ void TensorflowPredictVGGish::configure() {
                                       INHERIT("isTrainingName"),
                                       INHERIT("patchHopSize"),
                                       INHERIT("accumulate"),
-                                      INHERIT("lastPatchMode"));
+                                      INHERIT("lastPatchMode"),
+                                      INHERIT("patchSize"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.h
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.h
@@ -61,6 +61,7 @@ class TensorflowPredictVGGish : public AlgorithmComposite {
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single TensorFlow session at the end of the stream. Otherwise, a session is run for every new patch", "{true,false}", false);
+    declareParameter("patchSize", "number of frames to feed to the model on each call. This parameter should match the model's expected input shape.", "[0,inf)", 96);
   }
 
   void declareProcessOrder() {
@@ -113,6 +114,7 @@ class TensorflowPredictVGGish : public Algorithm {
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
     declareParameter("accumulate", "when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("patchSize", "number of frames to feed to the model on each call. This parameter should match the model's expected input shape.", "[0,inf)", 96);
   }
 
   void configure();

--- a/test/src/unittests/machinelearning/test_tensorflowpredictvggish.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredictvggish.py
@@ -40,6 +40,30 @@ class TestTensorFlowPredictVGGish(TestCase):
         # make valid predictions.
         self.assertAlmostEqualVector(found, expected, 1e-2)
 
+    def testPatchSize(self):
+        model = join(testdata.models_dir, 'vggish', 'small_vggish_init.pb')
+        # One second of audio.
+        data = numpy.ones((16000)).astype("float32")
+
+        # VGGish expects a fixed batch size of 96 frames.
+        patch_size = 96
+        TensorflowPredictVGGish(
+            graphFilename=model,
+            patchHopSize=0,
+            patchSize=patch_size,
+        )(data)
+
+        # An exception should be risen otherwise.
+        patch_size = 65
+        self.assertComputeFails(
+            TensorflowPredictVGGish(
+                graphFilename=model,
+                patchHopSize=0,
+                patchSize=patch_size,
+            ),
+            data
+        )
+
     def testRegressionSavedModel(self):
         expected = [0.49044114, 0.50241125]
 


### PR DESCRIPTION
Adds a  `patchSize` parameter so that `TensorflowPredictMusiCNN` and TensorflowPredictVGGish` can be use with derivate models expecting different input patch sizes.

Right now, we test this functionality  by assessing that an incorrect batch size produces an exception in VGGish. This approach can't be followed with MusiCNN as it accepts a dynamic input patch size.