### PR TITLE
Prefix for vamp linux install path

### DIFF
--- a/src/examples/wscript
+++ b/src/examples/wscript
@@ -184,7 +184,7 @@ def build(ctx):
         if sys.platform == 'darwin':
             install_path = os.environ['HOME'] + '/Library/Audio/Plug-Ins/Vamp'
         elif sys.platform.startswith('linux'):
-            install_path = '/usr/local/lib/vamp'
+            install_path = '${PREFIX}/vamp'
         else:
             install_path = None
 


### PR DESCRIPTION
This change makes sure the user can define the location of the vamp 3rd-party plugin at configure-time