### PR TITLE
Batch size management improvements

### DIFF
--- a/src/algorithms/machinelearning/tensorflowpredictcrepe.h
+++ b/src/algorithms/machinelearning/tensorflowpredictcrepe.h
@@ -63,7 +63,7 @@ class TensorflowPredictCREPE : public AlgorithmComposite {
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU is available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU is available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
   }
 
   void declareProcessOrder() {
@@ -113,7 +113,7 @@ class TensorflowPredictCREPE : public Algorithm {
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU is available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU is available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 16);
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredictcrepe.h
+++ b/src/algorithms/machinelearning/tensorflowpredictcrepe.h
@@ -63,7 +63,7 @@ class TensorflowPredictCREPE : public AlgorithmComposite {
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU is available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
   }
 
   void declareProcessOrder() {
@@ -113,7 +113,7 @@ class TensorflowPredictCREPE : public Algorithm {
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimations", "(0,inf)", 10.0);
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU is available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", -1);
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredicteffnetdiscogs.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicteffnetdiscogs.cpp
@@ -94,10 +94,6 @@ void TensorflowPredictEffnetDiscogs::configure() {
   int patchSize = parameter("patchSize").toInt();
   int batchSize = parameter("batchSize").toInt();
 
-  if (batchSize == 0) {
-    throw EssentiaException("TensorflowPredictEffnetDiscogs: `batchSize` cannot be 0");
-  }
-
   if (patchSize == 0) {
     throw EssentiaException("TensorflowPredictEffnetDiscogs: `patchSize` cannot be 0");
   }
@@ -146,10 +142,11 @@ const char* TensorflowPredictEffnetDiscogs::description = DOC(
   "(mel-spectrograms). It feeds the model with patches of 128 frames and "
   "jumps a constant amount of frames determined by `patchHopSize`.\n"
   "\n"
-  "By setting the `batchSize` parameter to -1 the patches are stored to run a single "
+  "By setting the `batchSize` parameter to -1 or 0 the patches are stored to run a single "
   "TensorFlow session at the end of the stream. This allows to take advantage "
   "of parallelization when GPUs are available, but at the same time it can be "
-  "memory exhausting for long files. This option is not supported by some EffnetDiscogs models.\n"
+  "memory exhausting for long files. "
+  "This option is not supported by some EffnetDiscogs models that require a fixed batch size.\n"
   "\n"
   "The recommended pipeline is as follows::\n"
   "\n"
@@ -215,12 +212,15 @@ void TensorflowPredictEffnetDiscogs::compute() {
 
   vector<Real> paddedSignal;
   int paddingPatches;
-  if (_lastBatchMode == "zeros" || _lastBatchMode == "same") {
-    // Computes the number of patches required to fill the final batch and makes a
-    //  zero-padded copy of the input signal only when needed.
-    paddingPatches = padSignal(*signal, paddedSignal);
-    if (paddingPatches) signal = &paddedSignal;
+  if (_batchSize > 0) {
+    if (_lastBatchMode == "zeros" || _lastBatchMode == "same") {
+      // Computes the number of patches required to fill the final batch and makes a
+      //  zero-padded copy of the input signal only when needed.
+      paddingPatches = padSignal(*signal, paddedSignal);
+      if (paddingPatches) signal = &paddedSignal;
+    }
   }
+
   _vectorInput->setVector(signal);
 
   _network->run();

--- a/src/algorithms/machinelearning/tensorflowpredicteffnetdiscogs.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicteffnetdiscogs.cpp
@@ -105,7 +105,8 @@ void TensorflowPredictEffnetDiscogs::configure() {
 
   _vectorRealToTensor->configure("shape", inputShape,
                                  "lastPatchMode", lastPatchMode,
-                                 "patchHopSize", patchHopSize);
+                                 "patchHopSize", patchHopSize,
+                                 "lastBatchMode", "discard");
 
   _configured = true;
 

--- a/src/algorithms/machinelearning/tensorflowpredicteffnetdiscogs.h
+++ b/src/algorithms/machinelearning/tensorflowpredicteffnetdiscogs.h
@@ -65,7 +65,7 @@ class TensorflowPredictEffnetDiscogs : public AlgorithmComposite {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "PartitionedCall");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap. The default value is 62 frames which corresponds to a prediction rate of 1.008 Hz", "[0,inf)", 62);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 128);
   }
 
@@ -130,7 +130,7 @@ class TensorflowPredictEffnetDiscogs : public Algorithm {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "PartitionedCall");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap. The default value is 62 frames which corresponds to a prediction rate of 1.008 Hz", "[0,inf)", 62);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 128);
     declareParameter("lastBatchMode", "some EffnetDiscogs models operate on a fixed batch size. The options are to `discard` the last patches or to pad with `zeros` to make a final batch. Additionally `same` zero-pads the input but returns only the predictions corresponding to patches with signal", "{discard,zeros,same}", "same");
   }

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.cpp
@@ -92,8 +92,9 @@ void TensorflowPredictMusiCNN::configure() {
   string lastPatchMode = parameter("lastPatchMode").toString();
   bool accumulate = parameter("accumulate").toBool();
   int patchSize = parameter("patchSize").toInt();
+  int batchSize = parameter("batchSize").toInt();
 
-  int batchSize = accumulate ? -1 : 1;
+  if (accumulate) batchSize = -1;
 
   // Hardcoded parameters matching the training setup:
   // https://github.com/jordipons/musicnn-training/blob/master/src/config_file.py
@@ -145,7 +146,7 @@ const char* TensorflowPredictMusiCNN::description = DOC(
   "(mel bands). It feeds the model with patches of 187 mel bands frames and "
   "jumps a constant amount of frames determined by `patchHopSize`.\n"
   "\n"
-  "With the `accumulate` parameter the patches are stored to run a single "
+  "By setting the `batchSize` parameter to -1 or 0 the patches are stored to run a single "
   "TensorFlow session at the end of the stream. This allows to take advantage "
   "of parallelization when GPUs are available, but at the same time it can be "
   "memory exhausting for long files.\n"
@@ -197,7 +198,8 @@ void TensorflowPredictMusiCNN::configure() {
                                        INHERIT("patchHopSize"),
                                        INHERIT("accumulate"),
                                        INHERIT("lastPatchMode"),
-                                       INHERIT("patchSize"));
+                                       INHERIT("patchSize"),
+                                       INHERIT("batchSize"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
@@ -60,7 +60,8 @@ class TensorflowPredictMusiCNN : public AlgorithmComposite {
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "when true it runs a single TensorFlow session at the end of the stream. Otherwise, a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 187);
   }
 
@@ -113,7 +114,8 @@ class TensorflowPredictMusiCNN : public Algorithm {
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 187);
   }
 

--- a/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredictmusicnn.h
@@ -60,7 +60,7 @@ class TensorflowPredictMusiCNN : public AlgorithmComposite {
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(deprecated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
     declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 187);
   }
@@ -114,7 +114,7 @@ class TensorflowPredictMusiCNN : public Algorithm {
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(deprecated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
     declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 187);
   }

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
@@ -159,7 +159,7 @@ const char* TensorflowPredictTempoCNN::description = DOC(
   "extraction (mel bands). It feeds the model with patches of 256 mel bands "
   "frames and jumps a constant amount of frames determined by `patchHopSize`.\n"
   "\n"
-  "With the `batchSize` parameter set to -1 the patches are stored to run a "
+  "With the `batchSize` parameter set to -1 or 0 the patches are stored to run a "
   "single TensorFlow session at the end of the stream. This allows to take "
   "advantage of parallelization when GPUs are available, but at the same time "
   "it can be memory exhausting for long files.\n"

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.cpp
@@ -97,10 +97,6 @@ void TensorflowPredictTempoCNN::configure() {
   string lastPatchMode = parameter("lastPatchMode").toString();
   int batchSize = parameter("batchSize").toInt();
 
-  if (batchSize == 0) {
-    throw EssentiaException("TensorflowPredictTempoCNN: 0 is not a valid `batchSize` value.");
-  }
-
   // Hardcoded parameters matching the training setup:
   // https://github.com/hendriks73/tempo-cnn/blob/master/tempocnn/feature.py
   int frameSize = 1024;

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
@@ -61,7 +61,7 @@ class TensorflowPredictTempoCNN : public AlgorithmComposite {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 64);
   }
 
   void declareProcessOrder() {
@@ -112,7 +112,7 @@ class TensorflowPredictTempoCNN : public Algorithm {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 16);
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
+++ b/src/algorithms/machinelearning/tensorflowpredicttempocnn.h
@@ -61,7 +61,7 @@ class TensorflowPredictTempoCNN : public AlgorithmComposite {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "number of patches to process in parallel. Use -1 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
   }
 
   void declareProcessOrder() {
@@ -112,7 +112,7 @@ class TensorflowPredictTempoCNN : public Algorithm {
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "output");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "number of patches to process in parallel. Use -1 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
   }
 
   void configure();

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.cpp
@@ -91,8 +91,9 @@ void TensorflowPredictVGGish::configure() {
   string lastPatchMode = parameter("lastPatchMode").toString();
   bool accumulate = parameter("accumulate").toBool();
   int patchSize = parameter("patchSize").toInt();
+  int batchSize = parameter("batchSize").toInt();
 
-  int batchSize = accumulate ? -1 : 1;
+  if (accumulate) batchSize = -1;
 
   // Hardcoded parameters matching the training setup:
   // https://github.com/tensorflow/models/blob/master/research/audioset/vggish/mel_features.py
@@ -143,7 +144,7 @@ const char* TensorflowPredictVGGish::description = DOC(
   "(mel bands). It feeds the model with patches of 96 mel bands frames and "
   "jumps a constant amount of frames determined by `patchHopSize`.\n"
   "\n"
-  "With the accumulate parameter the patches are stored to run a single "
+  "By setting the `batchSize` parameter to -1 or 0 the patches are stored to run a single "
   "TensorFlow session at the end of the stream. This allows to take advantage "
   "of parallelization when GPUs are available, but at the same time it can be "
   "memory exhausting for long files.\n"
@@ -197,7 +198,8 @@ void TensorflowPredictVGGish::configure() {
                                       INHERIT("patchHopSize"),
                                       INHERIT("accumulate"),
                                       INHERIT("lastPatchMode"),
-                                      INHERIT("patchSize"));
+                                      INHERIT("patchSize"),
+                                      INHERIT("batchSize"));
 }
 
 

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.h
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.h
@@ -60,7 +60,8 @@ class TensorflowPredictVGGish : public AlgorithmComposite {
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "when true it runs a single TensorFlow session at the end of the stream. Otherwise, a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 96);
   }
 
@@ -113,7 +114,8 @@ class TensorflowPredictVGGish : public Algorithm {
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 96);
   }
 

--- a/src/algorithms/machinelearning/tensorflowpredictvggish.h
+++ b/src/algorithms/machinelearning/tensorflowpredictvggish.h
@@ -60,7 +60,7 @@ class TensorflowPredictVGGish : public AlgorithmComposite {
     declareParameter("isTrainingName", "the name of an additional input node to indicate the model if it is in training mode or not. Leave it empty when the model does not need such input", "", "");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(deprecated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
     declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 96);
   }
@@ -114,7 +114,7 @@ class TensorflowPredictVGGish : public Algorithm {
     declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 93);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("accumulate", "(outdated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
+    declareParameter("accumulate", "(deprecated, use `batchSize`) when true it runs a single Tensorflow session at the end of the stream. Otherwise a session is run for every new patch", "{true,false}", false);
     declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream", "[-1,inf)", 64);
     declareParameter("patchSize", "number of frames required for each inference. This parameter should match the model's expected input shape.", "[0,inf)", 96);
   }

--- a/src/algorithms/rhythm/tempocnn.h
+++ b/src/algorithms/rhythm/tempocnn.h
@@ -61,9 +61,8 @@ class TempoCNN : public Algorithm {
     declareParameter("output", "the name of the node from which to retrieve the tempo bins activations", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "number of patches to process in parallel. Use -1 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
     declareParameter("aggregationMethod", "method used to estimate the global tempo.", "{majority,mean,median}", "majority");
-
   }
 
   void configure();

--- a/src/algorithms/rhythm/tempocnn.h
+++ b/src/algorithms/rhythm/tempocnn.h
@@ -61,7 +61,7 @@ class TempoCNN : public Algorithm {
     declareParameter("output", "the name of the node from which to retrieve the tempo bins activations", "", "output");
     declareParameter("patchHopSize", "the number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 128);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "discard");
-    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 1);
+    declareParameter("batchSize", "number of patches to process in parallel. Use -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end of the stream.", "[-1,inf)", 64);
     declareParameter("aggregationMethod", "method used to estimate the global tempo.", "{majority,mean,median}", "majority");
   }
 

--- a/src/algorithms/standard/vectorrealtotensor.h
+++ b/src/algorithms/standard/vectorrealtotensor.h
@@ -38,6 +38,7 @@ class VectorRealToTensor : public Algorithm {
   bool _push;
   bool _accumulate;
   std::string _lastPatchMode;
+  std::string _lastBatchMode;
 
   std::vector<std::vector<std::vector<Real> > > _acc;
 
@@ -56,6 +57,7 @@ class VectorRealToTensor : public Algorithm {
     declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. Use `0` to avoid overlap", "[0,inf)", 0);
     declareParameter("batchHopSize", "number of patches between the beginnings of adjacent batches. Use `0` to avoid overlap", "[0,inf)", 0);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "repeat");
+    declareParameter("lastBatchMode", "what to do with the last patches: `push` an incomplete batch (if the models accepts dynamic batches) or `discard` them", "{discard,push}", "push");
   }
 
   void configure();

--- a/src/algorithms/standard/vectorrealtotensor.h
+++ b/src/algorithms/standard/vectorrealtotensor.h
@@ -52,9 +52,9 @@ class VectorRealToTensor : public Algorithm {
     // This is a common setup for mel-spectrogram based architectures.
     std::vector<int> outputShape = {1, 1, 187, 96};
 
-    declareParameter("shape", "shape of the output tensor (batchSize, channels, patchSize, featureSize). If batchSize is -1 a single tensor is generated when the end of the stream is reached", "", outputShape);
-    declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. 0 to avoid overlap", "[0,inf)", 0);
-    declareParameter("batchHopSize", "number of patches between the beginnings of adjacent batches. 0 to avoid overlap", "[0,inf)", 0);
+    declareParameter("shape", "shape of the output tensor (batchSize, channels, patchSize, featureSize). If batchSize is set to -1 or 0 a single tensor is generated when the end of the stream is reached", "", outputShape);
+    declareParameter("patchHopSize", "number of frames between the beginnings of adjacent patches. Use `0` to avoid overlap", "[0,inf)", 0);
+    declareParameter("batchHopSize", "number of patches between the beginnings of adjacent batches. Use `0` to avoid overlap", "[0,inf)", 0);
     declareParameter("lastPatchMode", "what to do with the last frames: `repeat` them to fill the last patch or `discard` them", "{discard,repeat}", "repeat");
   }
 

--- a/src/algorithms/tonal/pitchcrepe.h
+++ b/src/algorithms/tonal/pitchcrepe.h
@@ -71,7 +71,7 @@ class PitchCREPE : public Algorithm {
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimation", "(0,inf)", 10.0);
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end", "[-1,inf)", -1);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end", "[-1,inf)", 64);
     // CREPE implements temporal smoothing via Viterbi but it is not applied by default and we will leave it unimplemented for now.
     // declareParameter("viterbi", "whether to use Viterbi decoding for temporal smoothing", "{true,false}", true);
   }

--- a/src/algorithms/tonal/pitchcrepe.h
+++ b/src/algorithms/tonal/pitchcrepe.h
@@ -71,7 +71,7 @@ class PitchCREPE : public Algorithm {
     declareParameter("input", "the name of the input node in the TensorFlow graph", "", "frames");
     declareParameter("output", "the name of the node from which to retrieve the output tensors", "", "model/classifier/Sigmoid");
     declareParameter("hopSize", "the hop size in milliseconds for running pitch estimation", "(0,inf)", 10.0);
-    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when GPUs are available. Set it to `-1` to accumulate all the patches and run a single TensorFlow session at the end", "[-1,inf)", -1);
+    declareParameter("batchSize", "the batch size for prediction. This allows parallelization when a GPU are available. Set it to -1 or 0 to accumulate all the patches and run a single TensorFlow session at the end", "[-1,inf)", -1);
     // CREPE implements temporal smoothing via Viterbi but it is not applied by default and we will leave it unimplemented for now.
     // declareParameter("viterbi", "whether to use Viterbi decoding for temporal smoothing", "{true,false}", true);
   }

--- a/test/src/unittests/machinelearning/test_tensorflowpredicteffnetdiscogs.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredicteffnetdiscogs.py
@@ -76,8 +76,8 @@ class TestTensorFlowPredictEffnetDiscogs(TestCase):
     def testInvalidParam(self):
         model = join(testdata.models_dir, 'effnetdiscogs', 'effnetdiscogs-bs64-1.pb')
         self.assertConfigureFails(TensorflowPredictEffnetDiscogs(), {'graphFilename': model,
-                                                                     'batchSize': 0,
-                                                                    })  # Cannot be 0.
+                                                                     'batchSize': -2,
+                                                                    })  # Cannot be < -1.
         self.assertConfigureFails(TensorflowPredictEffnetDiscogs(), {'graphFilename': model,
                                                                      'patchSze': 0,
                                                                     })  # Cannot be 0.

--- a/test/src/unittests/machinelearning/test_tensorflowpredicteffnetdiscogs.py
+++ b/test/src/unittests/machinelearning/test_tensorflowpredicteffnetdiscogs.py
@@ -79,7 +79,7 @@ class TestTensorFlowPredictEffnetDiscogs(TestCase):
                                                                      'batchSize': -2,
                                                                     })  # Cannot be < -1.
         self.assertConfigureFails(TensorflowPredictEffnetDiscogs(), {'graphFilename': model,
-                                                                     'patchSze': 0,
+                                                                     'patchSize': 0,
                                                                     })  # Cannot be 0.
 
 suite = allTests(TestTensorFlowPredictEffnetDiscogs)

--- a/test/src/unittests/streaming/test_vectorrealtotensor.py
+++ b/test/src/unittests/streaming/test_vectorrealtotensor.py
@@ -49,6 +49,25 @@ class TestVectorRealToTensor(TestCase):
 
         return pool['framesOut'], pool['framesIn']
 
+    def streamingPipeline(self, n_samples, params, frame_size=1):
+        fc = FrameCutter(
+            frameSize=frame_size,
+            hopSize=frame_size,
+            startFromZero=True,
+            lastFrameToEndOfFile=True,
+        )
+        vtt = VectorRealToTensor(**params)
+
+        data = numpy.zeros((n_samples), dtype="float32")
+        vi = VectorInput(data)
+        pool = Pool()
+
+        vi.data >> fc.signal
+        fc.frame >> vtt.frame
+        vtt.tensor >> (pool, "tensor")
+
+        run(vi)
+        return pool["tensor"]
 
     def testFramesToTensorAndBackToFramesDiscard(self):
         # The test audio file has 430 frames.
@@ -131,7 +150,7 @@ class TestVectorRealToTensor(TestCase):
         self.assertAlmostEqualMatrix(found[:expected.shape[0], :], expected, 1e-8)
 
     def testInvalidParam(self):
-        # VectorRealToTensor only supports single chanel data
+        # VectorRealToTensor only supports single chanel data.
         self.assertConfigureFails(VectorRealToTensor(), {'shape': [1, 2, 1, 1]})
 
         # the batch size has  be greater -1 or bigger.
@@ -170,7 +189,7 @@ class TestVectorRealToTensor(TestCase):
                     for patch_size in test_lens:
                         if accumulate:
                             # With batchSize = -1, the algorithm should return a single batch with as
-                            # many patches as possible
+                            # many patches as possible.
                             shape = [-1, 1, patch_size, frame_size]
                             expected_n_batches = 1
                             expected_batch_shape = [n_batches * batch_size, 1, patch_size, frame_size]
@@ -181,28 +200,11 @@ class TestVectorRealToTensor(TestCase):
                             expected_batch_shape = [batch_size, 1, patch_size, frame_size]
                             expected_n_batches = n_batches
 
-                        fc = FrameCutter(
-                            frameSize=frame_size,
-                            hopSize=frame_size,
-                            startFromZero=True,
-                            lastFrameToEndOfFile=True,
-                        )
-                        vtt = VectorRealToTensor(
-                            shape=shape,
-                            lastPatchMode="discard",
-                        )
-
                         n_samples = n_batches * batch_size * patch_size * frame_size
-                        data = numpy.zeros((n_samples), dtype="float32")
-                        vi = VectorInput(data)
-                        pool = Pool()
+                        params = {"shape": shape, "lastPatchMode": "discard", "lastBatchMode": "discard"}
 
-                        vi.data >> fc.signal
-                        fc.frame >> vtt.frame
-                        vtt.tensor >> (pool, "tensor")
+                        batches = self.streamingPipeline(n_samples, params)
 
-                        run(vi)
-                        batches = pool["tensor"]
                         self.assertEqual(len(batches), expected_n_batches)
                         for batch in batches:
                             self.assertEqualVector(batch.shape, expected_batch_shape)
@@ -210,38 +212,68 @@ class TestVectorRealToTensor(TestCase):
 
     def testDynamicBatchSizeIndicator(self):
         # Test that -1 and 0 are equivalent.
+        frame_size, patch_size, batch_size, n_batches = 1, 3, 3, 3
+        expected_batch_shape = [n_batches * batch_size, 1, patch_size, frame_size]
+        n_samples = n_batches * batch_size * patch_size * frame_size
 
-        frame_size, patch_size, batch_size, n_batches = 1, 3, 3 ,3
         for batch_shape in (-1, 0):
             shape = [batch_shape, 1, patch_size, frame_size]
+            params = {"shape": shape, "lastPatchMode": "discard"}
+
+            batches = self.streamingPipeline(n_samples, params)
+
             expected_n_batches = 1
-            expected_batch_shape = [n_batches * batch_size, 1, patch_size, frame_size]
-
-            fc = FrameCutter(
-                frameSize=frame_size,
-                hopSize=frame_size,
-                startFromZero=True,
-                lastFrameToEndOfFile=True,
-            )
-            vtt = VectorRealToTensor(
-                shape=shape,
-                lastPatchMode="discard",
-            )
-
-            n_samples = n_batches * batch_size * patch_size * frame_size
-            data = numpy.zeros((n_samples), dtype="float32")
-            vi = VectorInput(data)
-            pool = Pool()
-
-            vi.data >> fc.signal
-            fc.frame >> vtt.frame
-            vtt.tensor >> (pool, "tensor")
-
-            run(vi)
-            batches = pool["tensor"]
             self.assertEqual(len(batches), expected_n_batches)
             for batch in batches:
                 self.assertEqualVector(batch.shape, expected_batch_shape)
+
+    def testLastBatchMode(self):
+        # Test that the algorithm pushes an incomplete patch.
+        frame_size, patch_size, batch_size = 1, 3, 3
+        shape = [batch_size, 1, patch_size, frame_size]
+
+        # 1 complete batch plus 2 patches.
+        extra_patches = 2
+        n_samples = (batch_size + extra_patches) * (patch_size * frame_size)
+
+        for last_patch_model in ("repeat", "discard"):
+            params = {
+                "shape": shape,
+                "lastPatchMode": last_patch_model,
+                "lastBatchMode": "push",
+            }
+
+            batches = self.streamingPipeline(n_samples, params)
+
+            # In `push` mode we expect two patches.
+            expected_n_batches = 2
+            self.assertEqual(len(batches), expected_n_batches)
+
+            # The first one should be complete.
+            expected_shape_first = [batch_size, 1, patch_size, frame_size]
+            self.assertEqualVector(batches[0].shape, expected_shape_first)
+
+            # The second one should contain just two patches.
+            expected_shape_second = [extra_patches, 1, patch_size, frame_size]
+            self.assertEqualVector(batches[1].shape, expected_shape_second)
+
+        for last_patch_model in ("repeat", "discard"):
+            params = {
+                "shape": shape,
+                "lastPatchMode": last_patch_model,
+                "lastBatchMode": "discard",
+            }
+
+            batches = self.streamingPipeline(n_samples, params)
+
+            # In `discard` mode we expect a single complete batch.
+            expected_n_batches = 1
+            self.assertEqual(len(batches), expected_n_batches)
+
+            # It should be complete.
+            expected_shape_first = [batch_size, 1, patch_size, frame_size]
+            self.assertEqualVector(batches[0].shape, expected_shape_first)
+
 
 suite = allTests(TestVectorRealToTensor)
 


### PR DESCRIPTION
A series of improvements related to the management of the batch size:

1. Support both `0` and `-1` to activate the accumulate mode (see VectorRealToTensor's [documentation](https://essentia.upf.edu/reference/streaming_VectorRealToTensor.html)) as discused in https://github.com/MTG/essentia/pull/1236#issuecomment-1049841378.
2. Add a parameter `lastBatchMode` in `VectorRealToTensor`. Before, if `batchSize` was larger than 1, the last patches not fitting an entire final batch were discarded. The new option `push` (default) creates a final batch with the remaining patches. Note that this option is not suitable for models expecting a fixed batch size (e.g., EffnetDiscogs).
3. Implement the `batchSize` parameter in `TensorflowPredictMusiCNN` and `TensorflowPredictVGGish` for consistency with the rest of `TensorflowPredict*` algorithms.

## TODOs

- [x] Set a default `batchSize` of 64 for the `TensorflowPredict*` algorithms. Before, most of them had a batch size of `-1` (accumulate mode). This option was not memory constrained and could exhaust the  RAM /GPU VRAM on long streams, although it is optimal in terms of number of TensorFlow session executions.
- [x] Check that all `TensorflowPredict*` tests pass with the new defaults.
- [x] Assess the performance impact with the new defaults in our [benchmark](https://github.com/MTG/essentia-models-benchmark/).