### PR TITLE
Add changes to support building arm64 macos wheels

### DIFF
--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install pipx
+        if: ${{ matrix.os == macos-14 }}
         run: brew install pipx
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: artifact-{{ matrix.os }}-{{ matrix.config }}
+          name: artifact-${{ matrix.os }}-${{ matrix.config }}

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
-        config: [pyproject-tensorflow.toml, pyproject.toml]
+        os: [macos-11]
+        config: [pyproject.toml]
 
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
         with:
           config-file: ${{ matrix.config }}
         env:
-          CIBW_ARCHS_MACOS: arm64 x86_64 
+          CIBW_ARCHS_MACOS: arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -23,7 +23,8 @@ jobs:
         with:
           config-file: ${{ matrix.config }}
         env:
-          CIBW_ARCHS_MACOS: arm64
+          - CIBW_ARCHS_MACOS: arm64
+          - CIBW_SKIP: cp38-macosx_*
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -12,7 +12,7 @@ jobs:
         config: [pyproject.toml, pyproject-tensorflow.toml]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -16,16 +16,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install pipx
-        if: ${{ matrix.os == 'macos-14' }}
-        run: brew install pipx
-
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           config-file: ${{ matrix.config }}
 

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -22,6 +22,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         with:
           config-file: ${{ matrix.config }}
+        env:
+          CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           config-file: ${{ matrix.config }}
         env:
-          - CIBW_ARCHS_MACOS: arm64
-          - CIBW_SKIP: cp38-macosx_*
+          CIBW_ARCHS_MACOS: arm64
+          CIBW_SKIP: cp38-macosx_*
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install pipx
-        if: ${{ matrix.os == macos-14 }}
+        if: ${{ matrix.os == "macos-14" }}
         run: brew install pipx
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install pipx
-        if: ${{ matrix.os == "macos-14" }}
+        if: ${{ matrix.os == 'macos-14' }}
         run: brew install pipx
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12, macos-14]
-        config: [pyproject.toml, pyproject-tensorflow.toml]
+        config: [pyproject, pyproject-tensorflow]
 
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +23,9 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         with:
-          config-file: ${{ matrix.config }}
+          config-file: ${{ matrix.config }}.toml
 
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: artifact-{{ matrix.os }}-{{ matrix.config }}

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11]
+        os: [macos-14]
         config: [pyproject.toml]
 
     steps:
@@ -23,7 +23,6 @@ jobs:
         with:
           config-file: ${{ matrix.config }}
         env:
-          CIBW_ARCHS_MACOS: arm64
           CIBW_SKIP: cp38-macosx_*
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -14,17 +14,24 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          using: 'node20'
           fetch-depth: 0
+
       - name: Install pipx
         if: ${{ matrix.os == 'macos-14' }}
         run: brew install pipx
+
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.4
         with:
+          using: 'node20'
           config-file: ${{ matrix.config }}
+
       - uses: actions/upload-artifact@v3
         with:
+          using: 'node20'
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14]
-        config: [pyproject.toml]
+        os: [ubuntu-20.04, macos-12, macos-14]
+        config: [pyproject.toml, pyproject-tensorflow.toml]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,9 +24,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.4
         with:
           config-file: ${{ matrix.config }}
