### PR TITLE
VectorRealToTensor fix

### DIFF
--- a/src/algorithms/standard/vectorrealtotensor.cpp
+++ b/src/algorithms/standard/vectorrealtotensor.cpp
@@ -28,7 +28,7 @@ const char* VectorRealToTensor::name = "VectorRealToTensor";
 const char* VectorRealToTensor::category = "Standard";
 const char* VectorRealToTensor::description = DOC("This algorithm generates tensors "
 "out of a stream of input frames. The 4 dimensions of the tensors stand for (batchSize, channels, patchSize, featureSize):\n"
-"  - batchSize: Number of patches per tensor. If batchSize is set to 0 it will accumulate patches until the end of the stream is reached and then produce a single tensor. "
+"  - batchSize: Number of patches per tensor. If batchSize is set to -1 it will accumulate patches until the end of the stream is reached and then produce a single tensor. "
 "Warning: This option may exhaust memory depending on the size of the stream.\n"
 "  - channels: Number of channels per tensor. Currently, only single-channel tensors are supported. Otherwise, an exception is thrown.\n"
 "  - patchSize: Number of timestamps (i.e., number of frames) per patch.\n"

--- a/src/algorithms/standard/vectorrealtotensor.h
+++ b/src/algorithms/standard/vectorrealtotensor.h
@@ -42,7 +42,7 @@ class VectorRealToTensor : public Algorithm {
   std::vector<std::vector<std::vector<Real> > > _acc;
 
  public:
-  VectorRealToTensor(){
+  VectorRealToTensor() : _push(false), _accumulate(false) {
     declareInput(_frame, 187,"frame", "the input frames");
     declareOutput(_tensor, 1, "tensor", "the accumulated frame in one single tensor");
   }

--- a/test/src/unittests/streaming/test_vectorrealtotensor.py
+++ b/test/src/unittests/streaming/test_vectorrealtotensor.py
@@ -157,6 +157,54 @@ class TestVectorRealToTensor(TestCase):
         self.assertAlmostEqualMatrix(found, expected, 1e-8)
 
 
+    def testOutputShapes(self):
+        # Test that the outputs shapes correspond to the expected values.
+
+        frame_size = 1
+        test_lens = (1, 2, 3)
+        for accumulate in (True, False):
+            for n_batches in test_lens:
+                for batch_size in test_lens:
+                    for patch_size in test_lens:
+                        if accumulate:
+                            # With batchSize = -1, the algorithm should return a single batch with as
+                            # many patches as possible
+                            shape = [-1, 1, patch_size, frame_size]
+                            expected_n_batches = 1
+                            expected_batch_shape = [n_batches * batch_size, 1, patch_size, frame_size]
+                        else:
+                            # With a fixed batch size the algorithm should return `n_batches` with a
+                            # fixed batch size.
+                            shape = [batch_size, 1, patch_size, frame_size]
+                            expected_batch_shape = [batch_size, 1, patch_size, frame_size]
+                            expected_n_batches = n_batches
+
+                        fc = FrameCutter(
+                            frameSize=frame_size,
+                            hopSize=frame_size,
+                            startFromZero=True,
+                            lastFrameToEndOfFile=True,
+                        )
+                        vtt = VectorRealToTensor(
+                            shape=shape,
+                            lastPatchMode="discard",
+                        )
+
+                        n_samples = n_batches * batch_size * patch_size * frame_size
+                        data = numpy.zeros((n_samples), dtype="float32")
+                        vi = VectorInput(data)
+                        pool = Pool()
+
+                        vi.data >> fc.signal
+                        fc.frame >> vtt.frame
+                        vtt.tensor >> (pool, "tensor")
+
+                        run(vi)
+                        batches = pool["tensor"]
+                        self.assertEqual(len(batches), expected_n_batches)
+                        for batch in batches:
+                            self.assertEqualVector(batch.shape, expected_batch_shape)
+
 suite = allTests(TestVectorRealToTensor)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a bug because of an uninitialized variable in `VectorRealToTensor`:  `_accumulate`

`_accumulate` was only set when the batch size (first dimensions of the parameter `shape`) was set to -1, but its behavior was undefined in any other case. 
https://github.com/palonso/essentia/blob/master/src/algorithms/standard/vectorrealtotensor.cpp#L62

This problem affects a series of algorithms relying in `VectorRealToTensor`:
`TensorflowPredictMusiCNN`, `TensorflowPredictTempoCNN`, `TensorflowPredictVGGish`, and `TensorflowPredictCREPE`