### PR TITLE
Fixed C++17 compatibility issues

### DIFF
--- a/src/algorithms/highlevel/chromaprinter.cpp
+++ b/src/algorithms/highlevel/chromaprinter.cpp
@@ -21,6 +21,10 @@
 
 using namespace std;
 
+#if __cplusplus >= 201103L
+using namespace std::placeholders;
+#endif
+
 namespace essentia {
 namespace standard {
 
@@ -53,8 +57,13 @@ void Chromaprinter::compute() {
 
   // Copy the signal to new vector to expand it to the int16_t dynamic range before the cast.
   std::vector<Real> signalScaled = signal;
+#if __cplusplus >= 201103L
+  std::transform(signalScaled.begin(), signalScaled.end(), signalScaled.begin(),
+                 std::bind(std::multiplies<Real>(), pow(2,15), _1));
+#else
   std::transform(signalScaled.begin(), signalScaled.end(), signalScaled.begin(),
                  std::bind1st(std::multiplies<Real>(), pow(2,15)));
+#endif
 
   std::vector<int16_t> signalCast(signalScaled.begin(), signalScaled.end());
 
@@ -159,8 +168,13 @@ AlgorithmStatus Chromaprinter::process() {
 
     // Copy the signal to new vector to expand it to the int16_t dynamic range before the cast.
     std::vector<Real> signalScaled = signal;
+#if __cplusplus >= 201103L
+    std::transform(signalScaled.begin(), signalScaled.end(), signalScaled.begin(),
+                   std::bind(std::multiplies<Real>(), pow(2,15), _1));
+#else
     std::transform(signalScaled.begin(), signalScaled.end(), signalScaled.begin(),
                    std::bind1st(std::multiplies<Real>(), pow(2,15)));
+#endif
 
     std::vector<int16_t> signalCast(signalScaled.begin(), signalScaled.end());
 


### PR DESCRIPTION
The builds configured with the --std=c++17 option were failing because `std::bind1st()` and `std::bind2nd()` template methods were marked as deprecated in C++11 and finally removed starting from C++17.

Provided patch uses `__cpluplus` macro to determine used C++ standard and adjust the code accordingly.