-        env:
-          CIBW_SKIP: cp38-macosx_*
-
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           config-file: ${{ matrix.config }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Install pipx
+        run: brew install pipx
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           config-file: ${{ matrix.config }}
         env:
-          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_MACOS: arm64 x86_64 
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          using: 'node20'
           fetch-depth: 0
 
       - name: Install pipx
@@ -28,10 +27,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.4
         with:
-          using: 'node20'
           config-file: ${{ matrix.config }}
 
       - uses: actions/upload-artifact@v3
         with:
-          using: 'node20'
           path: ./wheelhouse/*.whl

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -44,7 +44,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
-skip = ["pp*", "cp38-macosx_*"]
+skip = ["pp*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
 

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -4,6 +4,7 @@ manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 
 # Only support x86_64 for essentia-tensorflow
 build = "cp**-manylinux_x86_64"
+# TODO: skipping Python 3.12 for now until we create manylinux wheels supporting this version.
 skip = ["pp*", "*-musllinux*", "*i686", "*cp312*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -4,7 +4,7 @@ manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 
 # Only support x86_64 for essentia-tensorflow
 build = "cp**-manylinux_x86_64"
-skip = ["pp*", "*-musllinux*", "*i686", "*cp312-cp312*"]
+skip = ["pp*", "*-musllinux*", "*i686", "*cp312*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -8,7 +8,7 @@ skip = ["pp*", "*-musllinux*", "*i686"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
-before-all = [
+before-build = [
   "PYBIN=/opt/python/cp36-cp36m/bin/",
   "\"${PYBIN}/python\" waf configure --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
   "\"${PYBIN}/python\" waf",
@@ -24,7 +24,7 @@ skip = ["pp*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
-before-all = [
+before-build = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
   "brew install tensorflow",
@@ -40,9 +40,9 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 
 
 [[tool.cibuildwheel.overrides]]
-select = "*arm64*"
+select = "*macosx_arm64*"
 
-before-all = [
+before-build = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
   "brew install tensorflow",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -43,8 +43,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
   "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
   "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -46,7 +46,7 @@ before-build = [
   "brew install ",
   "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
   "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
-  "PACKAGES=(tensorflow); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
+  "PACKAGES=(tensorflow); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -43,10 +43,9 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "brew install ",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
-  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -43,9 +43,10 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
-  "brew install tensorflow",
+  "brew install ",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
+  "PACKAGES=(tensorflow); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -44,9 +44,9 @@ select = "*macosx_arm64*"
 
 before-build = [
   "brew install ",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
-  "PACKAGES=(tensorflow); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
+  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -4,7 +4,7 @@ manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 
 # Only support x86_64 for essentia-tensorflow
 build = "cp**-manylinux_x86_64"
-# TODO: skipping Python 3.12 for now until we create manylinux wheels supporting this version.
+# TODO: skipping Python 3.12 for now until we create manylinux images supporting this version.
 skip = ["pp*", "*-musllinux*", "*i686", "*cp312*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -26,9 +26,11 @@ environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PRO
 
 before-build = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
-  "brew install tensorflow",
+  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
+  "brew install chromaprint",
+  "brew link --overwrite ffmpeg@2.8",
+  "brew install tensorflow",
   #"brew tap MTG/essentia",
   #"brew install gaia --HEAD",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\"",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -4,7 +4,7 @@ manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 
 # Only support x86_64 for essentia-tensorflow
 build = "cp**-manylinux_x86_64"
-skip = ["pp*", "*-musllinux*", "*i686"]
+skip = ["pp*", "*-musllinux*", "*i686", "*cp312-cp312*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -42,14 +42,35 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
+skip = ["pp*", "cp38-macosx_*"]
+
+environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
+
 before-build = [
-  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
+  "brew install pkg-config gcc readline sqlite gdbm libpng",
+  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
+  "brew install chromaprint",
+  "brew link --overwrite ffmpeg@2.8",
+  "brew install tensorflow",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
-  "python waf install"
+  "sudo python waf install",
+]
+
+# On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and
+# libavutil.54.31.100, depend on libSDL1.2-compat, which is a compatibility
+# layer for SDL2. libSDL1.2-compat expects SDL2 to be installed in the default
+# brew location (i.e., /opt/homebrew/opt/sdl2/lib), so the user would need to
+# install it via brew manually. Alternativelly, we can manualy copy the SDL2
+# libs into the wheel. This is a temporary solution, and in the long term we
+# should move to FFmpeg > 2.X.
+repair-wheel-command = [
+  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
+  "mkdir -p {dest_dir}/essentia/.dylibs",
+  "cp /opt/homebrew/opt/sdl2/lib/libSDL2*.dylib {dest_dir}/essentia/.dylibs",
+  "wheel_rel=$(echo {wheel} | grep -o '[^/]*$')",
+  "cd {dest_dir} && zip -u {dest_dir}/$wheel_rel essentia/.dylibs/*"
 ]
 
 [build-system]

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -43,9 +43,9 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
+  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -43,9 +43,9 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(tensorflow); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -44,8 +44,8 @@ select = "*macosx_arm64*"
 
 before-build = [
   "brew install ",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
   "PACKAGES=(tensorflow); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
   "brew link --force ffmpeg@2.8",
   "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -47,7 +47,7 @@ select = "*macosx_arm64*"
 
 skip = ["pp*"]
 
-environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
+environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
 
 before-build = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",

--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -39,6 +39,19 @@ before-all = [
 test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter, TensorflowPredict'"
 
 
+[[tool.cibuildwheel.overrides]]
+select = "*arm64*"
+
+before-all = [
+  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
+  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
+  "brew install tensorflow",
+  "brew link --force ffmpeg@2.8",
+  "python waf configure --with-tensorflow --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
+  "python waf",
+  "python waf install"
+]
+
 [build-system]
 
 requires = ["wheel", "setuptools", "oldest-supported-numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,10 @@ environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}"
 
 before-build = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
+  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
+  "brew install chromaprint",
+  "brew link --overwrite ffmpeg@2.8",
   #"brew tap MTG/essentia",
   #"brew install gaia --HEAD",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\"",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 manylinux-i686-image = "mtgupf/essentia-builds:manylinux2014_i686"
 
-# TODO: skipping Python 3.12 for now until we create manylinux wheels supporting this version.
+# TODO: skipping Python 3.12 for now until we create manylinux images supporting this version.
 skip = ["pp*", "*-musllinux*", "*i686", "*cp312*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
+  "brew install pkg-config gcc readline sqlite gdbm libpng",
+  "PACKAGES=(freetype); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
   "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,7 @@ select = "*macosx_arm64*"
 
 before-build = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
-  "PACKAGES=(freetype); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
+  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@
 manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 manylinux-i686-image = "mtgupf/essentia-builds:manylinux2014_i686"
 
+# TODO: skipping Python 3.12 for now until we create manylinux wheels supporting this version.
 skip = ["pp*", "*-musllinux*", "*i686", "*cp312*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 manylinux-i686-image = "mtgupf/essentia-builds:manylinux2014_i686"
 
-skip = ["pp*", "*-musllinux*", "*i686", "*cp312-cp312*"]
+skip = ["pp*", "*-musllinux*", "*i686", "*cp312*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ before-build = [
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
-  "brew link --force ffmpeg@2.8",
+  "brew link --overwrite ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
   "python waf install"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
+skip = ["pp*", "cp38-macosx_*"]
+
+environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
+
 before-build = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
@@ -49,7 +53,6 @@ before-build = [
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
   "sudo python waf install",
-  "ESSENTIA_MACOSX_ARM64=1",
 ]
 
 # On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ skip = ["pp*", "*-musllinux*", "*i686"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
-before-all = [
+before-build = [
   "PYBIN=/opt/python/cp36-cp36m/bin/",
   "\"${PYBIN}/python\" waf configure --with-gaia --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
   "\"${PYBIN}/python\" waf",
@@ -24,7 +24,7 @@ skip = ["pp*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
-before-all = [
+before-build = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
   "brew link --force ffmpeg@2.8",
@@ -38,9 +38,9 @@ before-all = [
 test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
 
 [[tool.cibuildwheel.overrides]]
-select = "*arm64*"
+select = "*macosx_arm64*"
 
-before-all = [
+before-build = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
   "brew link --force ffmpeg@2.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,21 @@ before-build = [
   "python waf install"
 ]
 
+# On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and
+# libavutil.54.31.100, depend on libSDL1.2-compat, which is a compatibility
+# layer for SDL2. libSDL1.2-compat expects SDL2 to be installed in the default
+# brew location (i.e., /opt/homebrew/opt/sdl2/lib), so the user would need to
+# install it via brew manually. Alternativelly, we can manualy copy the SDL2
+# libs into the wheel. This is a temporary solution, and in the long term we
+# should move to FFmpeg > 2.X.
+repair-wheel-command = [
+  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
+  "mkdir -p {dest_dir}/essentia/.dylibs",
+  "cp /opt/homebrew/opt/sdl2/lib/libSDL2*.dylib {dest_dir}/essentia/.dylibs",
+  "wheel_rel=$(echo {wheel} | grep -o '[^/]*$')",
+  "cd {dest_dir} && zip -u {dest_dir}/$wheel_rel essentia/.dylibs/*"
+]
+
 [build-system]
 
 requires = ["wheel", "setuptools", "oldest-supported-numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ before-build = [
   "brew link --overwrite ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
-  "sudo python waf install"
+  "sudo python waf install",
+  "ESSENTIA_MACOSX_ARM64=1",
 ]
 
 # On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
+  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_ventura $PACKAGE; result=$(brew --cache --bottle-tag=arm64_ventura $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done"
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,9 @@ before-build = [
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
   "brew link --overwrite ffmpeg@2.8",
-  "mkdir -p /usr/local/lib",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
-  "python waf install"
+  "sudo python waf install"
 ]
 
 # On Mac arm64, libavcodec.56.60.100, libavformat.56.40.101 and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
-skip = ["pp*", "cp38-macosx_*"]
+skip = ["pp*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 manylinux-i686-image = "mtgupf/essentia-builds:manylinux2014_i686"
 
-skip = ["pp*", "*-musllinux*", "*i686"]
+skip = ["pp*", "*-musllinux*", "*i686", "*cp312-cp312*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_big_sur $PACKAGE; result=$(brew --cache --bottle-tag=arm64_big_sur $PACKAGE); brew reinstall $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,17 @@ before-all = [
 
 test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"
 
+[[tool.cibuildwheel.overrides]]
+select = "*arm64*"
+
+before-all = [
+  "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
+  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
+  "brew link --force ffmpeg@2.8",
+  "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
+  "python waf",
+  "python waf install"
+]
 
 [build-system]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 select = "*macosx_arm64*"
 
 before-build = [
-  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
-  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in \"${PACKAGES[@]}\"; do brew fetch --force --bottle-tag=arm64_monterrey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterrey $PACKAGE) brew install $result; done",
+  "PACKAGES=(eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
+  "PACKAGES=(pkg-config gcc readline sqlite gdbm freetype libpng); for PACKAGE in ${PACKAGES[@]}; do brew fetch --force --bottle-tag=arm64_monterey $PACKAGE; result=$(brew --cache --bottle-tag=arm64_monterey $PACKAGE); brew install $result; done",
   "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ before-build = [
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
   "brew link --overwrite ffmpeg@2.8",
+  "mkdir -p /usr/local/lib",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
   "python waf install"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ before-build = [
   "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
   "brew install chromaprint",
+  "brew link --force ffmpeg@2.8",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
   "python waf install"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,9 @@ select = "*macosx_arm64*"
 
 before-build = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag chromaprint",
+  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
   "brew link --force ffmpeg@2.8",
+  "brew install chromaprint",
   "python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",
   "python waf install"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import shutil
 import os
 import glob
+import subprocess
 import sys
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
@@ -39,17 +40,17 @@ class EssentiaBuildExtension(build_ext):
         if var_skip_3rdparty in os.environ and os.environ[var_skip_3rdparty]=='1':
             print('Skipping building static 3rdparty dependencies (%s=1)' %  var_skip_3rdparty)
         else:
-            os.system('./packaging/build_3rdparty_static_debian.sh')
+            subprocess.run('./packaging/build_3rdparty_static_debian.sh', check=True)
 
         if var_only_python in os.environ and os.environ[var_only_python]=='1':
             print('Skipping building the core libessentia library (%s=1)' %  var_only_python)
-            os.system('%s waf configure --only-python --static-dependencies '
-                      '--prefix=tmp' % PYTHON)
+            subprocess.run([PYTHON,  'waf', 'configure', '--only-python', '--static-dependencies',
+                      '--prefix=tmp'], check=True)
         else:
-            os.system('%s waf configure --build-static --static-dependencies '
-                      '--with-python --prefix=tmp' % PYTHON)
-        os.system('%s waf' % PYTHON)
-        os.system('%s waf install' % PYTHON)
+            subprocess.run([PYTHON, 'waf', 'configure', '--build-static', '--static-dependencies'
+                      '--with-python --prefix=tmp'], check=True)
+        subprocess.run([PYTHON, 'waf'], check=True)
+        subprocess.run([PYTHON, 'waf', 'install'], check=True)
 
         library = glob.glob('tmp/lib/python*/*-packages/essentia')[0]
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,10 @@ class EssentiaBuildExtension(build_ext):
         var_skip_3rdparty = 'ESSENTIA_WHEEL_SKIP_3RDPARTY'
         var_only_python = 'ESSENTIA_WHEEL_ONLY_PYTHON'
 
+        var_macos_arm64 = os.getenv('ESSENTIA_MACOSX_ARM64')
+        if var_macos_arm64 == '1':
+            macos_arm64_flags = ['--arch=arm64', '--no-msse']
+
         if var_skip_3rdparty in os.environ and os.environ[var_skip_3rdparty]=='1':
             print('Skipping building static 3rdparty dependencies (%s=1)' %  var_skip_3rdparty)
         else:
@@ -45,10 +49,10 @@ class EssentiaBuildExtension(build_ext):
         if var_only_python in os.environ and os.environ[var_only_python]=='1':
             print('Skipping building the core libessentia library (%s=1)' %  var_only_python)
             subprocess.run([PYTHON,  'waf', 'configure', '--only-python', '--static-dependencies',
-                      '--prefix=tmp','--arch=arm64', '--no-msse'], check=True)
+                      '--prefix=tmp'] + macos_arm64_flags, check=True)
         else:
             subprocess.run([PYTHON, 'waf', 'configure', '--build-static', '--static-dependencies'
-                      '--with-python --prefix=tmp', '--arch=arm64', '--no-msse'], check=True)
+                      '--with-python --prefix=tmp'] + macos_arm64_flags, check=True)
         subprocess.run([PYTHON, 'waf'], check=True)
         subprocess.run([PYTHON, 'waf', 'install'], check=True)
 

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,10 @@ class EssentiaBuildExtension(build_ext):
         if var_only_python in os.environ and os.environ[var_only_python]=='1':
             print('Skipping building the core libessentia library (%s=1)' %  var_only_python)
             subprocess.run([PYTHON,  'waf', 'configure', '--only-python', '--static-dependencies',
-                      '--prefix=tmp'], check=True)
+                      '--prefix=tmp','--arch=arm64', '--no-msse'], check=True)
         else:
             subprocess.run([PYTHON, 'waf', 'configure', '--build-static', '--static-dependencies'
-                      '--with-python --prefix=tmp'], check=True)
+                      '--with-python --prefix=tmp', '--arch=arm64', '--no-msse'], check=True)
         subprocess.run([PYTHON, 'waf'], check=True)
         subprocess.run([PYTHON, 'waf', 'install'], check=True)
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ class EssentiaBuildExtension(build_ext):
         var_only_python = 'ESSENTIA_WHEEL_ONLY_PYTHON'
 
         var_macos_arm64 = os.getenv('ESSENTIA_MACOSX_ARM64')
