### PR TITLE
[feat] Add related tutorials in algorithms docs

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Essentia
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.1-beta6-dev
+PROJECT_NUMBER  = 2.1-beta6-dev
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/sphinxdoc/installing.rst
+++ b/doc/sphinxdoc/installing.rst
@@ -189,7 +189,7 @@ Install doxigen and pip3. If you are on Linux::
 
 Install additional dependencies (you might need to run this command with sudo)::
 
-  pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox
+  pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat
   sudo apt-get install pandoc
 
 Make sure to build Essentia with Python 3 bindings and run::


### PR DESCRIPTION
Display jupyter notebook tutorials using the algorithm in its documentation page