### PR TITLE
Fix build issues with deprecated functions in C++17

### DIFF
--- a/src/algorithms/highlevel/chromaprinter.cpp
+++ b/src/algorithms/highlevel/chromaprinter.cpp
@@ -54,7 +54,7 @@ void Chromaprinter::compute() {
   // Copy the signal to new vector to expand it to the int16_t dynamic range before the cast.
   std::vector<Real> signalScaled = signal;
   std::transform(signalScaled.begin(), signalScaled.end(), signalScaled.begin(),
-                 std::bind1st(std::multiplies<Real>(), pow(2,15)));
+                 std::bind(std::multiplies<Real>(), pow(2,15), std::placeholders::_1));
 
   std::vector<int16_t> signalCast(signalScaled.begin(), signalScaled.end());
 
@@ -160,7 +160,7 @@ AlgorithmStatus Chromaprinter::process() {
     // Copy the signal to new vector to expand it to the int16_t dynamic range before the cast.
     std::vector<Real> signalScaled = signal;
     std::transform(signalScaled.begin(), signalScaled.end(), signalScaled.begin(),
-                   std::bind1st(std::multiplies<Real>(), pow(2,15)));
+                   std::bind(std::multiplies<Real>(), pow(2,15), std::placeholders::_1));
 
     std::vector<int16_t> signalCast(signalScaled.begin(), signalScaled.end());
 

--- a/src/essentia/essentiamath.h
+++ b/src/essentia/essentiamath.h
@@ -914,7 +914,7 @@ std::vector<T> derivative(const std::vector<T>& array) {
 }
 
 template<typename T, typename U, typename Comparator=std::greater<T> >
-class PairCompare : public std::binary_function<T, U, bool> {
+class PairCompare {
   Comparator _cmp;
   public:
     bool operator () (const std::pair<T,U>& p1, const std::pair<T,U>& p2) const {

--- a/src/essentia/types.h
+++ b/src/essentia/types.h
@@ -115,8 +115,7 @@ inline bool case_insensitive_char_cmp(char a, char b) {
 /**
  * Function object for comparing two strings in a case-insensitive manner.
  */
-struct case_insensitive_str_cmp
-  : public std::binary_function<const std::string&, const std::string&, bool> {
+struct case_insensitive_str_cmp {
   bool operator()(const std::string& str1, const std::string& str2) const {
     return std::lexicographical_compare(str1.begin(), str1.end(),
                                         str2.begin(), str2.end(),

--- a/src/essentia/utils/peak.h
+++ b/src/essentia/utils/peak.h
@@ -71,7 +71,7 @@ class Peak {
 // the positions are equal it sorts by descending magnitude
 template<typename Comp1=std::less<Real>,
          typename Comp2=std::greater_equal<Real> >
-class ComparePeakPosition : public std::binary_function<Real, Real, bool> {
+class ComparePeakPosition {
   Comp1 _cmp1;
   Comp2 _cmp2;
   public:
@@ -86,7 +86,7 @@ class ComparePeakPosition : public std::binary_function<Real, Real, bool> {
 // the magnitudes are equal it sorts by ascending position
 template<typename Comp1=std::greater<Real>,
          typename Comp2=std::less_equal<Real> >
-class ComparePeakMagnitude : public std::binary_function<Real, Real, bool> {
+class ComparePeakMagnitude {
   Comp1 _cmp1;
   Comp2 _cmp2;
   public:


### PR DESCRIPTION
## Overview

This PR fixes build errors encountered when compiling Essentia with C++17 due to the removal of functions deprecated in C++11 (std::bind1st, std::binary_function). These deprecated functions have been replaced by the recommended alternatives (std::bind with placeholders and direct implementation without inheriting from std::binary_function).

## Motivation

Ensures compatibility and successful compilation with modern C++ standards (C++17 and newer), improving maintainability and future-proofing the codebase.

## Related Issues and Pull Requests

- **Issue #1206**: Compilation failure due to the removal of `std::binary_function` in C++17.
- **Pull Request #1370**: Initial fixes for C++17 compatibility issues.

## Solution

Inspired by the work of [@wo80](https://github.com/wo80) in commit [c98daf9](https://github.com/wo80/essentia/commit/c98daf92f9506dab0923e3aa03305ffb9297e722), this PR updates the codebase by:

- Removing the use of `std::binary_function`, which was deprecated in C++11 and removed in C++17.
- Replaced deprecated `std::bind1st` with `std::bind` using placeholders (`std::placeholders::_1`).

These changes align with the ongoing efforts to modernize the build system, as discussed in [Issue #1398](https://github.com/MTG/essentia/issues/1398), which focuses on migrating to CMake and enhancing compatibility with newer toolchains.

## Testing

The updates have been tested using the lightweight Waf (with the `--std=c++17` flag)  build system with the following configuration:

```bash
ESS_DIR=$(pwd)
python3 waf configure --build-static --static-dependencies --std=c++17 --lightweight= --out=$ESS_DIR/build/
python3 waf -v
python3 waf install  # May require sudo privileges
```

Testing was conducted on an Apple Silicon M1 system running macOS Sonoma 14.7.3.

Notes:
 - While this PR focuses on updating deprecated functions, it does not address the broader build system migration to CMake.
 - Further testing on other platforms and configurations is recommended to ensure comprehensive compatibility.

