### PR TITLE
PitchYinFFT updates (new weighting parameter, do not throw exception on empty peak detection)

### DIFF
--- a/src/algorithms/tonal/pitchyinfft.h
+++ b/src/algorithms/tonal/pitchyinfft.h
@@ -58,6 +58,7 @@ class PitchYinFFT : public Algorithm {
   int _tauMin;
   int _tauMax;
   Real _tolerance;
+  std::string _weighting;
 
  public:
   PitchYinFFT() {
@@ -83,12 +84,13 @@ class PitchYinFFT : public Algorithm {
     declareParameter("maxFrequency", "the maximum allowed frequency [Hz]", "(0,inf)", 22050.0);
     declareParameter("interpolate", "boolean flag to enable interpolation", "{true,false}", true);
     declareParameter("tolerance", "tolerance for peak detection", "[0,1]", 1.0);
+    declareParameter("weighting", "string to assign a weighting function", "{default,A,B,C,D,Z}", "default");
   }
 
   void configure();
   void compute();
 
-  void spectralWeights();
+  void spectralWeights(std::string weighting);
 
   static const char* name;
   static const char* category;


### PR DESCRIPTION
1) Add weighting parameter to select different weighting funcitons in PITCHYINFFT algorithm. The available choices are: 
    - the default weighting function
    - A-weighting
    - B-weighting
    - C-weighting
    - D-weighting
    - Z-weighting.

    Note that there is not experimental validation of better pitch estimation performance with new alternative weightings. 

2) Change behavior on empty spectrum peak detection: output zero pitch and confidence instead of throwing an exception.

@dbogdanov Edited for completeness.