### PR TITLE
Improve resizing for pages with a sidebar

### DIFF
--- a/doc/sphinxdoc/_templates/sphinxdoc_mtg/static/base.css
+++ b/doc/sphinxdoc/_templates/sphinxdoc_mtg/static/base.css
@@ -258,6 +258,12 @@ div.flex-container {
 
 div.bodywrapper {
     padding-left: 20px;
+    min-width: 0px;
+    max-width: 1270px;
+}
+
+div.bodywrapper > div.main-container {
+    width: 100%;
 }
 
 div.sphinxsidebar {


### PR DESCRIPTION
Set explicit limits for the bodywrapper div from 0 to 1270. This means that the the body text will occupy all the space available up to 1270 pixelsi horizontally.
Additionaly, set the width of main-containter to 100% to prevent overflow when the section is inside bodywraper. This only affect to pages with sideber.