### PR TITLE
[fix] Update deprecated artifact action versions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Fetch release tags from GitHub
@@ -44,7 +44,7 @@ jobs:
         run: |
           python3 waf doc
       - name: Upload built documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: essentia-docs
           path: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,7 +32,7 @@ jobs:
       PRE_CMD: ${{ matrix.PRE_CMD }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Fetch release tags from GitHub
@@ -51,7 +51,7 @@ jobs:
           ls wheelhouse/
           sudo python setup.py sdist
       - name: Upload wheels and sdist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: essentia-python-wheels
           path: |


### PR DESCRIPTION
Update `upload-artifact` checkout version from `v2` to `v4` in following workflow files -
 - `build-docs`
 - `build-wheels`