### PR TITLE
Maintenance: restore Sphinx documentation seach functionality

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libeigen3-dev libyaml-dev libfftw3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libsamplerate0-dev libtag1-dev libchromaprint-dev python3-dev python3-numpy-dev python3-numpy python3-yaml python3-six
           sudo apt-get install -y doxygen python3-pip pandoc
-          pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinxprettysearchresults sphinx-toolbox
+          pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox
           # Install TensorFlow
           sudo sh src/3rdparty/tensorflow/setup_from_libtensorflow.sh
           # Install Gaia dependencies

--- a/doc/sphinxdoc/_templates/search.html
+++ b/doc/sphinxdoc/_templates/search.html
@@ -39,6 +39,7 @@
 </script>
 <script src="{{ pathto("_static/doctools.js", 1) }}"></script>
 <script src="{{ pathto("_static/searchtools.js", 1) }}"></script>
+<script src="{{ pathto("_static/language_data.js", 1) }}"></script>
 <script>
 jQuery(function() {
   Search.loadIndex('searchindex.js');

--- a/doc/sphinxdoc/_templates/search.html
+++ b/doc/sphinxdoc/_templates/search.html
@@ -40,10 +40,5 @@
 <script src="{{ pathto("_static/doctools.js", 1) }}"></script>
 <script src="{{ pathto("_static/searchtools.js", 1) }}"></script>
 <script src="{{ pathto("_static/language_data.js", 1) }}"></script>
-<script>
-jQuery(function() {
-  Search.loadIndex('searchindex.js');
-});
-</script>
-<script id="searchindexloader"></script>
+<script src="{{ pathto("searchindex.js", 1) }}" defer></script>
 {% endblock %}

--- a/doc/sphinxdoc/_templates/search.html
+++ b/doc/sphinxdoc/_templates/search.html
@@ -27,6 +27,7 @@
 <script src="{{ pathto("_static/doctools.js", 1) }}"></script>
 <script src="{{ pathto("_static/documentation_options.js", 1) }}"></script>
 <script src="{{ pathto("_static/searchtools.js", 1) }}"></script>
+<script src="{{ pathto("_static/sphinx_highlight.js", 1) }}"></script>
 <script src="{{ pathto("_static/language_data.js", 1) }}"></script>
 <script src="{{ pathto("searchindex.js", 1) }}" defer></script>
 {% endblock %}

--- a/doc/sphinxdoc/_templates/search.html
+++ b/doc/sphinxdoc/_templates/search.html
@@ -24,20 +24,8 @@
 {% endblock %}
 
 {% block extrafooter %}
-<script>
-  jQuery = $;
-  $('#fallback').hide();
-  var DOCUMENTATION_OPTIONS = {
-    URL_ROOT: './',
-    VERSION: '{{version}}',
-    COLLAPSE_INDEX: false,
-    SOURCELINK_SUFFIX: '.txt',
-    FILE_SUFFIX: '.html',
-    HAS_SOURCE: true
-  };
-
-</script>
 <script src="{{ pathto("_static/doctools.js", 1) }}"></script>
+<script src="{{ pathto("_static/documentation_options.js", 1) }}"></script>
 <script src="{{ pathto("_static/searchtools.js", 1) }}"></script>
 <script src="{{ pathto("_static/language_data.js", 1) }}"></script>
 <script src="{{ pathto("searchindex.js", 1) }}" defer></script>

--- a/doc/sphinxdoc/_templates/search.html
+++ b/doc/sphinxdoc/_templates/search.html
@@ -37,7 +37,6 @@
   };
 
 </script>
-<script src="{{ pathto("_static/underscore.js", 1) }}"></script>
 <script src="{{ pathto("_static/doctools.js", 1) }}"></script>
 <script src="{{ pathto("_static/searchtools.js", 1) }}"></script>
 <script>

--- a/doc/sphinxdoc/_templates/sphinxdoc_mtg/base.html
+++ b/doc/sphinxdoc/_templates/sphinxdoc_mtg/base.html
@@ -43,7 +43,7 @@
       {%- endif %}
 {%- endmacro %}
 
-<html lang="en">
+<html{% if language is not none %} lang="{{ language }}"{% endif %} data-content_root="{{ content_root }}">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/doc/sphinxdoc/conf.py
+++ b/doc/sphinxdoc/conf.py
@@ -116,6 +116,10 @@ pygments_style = 'friendly'
 # a list of builtin themes.
 html_theme = 'sphinxdoc_mtg'
 
+# If true, the text around the keyword is shown as summary of each search result.
+# Default is True.
+html_show_search_summary = False
+
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ['_templates']
 

--- a/doc/sphinxdoc/conf.py
+++ b/doc/sphinxdoc/conf.py
@@ -46,7 +46,7 @@ import sys, os
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.viewcode',
               'sphinxcontrib.doxylink',
-              'sphinxprettysearchresults',
+              # 'sphinxprettysearchresults',
               'sphinx.ext.autosectionlabel',
               'sphinx_toolbox.collapse']
 

--- a/doc/sphinxdoc/installing.rst
+++ b/doc/sphinxdoc/installing.rst
@@ -189,7 +189,7 @@ Install doxigen and pip3. If you are on Linux::
 
 Install additional dependencies (you might need to run this command with sudo)::
 
-  pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinxprettysearchresults sphinx-toolbox
+  pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox
   sudo apt-get install pandoc
 
 Make sure to build Essentia with Python 3 bindings and run::


### PR DESCRIPTION
These changes should restore Sphinx search functionality to the Essentia documentation website.

Roughly speaking: the custom `search.html` template in `essentia.git` has drifted from the JavaScript files and interfaces provided during a Sphinx HTML documentation build.

Additionally, the `sphinxprettysearchresults` extension is removed; it was a workaround for a bug that caused unclearly-formatted search results that was fixed in v2.0.0 of Sphinx.

No server-side changes are required with this change.

Resolves #1198.