### PR TITLE
constantsDecimals parameter for Windowing

### DIFF
--- a/src/algorithms/standard/windowing.cpp
+++ b/src/algorithms/standard/windowing.cpp
@@ -127,6 +127,11 @@ void Windowing::compute() {
 // values which were 0.54 and 0.46 are actually approximations.
 // More precise values are 0.53836 and 0.46164 (found on wikipedia)
 // @todo find a more "scientific" reference than wikipedia
+//
+// Pablo A.: Even if the current values are more precise, the user
+// may want to replicate the 2-decimal version sometimes used in
+// other implementations (e.g., SciPy). Added a parameter to support
+// that use-case.
 void Windowing::hamming() {
   const int size = _window.size();
   double a0 = 0.53836, a1 = 0.46164;

--- a/src/algorithms/standard/windowing.cpp
+++ b/src/algorithms/standard/windowing.cpp
@@ -26,7 +26,15 @@ using namespace standard;
 
 const char* Windowing::name = "Windowing";
 const char* Windowing::category = "Standard";
-const char* Windowing::description = DOC("This algorithm applies windowing to an audio signal. It optionally applies zero-phase windowing and optionally adds zero-padding. The resulting windowed frame size is equal to the incoming frame size plus the number of padded zeros. By default, the available windows are normalized (to have an area of 1) and then scaled by a factor of 2.\n"
+const char* Windowing::description = DOC("This algorithm applies windowing to an audio signal. "
+"It optionally applies zero-phase windowing and optionally adds zero-padding. "
+"The resulting windowed frame size is equal to the incoming frame size plus the number of padded zeros. "
+"By default, the available windows are normalized (to have an area of 1) and then scaled by a factor of 2.\n"
+"\n"
+"The parameter constantsDecimals allows choosing the number of decimals used in the constants for the formulation "
+"of the Hamming and Blackman-Harris windows, which allows replicating alternative windowing implementations. "
+"For example, setting type='hamming', constantsDecimals=2, normalized=False, and zeroPhase=False results in a "
+"Hamming window similar to the default SciPy implementation [3].\n"
 "\n"
 "An exception is thrown if the size of the frame is less than 2.\n"
 "\n"
@@ -35,11 +43,15 @@ const char* Windowing::description = DOC("This algorithm applies windowing to an
 "  discrete Fourier transform, Proceedings of the IEEE, vol. 66, no. 1,\n"
 "  pp. 51-83, Jan. 1978\n\n"
 "  [2] Window function - Wikipedia, the free encyclopedia,\n"
-"  http://en.wikipedia.org/wiki/Window_function");
+"  http://en.wikipedia.org/wiki/Window_function\n\n"
+"  [3] Hamming window - SciPy documentation,\n"
+"  https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.hamming.html"
+);
 
 void Windowing::configure() {
   _normalized = parameter("normalized").toBool();
   _window.resize(parameter("size").toInt());
+  _constantsDecimals = parameter("constantsDecimals").toInt();
   createWindow(parameter("type").toLower());
   _zeroPadding = parameter("zeroPadding").toInt();
   _zeroPhase = parameter("zeroPhase").toBool();
@@ -57,7 +69,7 @@ void Windowing::createWindow(const std::string& windowtype) {
   else if (windowtype == "blackmanharris92") blackmanHarris92();
 
   if (_normalized) {
-    normalize();  
+    normalize();
   }
 }
 
@@ -117,9 +129,13 @@ void Windowing::compute() {
 // @todo find a more "scientific" reference than wikipedia
 void Windowing::hamming() {
   const int size = _window.size();
+  double a0 = 0.53836, a1 = 0.46164;
+
+  a0 = roundToDecimal(a0, _constantsDecimals);
+  a1 = roundToDecimal(a1, _constantsDecimals);
 
   for (int i=0; i<size; i++) {
-    _window[i] = 0.53836 - 0.46164 * cos((2.0*M_PI*i) / (size - 1.0));
+    _window[i] = a0 - a1 * cos((2.0*M_PI*i) / (size - 1.0));
   }
 }
 
@@ -163,6 +179,11 @@ void Windowing::square() {
 // @todo lookup implementation of windows on wikipedia and other resources
 void Windowing::blackmanHarris(double a0, double a1, double a2, double a3) {
   int size = _window.size();
+
+  a0 = roundToDecimal(a0, _constantsDecimals);
+  a1 = roundToDecimal(a1, _constantsDecimals);
+  a2 = roundToDecimal(a2, _constantsDecimals);
+  a3 = roundToDecimal(a3, _constantsDecimals);
 
   double fConst = 2.0 * M_PI / (size-1);
 

--- a/src/algorithms/standard/windowing.h
+++ b/src/algorithms/standard/windowing.h
@@ -43,6 +43,7 @@ class Windowing : public Algorithm {
     declareParameter("type", "the window type", "{hamming,hann,hannnsgcq,triangular,square,blackmanharris62,blackmanharris70,blackmanharris74,blackmanharris92}", "hann");
     declareParameter("zeroPhase", "a boolean value that enables zero-phase windowing", "{true,false}", true);
     declareParameter("normalized", "a boolean value to specify whether to normalize windows (to have an area of 1) and then scale by a factor of 2", "{true,false}", true);
+    declareParameter("constantsDecimals", "number of decimals considered in the constants for the formulation of the hamming and blackmanharris* windows ", "[1,5]", 5);
   }
 
   void configure();
@@ -73,6 +74,7 @@ protected:
 
   std::vector<Real> _window;
   int _zeroPadding;
+  int _constantsDecimals;
   bool _zeroPhase;
   bool _normalized;
 };

--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -1336,6 +1336,17 @@ Tensor<T> tensorMax(const Tensor<T>& tensor, int axis) {
   return TensorMap<Real>(maxima.data(), summarizerShape);
 }
 
+/**
+ * Rounds x up to the desired decimal place.
+ */
+template <typename T>
+T roundToDecimal(T x, int decimal) {
+  if (decimal < 0) {
+    throw EssentiaException("the number of decimals has to be 0 or positive");
+  }
+  return round(pow(10, decimal) * x) / pow(10, decimal);
+}
+
 } // namespace essentia
 
 #endif // ESSENTIA_MATH_H

--- a/test/src/unittests/standard/test_windowing.py
+++ b/test/src/unittests/standard/test_windowing.py
@@ -156,10 +156,29 @@ class TestWindowing(TestCase):
 
     def testOne(self):
         # Checks for a single value
-        self.assertComputeFails(Windowing(type='hann'),  [1])
+        self.assertComputeFails(Windowing(type='hann'), [1])
 
     def testInvalidParam(self):
         self.assertConfigureFails(Windowing(), { 'type': 'unknown' })
+
+    def testScipyHammingWindow(self):
+        """Checks that we obtain a Hamming window equivalent to the default SciPy implementation.
+        """
+        from scipy.signal.windows import hamming
+
+        input_size = 1024
+        input_signal = [1] * input_size
+        found = Windowing(
+            type="hamming",
+            zeroPhase=False,
+            normalized=False,
+            constantsDecimals=2
+        )(input_signal)
+
+        expected = hamming(input_size, sym=True)
+
+        # Checks whether the windows are as expected
+        self.assertAlmostEqualVector(found, expected, 1e-6)
 
 suite = allTests(TestWindowing)
 


### PR DESCRIPTION
Implement a parameter `constantsDecimals` to allow choosing the number of decimals used in the constants for the formulation of the Hamming and Blackman-harris windows as demanded in #1199.

This functionality provides more flexibility in order to replicate alternative window implementations. In this case, we test that we can replicate the Hamming windows produced by SciPy.