### PR TITLE
[feat] Support source code links from algorithm reference

### DIFF
--- a/doc/sphinxdoc/installing.rst
+++ b/doc/sphinxdoc/installing.rst
@@ -189,7 +189,7 @@ Install doxigen and pip3. If you are on Linux::
 
 Install additional dependencies (you might need to run this command with sudo)::
 
-  pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat
+  pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat gitpython
   sudo apt-get install pandoc
 
 Make sure to build Essentia with Python 3 bindings and run::


### PR DESCRIPTION
Add links to C++ source and header file for each algorithm
<img width="1171" alt="Screenshot 2024-04-12 at 12 17 22" src="https://github.com/MTG/essentia/assets/21194620/a291e69b-3b68-4ecb-8e71-b1af458fc6d0">