+        macos_arm64_flags = []
         if var_macos_arm64 == '1':
             macos_arm64_flags = ['--arch=arm64', '--no-msse']
 

--- a/wscript
+++ b/wscript
@@ -194,6 +194,11 @@ def configure(ctx):
             ctx.env.LINKFLAGS += ['-arch', 'i386', '-arch', 'x86_64']
             ctx.env.LDFLAGS = ['-arch', 'i386', '-arch', 'x86_64']
 
+        if ctx.options.ARCH == 'arm64':
+            ctx.env.CXXFLAGS += ['-arch', 'arm64']
+            ctx.env.LINKFLAGS += ['-arch', 'arm64']
+            ctx.env.LDFLAGS += ['-arch', 'arm64']
+
     elif sys.platform.startswith('linux'):
         # include -pthread flag because not all versions of gcc provide it automatically
         ctx.env.CXXFLAGS += ['-pthread']

--- a/wscript
+++ b/wscript
@@ -195,6 +195,7 @@ def configure(ctx):
             ctx.env.LDFLAGS = ['-arch', 'i386', '-arch', 'x86_64']
 
         if ctx.options.ARCH == 'arm64':
+            ctx.env.CFLAGS += ['-arch', 'arm64']
             ctx.env.CXXFLAGS += ['-arch', 'arm64']
             ctx.env.LINKFLAGS += ['-arch', 'arm64']
             ctx.env.LDFLAGS += ['-arch', 'arm64']


### PR DESCRIPTION
In theory, Apple Silicon wheels can be cross-compiled from the intel mac machines (however the can't be tested):
https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon

Additionally, we replace `os.system` calls by `subprocess.run` so that we can notice when one of these subprocesses fail.