### PR TITLE
Update to NumPy 2 C-API

### DIFF
--- a/pyproject-tensorflow.toml
+++ b/pyproject-tensorflow.toml
@@ -21,7 +21,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 
 [tool.cibuildwheel.macos]
 
-skip = ["pp*"]
+skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
@@ -45,7 +45,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
-skip = ["pp*"]
+skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 
 [tool.cibuildwheel.macos]
 
-skip = ["pp*"]
+skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
@@ -42,7 +42,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
-skip = ["pp*"]
+skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1 }
 

--- a/src/python/pytypes/matrixreal.cpp
+++ b/src/python/pytypes/matrixreal.cpp
@@ -32,17 +32,19 @@ PyObject* MatrixReal::toPythonRef(TNT::Array2D<Real>* mat) {
 
   PyObject* result;
   if (dims[0] == 0 || dims[1] == 0) {
-    result = PyArray_SimpleNew(2, dims, PyArray_FLOAT);
+    result = PyArray_SimpleNew(2, dims, NPY_FLOAT);
   }
   else {
-    result = PyArray_SimpleNewFromData(2, dims, PyArray_FLOAT, &((*mat)[0][0]));
+    result = PyArray_SimpleNewFromData(2, dims, NPY_FLOAT, &((*mat)[0][0]));
   }
 
   if (result == NULL) {
     throw EssentiaException("MatrixReal: dang null object");
   }
 
-  PyArray_BASE(result) = TO_PYTHON_PROXY(MatrixReal, mat);
+  PyObject* resultBase;
+  resultBase = PyArray_BASE((PyArrayObject*) result);
+  resultBase = TO_PYTHON_PROXY(MatrixReal, mat);
 
   return result;
 }
@@ -65,11 +67,11 @@ void* MatrixReal::fromPythonCopy(PyObject* obj) {
   if (!PyArray_Check(obj)) {
     throw EssentiaException("MatrixReal::fromPythonRef: argument not a PyArray");
   }
-  if (PyArray_NDIM(obj) != 2) {
+  if (PyArray_NDIM((const PyArrayObject *) obj) != 2) {
     throw EssentiaException("MatrixReal::fromPythonRef: argument is not a 2-dimensional PyArray");
   }
 
-  TNT::Array2D<Real>* tntmat = new TNT::Array2D<Real>(PyArray_DIM(obj, 0), PyArray_DIM(obj, 1), 0.0);
+  TNT::Array2D<Real>* tntmat = new TNT::Array2D<Real>(PyArray_DIM((const PyArrayObject *) obj, 0), PyArray_DIM((const PyArrayObject *) obj, 1), 0.0);
 
   // copy data from numpy array to matrix
   PyArrayObject* numpyarr = (PyArrayObject*)obj;

--- a/src/python/pytypes/matrixreal.cpp
+++ b/src/python/pytypes/matrixreal.cpp
@@ -42,9 +42,10 @@ PyObject* MatrixReal::toPythonRef(TNT::Array2D<Real>* mat) {
     throw EssentiaException("MatrixReal: dang null object");
   }
 
-  PyObject* resultBase;
-  resultBase = PyArray_BASE((PyArrayObject*) result);
-  resultBase = TO_PYTHON_PROXY(MatrixReal, mat);
+  if (PyArray_SetBaseObject((PyArrayObject*)result, TO_PYTHON_PROXY(MatrixReal, mat)) < 0) {
+    Py_DECREF(result);
+    throw EssentiaException("MatrixReal: failed to set base object");
+  }
 
   return result;
 }

--- a/src/python/pytypes/tensorreal.cpp
+++ b/src/python/pytypes/tensorreal.cpp
@@ -35,7 +35,7 @@ PyObject* TensorReal::toPythonCopy(const essentia::Tensor<essentia::Real>* tenso
   for (int i = 0; i < nd; i++)
     dims[i] = tensor->dimension(i);
 
-  result = PyArray_SimpleNew(nd, dims, PyArray_FLOAT);
+  result = PyArray_SimpleNew(nd, dims, NPY_FLOAT);
 
   Real* dest = (Real*)(((PyArrayObject*)result)->data);
   const Real* src = tensor->data();
@@ -55,19 +55,19 @@ void* TensorReal::fromPythonCopy(PyObject* obj) {
   if (!PyArray_Check(obj)) {
     throw EssentiaException("TensorReal::fromPythonRef: expected PyArray, received: ", strtype(obj));
   }
-  if (PyArray_NDIM(obj) != TENSORRANK) {
+  if (PyArray_NDIM((const PyArrayObject *) obj) != TENSORRANK) {
     throw EssentiaException("TensorReal::fromPythonCopy: argument is not a 4-dimensional PyArray");
   }
 
   // // copy data from numpy array to matrix
   PyArrayObject* numpyarr = (PyArrayObject*)obj;
-  if (numpyarr->descr->type_num != PyArray_FLOAT) {
+  if (numpyarr->descr->type_num != NPY_FLOAT) {
      throw EssentiaException("TensorReal::fromPythonRef: this NumPy array doesn't contain Reals (maybe you forgot dtype='f4')");
    }
 
   return new Tensor<Real>(TensorMap<Real>((Real *)PyArray_DATA(numpyarr),
-                                                  PyArray_DIM(obj, 0),
-                                                  PyArray_DIM(obj, 1),
-                                                  PyArray_DIM(obj, 2),
-                                                  PyArray_DIM(obj, 3)));
+                                                  PyArray_DIM(numpyarr, 0),
+                                                  PyArray_DIM(numpyarr, 1),
+                                                  PyArray_DIM(numpyarr, 2),
+                                                  PyArray_DIM(numpyarr, 3)));
 }

--- a/src/python/pytypes/vectorcomplex.cpp
+++ b/src/python/pytypes/vectorcomplex.cpp
@@ -28,16 +28,18 @@ PyObject* VectorComplex::toPythonRef(RogueVector<complex<Real> >* v) {
   npy_intp dim = v->size();
   PyObject* result;
 
-  if (dim > 0) result = PyArray_SimpleNewFromData(1, &dim, PyArray_COMPLEX64, &((*v)[0]));
-  else         result = PyArray_SimpleNew(1, &dim, PyArray_COMPLEX64);
+  if (dim > 0) result = PyArray_SimpleNewFromData(1, &dim, NPY_COMPLEX64, &((*v)[0]));
+  else         result = PyArray_SimpleNew(1, &dim, NPY_COMPLEX64);
 
   if (result == NULL) {
-    throw EssentiaException("VectorComplex::toPythonRef: could not create PyArray of type PyArray_COMPLEX64");
+    throw EssentiaException("VectorComplex::toPythonRef: could not create PyArray of type NPY_COMPLEX64");
   }
 
   // set the PyArray pointer to our vector, so it can be released when the
   // PyArray is released
-  PyArray_BASE(result) = TO_PYTHON_PROXY(VectorComplex, v);
+  PyObject* resultBase;
+  resultBase = PyArray_BASE((PyArrayObject*) result);
+  resultBase = TO_PYTHON_PROXY(VectorComplex, v);
 
   return result;
 }
@@ -50,12 +52,12 @@ void* VectorComplex::fromPythonRef(PyObject* obj) {
 
   PyArrayObject* array = (PyArrayObject*)obj;
 
-  if (array->descr->type_num != PyArray_CFLOAT) {
+  if (array->descr->type_num != NPY_CFLOAT) {
     throw EssentiaException("VectorComplex::fromPythonRef: this NumPy array doesn't contain complex<Real> (maybe you forgot dtype='c8')");
   }
   if (array->nd != 1) {
     throw EssentiaException("VectorComplex::fromPythonRef: this NumPy array has dimension ", array->nd, " (expected 1)");
   }
 
-  return new RogueVector<complex<Real> >((complex<Real>*)PyArray_DATA(obj), PyArray_SIZE(obj));
+  return new RogueVector<complex<Real> >((complex<Real>*)PyArray_DATA(array), PyArray_SIZE(array));
 }

--- a/src/python/pytypes/vectorcomplex.cpp
+++ b/src/python/pytypes/vectorcomplex.cpp
@@ -37,9 +37,10 @@ PyObject* VectorComplex::toPythonRef(RogueVector<complex<Real> >* v) {
 
   // set the PyArray pointer to our vector, so it can be released when the
   // PyArray is released
-  PyObject* resultBase;
-  resultBase = PyArray_BASE((PyArrayObject*) result);
-  resultBase = TO_PYTHON_PROXY(VectorComplex, v);
+  if (PyArray_SetBaseObject((PyArrayObject*)result, TO_PYTHON_PROXY(VectorComplex, v)) < 0) {
+    Py_DECREF(result);
+    throw EssentiaException("VectorComplex: failed to set base object");
+  }
 
   return result;
 }

--- a/src/python/pytypes/vectorinteger.cpp
+++ b/src/python/pytypes/vectorinteger.cpp
@@ -34,9 +34,10 @@ PyObject* VectorInteger::toPythonRef(RogueVector<int>* v) {
     throw EssentiaException("VectorInteger::toPythonRef: could not create PyArray of type NPY_INT");
   }
 
-  PyObject* resultBase;
-  resultBase = PyArray_BASE((const PyArrayObject *) result);
-  resultBase = TO_PYTHON_PROXY(VectorInteger, v);
+  if (PyArray_SetBaseObject((PyArrayObject*)result, TO_PYTHON_PROXY(VectorInteger, v)) < 0) {
+    Py_DECREF(result);
+    throw EssentiaException("VectorInteger: failed to set base object");
+  }
 
   return result;
 }

--- a/src/python/pytypes/vectorinteger.cpp
+++ b/src/python/pytypes/vectorinteger.cpp
@@ -27,14 +27,16 @@ PyObject* VectorInteger::toPythonRef(RogueVector<int>* v) {
   npy_intp dim = v->size();
   PyObject* result;
 
-  if (dim > 0) result = PyArray_SimpleNewFromData(1, &dim, PyArray_INT, &((*v)[0]));
-  else         result = PyArray_SimpleNew(1, &dim, PyArray_INT);
+  if (dim > 0) result = PyArray_SimpleNewFromData(1, &dim, NPY_INT, &((*v)[0]));
+  else         result = PyArray_SimpleNew(1, &dim, NPY_INT);
 
   if (result == NULL) {
-    throw EssentiaException("VectorInteger::toPythonRef: could not create PyArray of type PyArray_INT");
+    throw EssentiaException("VectorInteger::toPythonRef: could not create PyArray of type NPY_INT");
   }
 
-  PyArray_BASE(result) = TO_PYTHON_PROXY(VectorInteger, v);
+  PyObject* resultBase;
+  resultBase = PyArray_BASE((const PyArrayObject *) result);
+  resultBase = TO_PYTHON_PROXY(VectorInteger, v);
 
   return result;
 }
@@ -48,14 +50,14 @@ void* VectorInteger::fromPythonRef(PyObject* obj) {
 
   PyArrayObject* array = (PyArrayObject*)obj;
 
-  if (array->descr->type_num != PyArray_INT32) {
+  if (array->descr->type_num != NPY_INT32) {
     throw EssentiaException("VectorInteger::fromPythonRef: this NumPy array doesn't contain ints (maybe you forgot dtype='int'), type code: ", array->descr->type_num);
   }
   if (array->nd != 1) {
     throw EssentiaException("VectorInteger::fromPythonRef: this NumPy array has dimension ", array->nd, " (expected 1)");
   }
 
-  return new RogueVector<int>((int*)PyArray_DATA(obj), PyArray_SIZE(obj));
+  return new RogueVector<int>((int*)PyArray_DATA(array), PyArray_SIZE(array));
 }
 
 Parameter* VectorInteger::toParameter(PyObject* obj) {

--- a/src/python/pytypes/vectormatrixreal.cpp
+++ b/src/python/pytypes/vectormatrixreal.cpp
@@ -33,7 +33,7 @@ PyObject* VectorMatrixReal::toPythonCopy(const vector<TNT::Array2D<Real> >* matV
     dims[0] = (*matVec)[i].dim1();
     dims[1] = (*matVec)[i].dim2();
 
-    PyArrayObject* mat = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_FLOAT);
+    PyArrayObject* mat = (PyArrayObject*)PyArray_SimpleNew(2, dims, NPY_FLOAT);
 
     if (mat == NULL) {
       throw EssentiaException("VectorMatrixReal::toPythonCopy: dang null object");

--- a/src/python/pytypes/vectorreal.cpp
+++ b/src/python/pytypes/vectorreal.cpp
@@ -27,14 +27,16 @@ PyObject* VectorReal::toPythonRef(RogueVector<Real>* v) {
   npy_intp dim = v->size();
   PyObject* result;
 
-  if (dim > 0) result = PyArray_SimpleNewFromData(1, &dim, PyArray_FLOAT, &((*v)[0]));
-  else         result = PyArray_SimpleNew(1, &dim, PyArray_FLOAT);
+  if (dim > 0) result = PyArray_SimpleNewFromData(1, &dim, NPY_FLOAT, &((*v)[0]));
+  else         result = PyArray_SimpleNew(1, &dim, NPY_FLOAT);
 
   if (result == NULL) {
     throw EssentiaException("VectorReal: dang null object");
   }
 
-  PyArray_BASE(result) = TO_PYTHON_PROXY(VectorReal, v);
+  PyObject* resultBase;
+  resultBase = PyArray_BASE((PyArrayObject*) result);
+  resultBase = TO_PYTHON_PROXY(VectorReal, v);
 
   return result;
 }
@@ -48,14 +50,14 @@ void* VectorReal::fromPythonRef(PyObject* obj) {
 
   PyArrayObject* array = (PyArrayObject*)obj;
 
-  if (array->descr->type_num != PyArray_FLOAT) {
+  if (array->descr->type_num != NPY_FLOAT) {
     throw EssentiaException("VectorReal::fromPythonRef: this NumPy array doesn't contain Reals (maybe you forgot dtype='f4')");
   }
   if (array->nd != 1) {
     throw EssentiaException("VectorReal::fromPythonRef: this NumPy array has dimension ", array->nd, " (expected 1)");
   }
 
-  return new RogueVector<Real>((Real*)PyArray_DATA(obj), PyArray_SIZE(obj));
+  return new RogueVector<Real>((Real*)PyArray_DATA(array), PyArray_SIZE(array));
 }
 
 Parameter* VectorReal::toParameter(PyObject* obj) {

--- a/src/python/pytypes/vectorreal.cpp
+++ b/src/python/pytypes/vectorreal.cpp
@@ -34,9 +34,10 @@ PyObject* VectorReal::toPythonRef(RogueVector<Real>* v) {
     throw EssentiaException("VectorReal: dang null object");
   }
 
-  PyObject* resultBase;
-  resultBase = PyArray_BASE((PyArrayObject*) result);
-  resultBase = TO_PYTHON_PROXY(VectorReal, v);
+  if (PyArray_SetBaseObject((PyArrayObject*)result, TO_PYTHON_PROXY(VectorReal, v)) < 0) {
+    Py_DECREF(result);
+    throw EssentiaException("VectorReal: failed to set base object");
+  }
 
   return result;
 }

--- a/src/python/pytypes/vectorstereosample.cpp
+++ b/src/python/pytypes/vectorstereosample.cpp
@@ -49,18 +49,19 @@ void* VectorStereoSample::fromPythonCopy(PyObject* obj) {
                             "is not a numpy array: ", strtype(obj));
   }
 
-  if (PyArray_NDIM(obj) != 2) {
-    throw EssentiaException("VectorStereoSample::fromPythonCopy: given input "
-                            "is not a 2-dimensional numpy array: ", PyArray_NDIM(obj));
-  }
-
-  if (PyArray_DIM(obj, 1) != 2) {
-    throw EssentiaException("VectorStereoSample::fromPythonCopy: given input's "
-                            "second dimension is not 2: ", PyArray_DIM(obj, 1));
-  }
-
-  Py_ssize_t total = PyArray_DIM(obj, 0);
   PyArrayObject* arr = (PyArrayObject*)obj;
+  
+  if (PyArray_NDIM(arr) != 2) {
+    throw EssentiaException("VectorStereoSample::fromPythonCopy: given input "
+                            "is not a 2-dimensional numpy array: ", PyArray_NDIM(arr));
+  }
+
+  if (PyArray_DIM(arr, 1) != 2) {
+    throw EssentiaException("VectorStereoSample::fromPythonCopy: given input's "
+                            "second dimension is not 2: ", PyArray_DIM(arr, 1));
+  }
+
+  Py_ssize_t total = PyArray_DIM(arr, 0);
   vector<StereoSample>* result = new vector<StereoSample>(total);
 
   for (int i=0; i<int(total); ++i) {

--- a/src/python/pytypes/vectortensorreal.cpp
+++ b/src/python/pytypes/vectortensorreal.cpp
@@ -39,7 +39,7 @@ PyObject* VectorTensorReal::toPythonCopy(const vector<Tensor<Real> >* tenVec) {
     for (int j = 0; j< nd; j++)
       dims[j] = tensor.dimension(j);
 
-    PyArrayObject* numpyarr = (PyArrayObject*)PyArray_SimpleNew(nd, dims, PyArray_FLOAT);
+    PyArrayObject* numpyarr = (PyArrayObject*)PyArray_SimpleNew(nd, dims, NPY_FLOAT);
     
     if (numpyarr == NULL) {
       throw EssentiaException("VectorTensorReal::toPythonCopy: dang null object");

--- a/src/python/pytypes/vectorvectorcomplex.cpp
+++ b/src/python/pytypes/vectorvectorcomplex.cpp
@@ -40,7 +40,7 @@ PyObject* VectorVectorComplex::toPythonCopy(const vector<vector<complex<Real> > 
   if (isRectangular && dims[0] > 0 && dims[1] > 0) {
     PyArrayObject* result;
 
-    result = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_COMPLEX64);
+    result = (PyArrayObject*)PyArray_SimpleNew(2, dims, NPY_COMPLEX64);
     assert(result->strides[1] == sizeof(complex<Real>));
 
     if (result == NULL) {

--- a/src/python/pytypes/vectorvectorreal.cpp
+++ b/src/python/pytypes/vectorvectorreal.cpp
@@ -40,7 +40,7 @@ PyObject* VectorVectorReal::toPythonCopy(const vector<vector<Real> >* v) {
   if (isRectangular && dims[0] > 0 && dims[1] > 0) {
     PyArrayObject* result;
 
-    result = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_FLOAT);
+    result = (PyArrayObject*)PyArray_SimpleNew(2, dims, NPY_FLOAT);
     assert(result->strides[1] == sizeof(Real));
 
     if (result == NULL) {
@@ -61,7 +61,7 @@ PyObject* VectorVectorReal::toPythonCopy(const vector<vector<Real> >* v) {
 
   for (int i=0; i<(int)v->size(); ++i) {
     npy_intp itemDims[1] = {(int)(*v)[i].size()};
-    PyArrayObject* item = (PyArrayObject*)PyArray_SimpleNew(1, itemDims, PyArray_FLOAT);
+    PyArrayObject* item = (PyArrayObject*)PyArray_SimpleNew(1, itemDims, NPY_FLOAT);
     assert(item->strides[0] == sizeof(Real));
     if (item == NULL) {
       throw EssentiaException("VectorVectorReal: dang null object (list of numpy arrays)");
@@ -116,15 +116,16 @@ void* VectorVectorReal::fromPythonCopy(PyObject* obj) {
 
     // Numpy array of floats
     else if (PyArray_Check(row)) {
-      if (PyArray_NDIM(row) != 1) {
-        throw EssentiaException("VectorVectorReal::fromPythonCopy: the element of input list "
-                                "is not a 1-dimensional numpy array: ", PyArray_NDIM(row));
-      }
       PyArrayObject* array = (PyArrayObject*)row;
+      if (PyArray_NDIM(array) != 1) {
+        throw EssentiaException("VectorVectorReal::fromPythonCopy: the element of input list "
+                                "is not a 1-dimensional numpy array: ", PyArray_NDIM(array));
+      }
+
       if (array == NULL) {
         throw EssentiaException("VectorVectorReal::fromPythonCopy: dang null object (list of numpy arrays)");
       }
-      if (array->descr->type_num != PyArray_FLOAT) {
+      if (array->descr->type_num != NPY_FLOAT) {
         throw EssentiaException("VectorVectorReal::fromPythonCopy: this NumPy array doesn't contain Reals (maybe you forgot dtype='f4')");
       }
       assert(array->strides[0] == sizeof(Real));

--- a/src/python/pytypes/vectorvectorstereosample.cpp
+++ b/src/python/pytypes/vectorvectorstereosample.cpp
@@ -36,7 +36,7 @@ PyObject* VectorVectorStereoSample::toPythonCopy(const vector<vector<StereoSampl
   }
 
   if (isRectangular) {
-    PyArrayObject* result = (PyArrayObject*)PyArray_SimpleNew(2, dims, PyArray_OBJECT);
+    PyArrayObject* result = (PyArrayObject*)PyArray_SimpleNew(2, dims, NPY_OBJECT);
 
     if (result == NULL) {
       throw EssentiaException("VectorVectorStereoSample: dang null object");

--- a/test/src/unittests/synthesis/test_hprmodel_streaming.py
+++ b/test/src/unittests/synthesis/test_hprmodel_streaming.py
@@ -21,10 +21,12 @@
 
 from essentia_test import *
 import math
+from numpy import append, zeros, sin, round
 
 import essentia
 import essentia.streaming as es
 import essentia.standard as std
+
 
 
 def cutFrames(params, input = range(100)):
@@ -36,43 +38,43 @@ def cutFrames(params, input = range(100)):
                                 hopSize = params['hopSize'],
                                 validFrameThresholdRatio = params['validFrameThresholdRatio'],
                                 startFromZero = params['startFromZero'])
-                                
+
     return [ frame for frame in framegen ]
 
 
 def cleaningHarmonicTracks(freqsTotal, minFrames, pitchConf):
-  
+
   confThreshold = 0.5
-  nFrames = freqsTotal.shape[0];
-  begTrack = 0;
+  nFrames = freqsTotal.shape[0]
+  begTrack = 0
   freqsClean = freqsTotal.copy()
-  
+
   if (nFrames > 0 ):
-    
-    f = 0;
-    nTracks = freqsTotal.shape[1]# we assume all frames have a fix number of tracks
+
+    f = 0
+    nTracks = freqsTotal.shape[1] # we assume all frames have a fix number of tracks
 
     for t in range (nTracks):
-      
-      f = 0;
-      begTrack = f;
-      
+
+      f = 0
+      begTrack = f
+
       while (f < nFrames-1):
-        
+
         #// check if f is begin of track
         if (freqsClean[f][t] <= 0 and freqsClean[f+1][t] > 0 ):
-          begTrack = f+1;
-        
+          begTrack = f+1
+
         # clean track if shorter than min duration
         if ((freqsClean[f][t] > 0 and freqsClean[f+1][t] <= 0 ) and ( (f - begTrack) < minFrames)) :
           for i in range(begTrack, f+1):
-            freqsClean[i][t] = 0;
-            
+            freqsClean[i][t] = 0
+
         # clean track if  pitch confidence for that frameis below a ionfidence threshold
-        if (pitchConf[f] < confThreshold) :        
-          freqsClean[f][t] = 0;
-          
-        f+=1;
+        if (pitchConf[f] < confThreshold) :
+          freqsClean[f][t] = 0
+
+        f+=1
 
   return freqsClean
 
@@ -80,46 +82,43 @@ def cleaningHarmonicTracks(freqsTotal, minFrames, pitchConf):
 # converts audio frames to a single array
 def framesToAudio(frames):
 
-    audio = frames.flatten()      
+    audio = frames.flatten()
     return audio
-    
+
 
 # computes  analysis only
 def analHprModelStreaming(params, signal):
-  
-    #out = numpy.array(0)
+
     pool = essentia.Pool()
     fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False);
-    w = es.Windowing(type = "blackmanharris92");  
+    w = es.Windowing(type = "blackmanharris92");
     spec = es.Spectrum(size = params['frameSize']);
-    
-    # pitch detection
-    pitchDetect = es.PitchYinFFT(frameSize=params['frameSize'], sampleRate =  params['sampleRate'])    
-    smanal = es.HprModelAnal(sampleRate = params['sampleRate'], hopSize = params['hopSize'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'])
-    
-    # add half window of zeros to input signal to reach same ooutput length
-    signal  = numpy.append(signal, zeros(params['frameSize'] // 2))
-    insignal = VectorInput (signal)
 
+    # pitch detection
+    pitchDetect = es.PitchYinFFT(frameSize=params['frameSize'], sampleRate =  params['sampleRate'])
+    smanal = es.HprModelAnal(sampleRate = params['sampleRate'], hopSize = params['hopSize'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'])
+
+    # add half window of zeros to input signal to reach same ooutput length
+    signal  = append(signal, essentia.zeros(params['frameSize'] // 2))
+    insignal = VectorInput(signal)
 
     # analysis
     insignal.data >> fcut.signal
     fcut.frame >> w.frame
-    w.frame >> spec.frame    
+    w.frame >> spec.frame
     spec.spectrum >> pitchDetect.spectrum
-    
+
     fcut.frame >> smanal.frame
-    pitchDetect.pitch >> smanal.pitch  
-    pitchDetect.pitch >> (pool, 'pitch')    
-    pitchDetect.pitchConfidence >> (pool, 'pitchConfidence')  
+    pitchDetect.pitch >> smanal.pitch
+    pitchDetect.pitch >> (pool, 'pitch')
+    pitchDetect.pitchConfidence >> (pool, 'pitchConfidence')
     smanal.magnitudes >> (pool, 'magnitudes')
     smanal.frequencies >> (pool, 'frequencies')
     smanal.phases >> (pool, 'phases')
     smanal.res >> (pool, 'res')
-    
-    
+
     essentia.run(insignal)
-    
+
     # remove first half window frames
     mags = pool['magnitudes']
     freqs = pool['frequencies']
@@ -127,39 +126,39 @@ def analHprModelStreaming(params, signal):
     pitchConf =  pool['pitchConfidence']
 
     # remove short tracks
-    minFrames = int( params['minSineDur'] * params['sampleRate'] / params['hopSize']);
+    minFrames = int(params['minSineDur'] * params['sampleRate'] / params['hopSize'])
     freqsClean = cleaningHarmonicTracks(freqs, minFrames, pitchConf)
-    pool['frequencies'].data = freqsClean
-    
     return mags, freqsClean, phases
-
-
 
 
 # computes analysis/stynthesis
 def analsynthHprModelStreaming(params, signal):
-  
-    out = array([0.])
-  
     pool = essentia.Pool()
+
     # windowing and FFT
-    fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False);
-    w = es.Windowing(type = "blackmanharris92");    
-    spec = es.Spectrum(size = params['frameSize']);
+    fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False)
+    w = es.Windowing(type = "blackmanharris92")
+    spec = es.Spectrum(size = params['frameSize'])
 
     # pitch detection
-    pitchDetect = es.PitchYinFFT(frameSize=params['frameSize'], sampleRate =  params['sampleRate'])    
+    pitchDetect = es.PitchYinFFT(frameSize=params['frameSize'], sampleRate =  params['sampleRate'])
 
-    smanal = es.HprModelAnal(sampleRate = params['sampleRate'], hopSize = params['hopSize'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'])
+    smanal = es.HprModelAnal(sampleRate = params['sampleRate'],
+                             hopSize = params['hopSize'],
+                             maxnSines = params['maxnSines'],
+                             magnitudeThreshold = params['magnitudeThreshold'],
+                             freqDevOffset = params['freqDevOffset'],
+                             freqDevSlope = params['freqDevSlope'],
+                             minFrequency =  params['minFrequency'],
+                             maxFrequency =  params['maxFrequency'])
     synFFTSize = min(int(params['frameSize']/4), 4*params['hopSize'])  # make sure the FFT size is appropriate
     smsyn = es.SprModelSynth(sampleRate=params['sampleRate'],
                              fftSize=synFFTSize,
                              hopSize=params['hopSize'])
 
     # add half window of zeros to input signal to reach same ooutput length
-    signal  = numpy.append(signal, zeros(params['frameSize'] // 2))
-    insignal = VectorInput (signal)
-
+    signal = append(signal, essentia.zeros(params['frameSize'] // 2))
+    insignal = VectorInput(signal)
 
     # analysis
     insignal.data >> fcut.signal
@@ -184,33 +183,32 @@ def analsynthHprModelStreaming(params, signal):
 
     essentia.run(insignal)
 
-    outaudio = framesToAudio(pool['frames'])   
+    outaudio = framesToAudio(pool['frames'])
     outaudio = outaudio[2*params['hopSize']:]
 
     return outaudio, pool
 
 
 
-#-------------------------------------
 
 class TestHprModel(TestCase):
 
     params = { 'frameSize': 2048, 'hopSize': 128, 'startFromZero': False, 'sampleRate': 44100,'maxnSines': 100,'magnitudeThreshold': -74,'minSineDur': 0.02,'freqDevOffset': 10, 'freqDevSlope': 0.001, 'maxFrequency': 550.,'minFrequency': 65.}
-    
+
     precisiondB = -40. # -40dB of allowed noise floor for sinusoidal model
-    precisionDigits = int(-numpy.round(precisiondB/20.) -1) # -1 due to the rounding digit comparison.
-    
+    precisionDigits = int(-round(precisiondB/20.) -1) # -1 due to the rounding digit comparison.
+
 
     def testZero(self):
-      
+
         # generate test signal
         signalSize = 20 * self.params['frameSize']
-        signal = zeros(signalSize)
-        
+        signal = essentia.zeros(signalSize)
+
         [mags, freqs, phases] = analHprModelStreaming(self.params, signal)
 
         # compare
-        zerofreqs = numpy.zeros(freqs.shape)
+        zerofreqs = zeros(freqs.shape)
         self.assertAlmostEqualMatrix(freqs, zerofreqs)
 
 
@@ -218,47 +216,41 @@ class TestHprModel(TestCase):
         from random import random
         # generate test signal
         signalSize = 20 * self.params['frameSize']
-        signal = array([2*(random()-0.5)*i for i in ones(signalSize)])
-        
-        
+        signal = array([2*(random()-0.5)*i for i in essentia.ones(signalSize)])
+
+
         # for white noise test set sine minimum duration to 350ms, and min threshold of -20dB
         self.params['minSineDur'] = 0.35 # limit pitch tracks of a nimumim length of 350ms for the case of white noise input
         self.params['magnitudeThreshold']= -20
-    
+
         [mags, freqs, phases]  = analHprModelStreaming(self.params, signal)
-        
+
         # compare: no frequencies  should be found
-        zerofreqs = numpy.zeros(freqs.shape)
+        zerofreqs = zeros(freqs.shape)
         self.assertAlmostEqualMatrix(freqs, zerofreqs)
 
     def testRegression(self):
 
         # generate test signal: sine 220Hz @44100kHz
         signalSize = 20 * self.params['frameSize']
-        signal = .5 * numpy.sin( (array(range(signalSize))/self.params['sampleRate']) * 220 * 2*math.pi)
+        signal = .5 * sin( (array(range(signalSize))/self.params['sampleRate']) * 220 * 2*math.pi)
 
-        # generate noise components        
-        from random import random            
-        noise = 0.1 * array([2*(random()-0.5)*i for i in ones(signalSize)]) # -10dB
+        # generate noise components
+        from random import random
+        noise = 0.1 * array([2*(random()-0.5)*i for i in essentia.ones(signalSize)]) # -10dB
         signal = signal + noise
 
-        outsignal,pool = analsynthHprModelStreaming(self.params, signal)
+        outsignal, pool = analsynthHprModelStreaming(self.params, signal)
 
         outsignal = outsignal[:signalSize] # cut to durations of input and output signal
 
         # compare without half-window bounds to avoid windowing effect
         halfwin = self.params['frameSize'] // 2
 
-                
         self.assertAlmostEqualVectorFixedPrecision(outsignal[halfwin:-halfwin], signal[halfwin:-halfwin], self.precisionDigits)
-
-
-
-
 
 
 suite = allTests(TestHprModel)
 
 if __name__ == '__main__':
     TextTestRunner(verbosity=2).run(suite)
-

--- a/test/src/unittests/synthesis/test_sinemodel_streaming.py
+++ b/test/src/unittests/synthesis/test_sinemodel_streaming.py
@@ -30,61 +30,57 @@ import essentia.standard as std
 def cutFrames(params, input = range(100)):
 
     if not 'validFrameThresholdRatio' in params:
-      params['validFrameThresholdRatio'] = 0
+        params['validFrameThresholdRatio'] = 0
     framegen = std.FrameGenerator(input,
                                 frameSize = params['frameSize'],
                                 hopSize = params['hopSize'],
                                 validFrameThresholdRatio = params['validFrameThresholdRatio'],
                                 startFromZero = params['startFromZero'])
-                                
+
     return [ frame for frame in framegen ]
 
 
 def cleaningSineTracks(freqsTotal, minFrames):
-  
-  nFrames = freqsTotal.shape[0];
-  begTrack = 0;
+
+  nFrames = freqsTotal.shape[0]
+  begTrack = 0
   freqsClean = freqsTotal.copy()
-  
+
   if (nFrames > 0 ):
-    
-    f = 0;
-    nTracks = freqsTotal.shape[1]# we assume all frames have a fix number of tracks
+
+    f = 0
+    nTracks = freqsTotal.shape[1] # we assume all frames have a fix number of tracks
 
     for t in range (nTracks):
-      
-      f = 0;
-      begTrack = f;
-      
+      f = 0
+      begTrack = f
+
       while (f < nFrames-1):
-        
-        #// check if f is begin of track
+
+        # check if f is begin of track
         if (freqsClean[f][t] <= 0 and freqsClean[f+1][t] > 0 ):
-          begTrack = f+1;
-        
+          begTrack = f+1
+
         # clean track if shorter than min duration
         if ((freqsClean[f][t] > 0 and freqsClean[f+1][t] <= 0 ) and ( (f - begTrack) < minFrames)):
           for i in range(begTrack, f+1):
             freqsClean[i][t] = 0;
-              
-        f+=1;
+
+        f+=1
 
   return freqsClean
 
 
-
 def analSineModelStreaming(params, signal):
-  
-    #out = numpy.array(0)
     pool = essentia.Pool()
     fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False);
-    w = es.Windowing(type = "hann");
-    fft = es.FFT(size = params['frameSize']);
+    w = es.Windowing(type = "hann")
+    fft = es.FFT(size = params['frameSize'])
     smanal = es.SineModelAnal(sampleRate = params['sampleRate'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'])
-    
+
     # add half window of zeros to input signal to reach same ooutput length
-    signal  = numpy.append(signal, zeros(params['frameSize'] // 2))
-    insignal = VectorInput (signal)
+    signal  = numpy.append(signal, essentia.zeros(params['frameSize'] // 2))
+    insignal = VectorInput(signal)
     insignal.data >> fcut.signal
     fcut.frame >> w.frame
     w.frame >> fft.frame
@@ -92,38 +88,34 @@ def analSineModelStreaming(params, signal):
     smanal.magnitudes >> (pool, 'magnitudes')
     smanal.frequencies >> (pool, 'frequencies')
     smanal.phases >> (pool, 'phases')
-    
+
     essentia.run(insignal)
-    
+
     # remove first half window frames
     mags = pool['magnitudes']
     freqs = pool['frequencies']
     phases = pool['phases']
 
     # remove short tracks
-    minFrames = int( params['minSineDur'] * params['sampleRate'] / params['hopSize']);
+    minFrames = int( params['minSineDur'] * params['sampleRate'] / params['hopSize'])
     freqsClean = cleaningSineTracks(freqs, minFrames)
-    pool['frequencies'].data = freqsClean
-    
+
     return mags, freqsClean, phases
 
+
 def analsynthSineModelStreaming(params, signal):
-  
-    out = numpy.array(0)
-  
     pool = essentia.Pool()
-    fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False);
-    w = es.Windowing(type = "blackmanharris92");
-    fft = es.FFT(size = params['frameSize']);
+    fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False)
+    w = es.Windowing(type = "blackmanharris92")
+    fft = es.FFT(size = params['frameSize'])
     smanal = es.SineModelAnal(sampleRate = params['sampleRate'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'])
     smsyn = es.SineModelSynth(sampleRate = params['sampleRate'], fftSize = params['frameSize'], hopSize = params['hopSize'])
     ifft = es.IFFT(size = params['frameSize']);
-    overl = es.OverlapAdd (frameSize = params['frameSize'], hopSize = params['hopSize']);
-
+    overl = es.OverlapAdd (frameSize = params['frameSize'], hopSize = params['hopSize'])
 
     # add half window of zeros to input signal to reach same ooutput length
-    signal  = numpy.append(signal, zeros(params['frameSize'] // 2))
-    insignal = VectorInput (signal)
+    signal  = numpy.append(signal, essentia.zeros(params['frameSize'] // 2))
+    insignal = VectorInput(signal)
     # analysis
     insignal.data >> fcut.signal
     fcut.frame >> w.frame
@@ -141,40 +133,33 @@ def analsynthSineModelStreaming(params, signal):
     overl.signal >> (pool, 'audio')
 
     essentia.run(insignal)
-    
 
     # remove short tracks
-    freqs = pool['frequencies']
-    minFrames = int( params['minSineDur'] * params['sampleRate'] / params['hopSize']);
-    freqsClean = cleaningSineTracks(freqs, minFrames)
-    pool['frequencies'].data = freqsClean
+    #freqs = pool['frequencies']
+    #minFrames = int( params['minSineDur'] * params['sampleRate'] / params['hopSize']);
+    #freqsClean = cleaningSineTracks(freqs, minFrames)
 
     # remove first half window frames
     outaudio = pool['audio']
     outaudio = outaudio [2*params['hopSize']:]
 
-    return outaudio, pool
+    return outaudio
 
-
-
-
-
-#-------------------------------------
 
 class TestSineModel(TestCase):
 
     params = { 'frameSize': 2048, 'hopSize': 512, 'startFromZero': False, 'sampleRate': 44100,'maxnSines': 100,'magnitudeThreshold': -74,'minSineDur': 0.02,'freqDevOffset': 10, 'freqDevSlope': 0.001}
-    
+
     precisiondB = -40. # -40dB of allowed noise floor for sinusoidal model
     precisionDigits = int(-numpy.round(precisiondB/20.) -1) # -1 due to the rounding digit comparison.
-    
+
 
     def testZero(self):
-      
+
         # generate test signal
         signalSize = 10 * self.params['frameSize']
-        signal = zeros(signalSize)
-        
+        signal = essentia.zeros(signalSize)
+
         [mags, freqs, phases] = analSineModelStreaming(self.params, signal)
 
         # compare
@@ -186,14 +171,14 @@ class TestSineModel(TestCase):
         from random import random
         # generate test signal
         signalSize = 10 * self.params['frameSize']
-        signal = array([2*(random()-0.5)*i for i in ones(signalSize)])
-        
+        signal = array([2*(random()-0.5)*i for i in essentia.ones(signalSize)])
+
         # for white noise test set sine minimum duration to 50ms, and min threshold of -20dB
         self.params['minSineDur'] = 0.05
         self.params['magnitudeThreshold']= -20
-    
+
         [mags, freqs, phases]  = analSineModelStreaming(self.params, signal)
-        
+
 
         # compare
         zerofreqs = numpy.zeros(freqs.shape)
@@ -206,23 +191,19 @@ class TestSineModel(TestCase):
         # generate test signal: sine 110Hz @44100kHz
         signalSize = 10 * self.params['frameSize']
         signal = .5 * numpy.sin( (array(range(signalSize))/self.params['sampleRate']) * 110 * 2*math.pi)
-        
-        outsignal,pool = analsynthSineModelStreaming(self.params, signal)
+
+        outsignal = analsynthSineModelStreaming(self.params, signal)
 
         outsignal = outsignal[:signalSize] # cut to durations of input and output signal
 
         # compare without half-window bounds to avoid windowing effect
         halfwin = (self.params['frameSize'] // 2)
-        
+
         # Save sines in a text file. Use only for debugging purposes.
         #numpy.savetxt('sine.txt',signal[halfwin:-halfwin])
         #numpy.savetxt('sine_out.txt',outsignal[halfwin:-halfwin])
-        
+
         self.assertAlmostEqualVectorFixedPrecision(outsignal[halfwin:-halfwin], signal[halfwin:-halfwin], self.precisionDigits)
-
-
-
-
 
 
 suite = allTests(TestSineModel)

--- a/test/src/unittests/synthesis/test_sprmodel_streaming.py
+++ b/test/src/unittests/synthesis/test_sprmodel_streaming.py
@@ -30,81 +30,77 @@ import essentia.standard as std
 def cutFrames(params, input = range(100)):
 
     if not 'validFrameThresholdRatio' in params:
-      params['validFrameThresholdRatio'] = 0
+        params['validFrameThresholdRatio'] = 0
     framegen = std.FrameGenerator(input,
                                 frameSize = params['frameSize'],
                                 hopSize = params['hopSize'],
                                 validFrameThresholdRatio = params['validFrameThresholdRatio'],
                                 startFromZero = params['startFromZero'])
-                                
+
     return [ frame for frame in framegen ]
 
 
 def cleaningSineTracks(freqsTotal, minFrames):
-  
-  nFrames = freqsTotal.shape[0];
-  begTrack = 0;
+
+  nFrames = freqsTotal.shape[0]
+  begTrack = 0
   freqsClean = freqsTotal.copy()
-  
+
   if (nFrames > 0 ):
-    
-    f = 0;
+
+    f = 0
     nTracks = freqsTotal.shape[1]# we assume all frames have a fix number of tracks
 
     for t in range (nTracks):
-      
-      f = 0;
-      begTrack = f;
-      
+
+      f = 0
+      begTrack = f
+
       while (f < nFrames-1):
-        
+
         #// check if f is begin of track
         if (freqsClean[f][t] <= 0 and freqsClean[f+1][t] > 0 ):
-          begTrack = f+1;
-        
+          begTrack = f+1
+
         # clean track if shorter than min duration
         if ((freqsClean[f][t] > 0 and freqsClean[f+1][t] <= 0 ) and ( (f - begTrack) < minFrames)):
           for i in range(begTrack, f+1):
-            freqsClean[i][t] = 0;
-              
-        f+=1;
+            freqsClean[i][t] = 0
+
+        f+=1
 
   return freqsClean
 
 
 def framesToAudio(frames):
 
-    audio = frames.flatten()      
+    audio = frames.flatten()
     return audio
-    
+
 
 def analSprModelStreaming(params, signal):
-  
-    #out = numpy.array(0)
     pool = essentia.Pool()
     fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False);
-    w = es.Windowing(type = "blackmanharris92");  
+    w = es.Windowing(type = "blackmanharris92");
     spec = es.Spectrum(size = params['frameSize']);
-    
-    smanal = es.SprModelAnal(sampleRate = params['sampleRate'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'])
-    
-    # add half window of zeros to input signal to reach same ooutput length
-    signal  = numpy.append(signal, zeros(params['frameSize'] // 2))
-    insignal = VectorInput (signal)
 
+    smanal = es.SprModelAnal(sampleRate = params['sampleRate'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'])
+
+    # add half window of zeros to input signal to reach same ooutput length
+    signal  = numpy.append(signal, essentia.zeros(params['frameSize'] // 2))
+    insignal = VectorInput(signal)
 
     # analysis
     insignal.data >> fcut.signal
- 
-    fcut.frame >> smanal.frame 
+
+    fcut.frame >> smanal.frame
     smanal.magnitudes >> (pool, 'magnitudes')
     smanal.frequencies >> (pool, 'frequencies')
     smanal.phases >> (pool, 'phases')
     smanal.res >> (pool, 'res')
-    
-    
+
     essentia.run(insignal)
-    
+
     # remove first half window frames
     mags = pool['magnitudes']
     freqs = pool['frequencies']
@@ -113,24 +109,16 @@ def analSprModelStreaming(params, signal):
     # remove short tracks
     minFrames = int( params['minSineDur'] * params['sampleRate'] / params['hopSize']);
     freqsClean = cleaningSineTracks(freqs, minFrames)
-    pool['frequencies'].data = freqsClean
-    
+
     return mags, freqsClean, phases
 
 
-
-
-
 def analsynthSprModelStreaming(params, signal):
-
-    out = array([0.])
-
     pool = essentia.Pool()
     # windowing and FFT
     fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False)
-    w = es.Windowing(type = "blackmanharris92") 
-    spec = es.Spectrum(size = params['frameSize'])
-
+    #w = es.Windowing(type = "blackmanharris92")
+    #spec = es.Spectrum(size = params['frameSize'])
 
     smanal = es.SprModelAnal(sampleRate = params['sampleRate'], hopSize = params['hopSize'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'])
     synFFTSize = min(int(params['frameSize']/4), 4*params['hopSize'])  # make sure the FFT size is appropriate
@@ -139,9 +127,8 @@ def analsynthSprModelStreaming(params, signal):
                              hopSize=params['hopSize'])
 
     # add half window of zeros to input signal to reach same ooutput length
-    signal = numpy.append(signal, zeros(params['frameSize'] // 2))
+    signal = numpy.append(signal, essentia.zeros(params['frameSize'] // 2))
     insignal = VectorInput(signal)
-
 
     # analysis
     insignal.data >> fcut.signal
@@ -165,23 +152,20 @@ def analsynthSprModelStreaming(params, signal):
     return outaudio, pool
 
 
-
-#-------------------------------------
-
 class TestSprModel(TestCase):
 
     params = { 'frameSize': 2048, 'hopSize': 128, 'startFromZero': False, 'sampleRate': 44100,'maxnSines': 100,'magnitudeThreshold': -74,'minSineDur': 0.02,'freqDevOffset': 10, 'freqDevSlope': 0.001, 'maxFrequency': 550.,'minFrequency': 65.}
-    
+
     precisiondB = -40. # -40dB of allowed noise floor for sinusoidal model
     precisionDigits = int(-numpy.round(precisiondB/20.) -1) # -1 due to the rounding digit comparison.
-    
+
 
     def testZero(self):
-      
+
         # generate test signal
         signalSize = 10 * self.params['frameSize']
-        signal = zeros(signalSize)
-        
+        signal = essentia.zeros(signalSize)
+
         [mags, freqs, phases] = analSprModelStreaming(self.params, signal)
 
         # compare
@@ -193,19 +177,17 @@ class TestSprModel(TestCase):
         from random import random
         # generate test signal
         signalSize = 10 * self.params['frameSize']
-        signal = array([2*(random()-0.5)*i for i in ones(signalSize)])
-        
+        signal = array([2*(random()-0.5)*i for i in essentia.ones(signalSize)])
+
         # for white noise test set sine minimum duration to 50ms, and min threshold of -20dB
         self.params['minSineDur'] = 0.35 # limit pitch tracks of a nimumim length of 350ms for the case of white noise input
         self.params['magnitudeThreshold']= -20
-    
+
         [mags, freqs, phases]  = analSprModelStreaming(self.params, signal)
-        
 
         # compare
         zerofreqs = numpy.zeros(freqs.shape)
         self.assertAlmostEqualMatrix(freqs, zerofreqs)
-
 
 
     def testRegression(self):
@@ -214,29 +196,22 @@ class TestSprModel(TestCase):
         signalSize = 10 * self.params['frameSize']
         signal = .5 * numpy.sin( (array(range(signalSize))/self.params['sampleRate']) * 110 * 2*math.pi)
 
-        # generate noise components        
-        from random import random            
-        noise = 0.1 * array([2*(random()-0.5)*i for i in ones(signalSize)]) # -10dB
+        # generate noise components
+        from random import random
+        noise = 0.1 * array([2*(random()-0.5)*i for i in essentia.ones(signalSize)]) # -10dB
         signal = signal + noise
-               
-        
-        outsignal,pool = analsynthSprModelStreaming(self.params, signal)
+
+        outsignal, pool = analsynthSprModelStreaming(self.params, signal)
 
         outsignal = outsignal[:signalSize] # cut to durations of input and output signal
 
         # compare without half-window bounds to avoid windowing effect
         halfwin = (self.params['frameSize'] // 2)
 
-        
         self.assertAlmostEqualVectorFixedPrecision(outsignal[halfwin:-halfwin], signal[halfwin:-halfwin], self.precisionDigits)
-
-
-
-
 
 
 suite = allTests(TestSprModel)
 
 if __name__ == '__main__':
     TextTestRunner(verbosity=2).run(suite)
-

--- a/test/src/unittests/synthesis/test_spsmodel_streaming.py
+++ b/test/src/unittests/synthesis/test_spsmodel_streaming.py
@@ -36,75 +36,73 @@ def cutFrames(params, input = range(100)):
                                 hopSize = params['hopSize'],
                                 validFrameThresholdRatio = params['validFrameThresholdRatio'],
                                 startFromZero = params['startFromZero'])
-                                
+
     return [ frame for frame in framegen ]
 
 
 def cleaningSineTracks(freqsTotal, minFrames):
-  
-  nFrames = freqsTotal.shape[0];
-  begTrack = 0;
+
+  nFrames = freqsTotal.shape[0]
+  begTrack = 0
   freqsClean = freqsTotal.copy()
-  
-  if (nFrames > 0 ):
-    
+
+  if (nFrames > 0):
+
     f = 0;
-    nTracks = freqsTotal.shape[1]# we assume all frames have a fix number of tracks
+    nTracks = freqsTotal.shape[1] # we assume all frames have a fix number of tracks
 
     for t in range (nTracks):
-      
-      f = 0;
-      begTrack = f;
-      
+
+      f = 0
+      begTrack = f
+
       while (f < nFrames-1):
-        
+
         #// check if f is begin of track
         if (freqsClean[f][t] <= 0 and freqsClean[f+1][t] > 0 ):
-          begTrack = f+1;
-        
+          begTrack = f+1
+
         # clean track if shorter than min duration
         if ((freqsClean[f][t] > 0 and freqsClean[f+1][t] <= 0 ) and ( (f - begTrack) < minFrames)):
           for i in range(begTrack, f+1):
-            freqsClean[i][t] = 0;
-              
-        f+=1;
+            freqsClean[i][t] = 0
+
+        f+=1
 
   return freqsClean
 
 
 def framesToAudio(frames):
 
-    audio = frames.flatten()      
+    audio = frames.flatten()
     return audio
-    
+
 
 def analSpsModelStreaming(params, signal):
-  
+
     #out = numpy.array(0)
     pool = essentia.Pool()
     fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False);
-    w = es.Windowing(type = "blackmanharris92");  
-    spec = es.Spectrum(size = params['frameSize']);
-    
-    smanal = es.SpsModelAnal(sampleRate = params['sampleRate'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'],  stocf = params['stocf'])
-    
-    # add half window of zeros to input signal to reach same ooutput length
-    signal  = numpy.append(signal, zeros(params['frameSize'] // 2))
-    insignal = VectorInput (signal)
+    w = es.Windowing(type = "blackmanharris92")
+    spec = es.Spectrum(size = params['frameSize'])
 
+    smanal = es.SpsModelAnal(sampleRate = params['sampleRate'], maxnSines = params['maxnSines'], magnitudeThreshold = params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'],  stocf = params['stocf'])
+
+    # add half window of zeros to input signal to reach same ooutput length
+    signal  = numpy.append(signal, essentia.zeros(params['frameSize'] // 2))
+    insignal = VectorInput(signal)
 
     # analysis
     insignal.data >> fcut.signal
- 
-    fcut.frame >> smanal.frame 
+
+    fcut.frame >> smanal.frame
     smanal.magnitudes >> (pool, 'magnitudes')
     smanal.frequencies >> (pool, 'frequencies')
     smanal.phases >> (pool, 'phases')
     smanal.stocenv >> (pool, 'stocenv')
-    
-    
+
     essentia.run(insignal)
-    
+
     # remove first half window frames
     mags = pool['magnitudes']
     freqs = pool['frequencies']
@@ -113,28 +111,25 @@ def analSpsModelStreaming(params, signal):
     # remove short tracks
     minFrames = int( params['minSineDur'] * params['sampleRate'] / params['hopSize']);
     freqsClean = cleaningSineTracks(freqs, minFrames)
-    pool['frequencies'].data = freqsClean
 
     return mags, freqsClean, phases
 
 
 def analsynthSpsModelStreaming(params, signal):
-
-    out = array([0.])
-
     pool = essentia.Pool()
+
     # windowing and FFT
     fcut = es.FrameCutter(frameSize = params['frameSize'], hopSize = params['hopSize'], startFromZero =  False)
-    w = es.Windowing(type = "blackmanharris92")
-    spec = es.Spectrum(size = params['frameSize'])
+    #w = es.Windowing(type = "blackmanharris92")
+    #spec = es.Spectrum(size = params['frameSize'])
 
     smanal = es.SpsModelAnal(sampleRate=params['sampleRate'], hopSize=params['hopSize'], maxnSines=params['maxnSines'], magnitudeThreshold=params['magnitudeThreshold'], freqDevOffset = params['freqDevOffset'], freqDevSlope = params['freqDevSlope'], minFrequency =  params['minFrequency'], maxFrequency =  params['maxFrequency'], stocf = params['stocf'])
     synFFTSize = min(int(params['frameSize']/4), 4*params['hopSize'])  # make sure the FFT size is appropriate
     smsyn = es.SpsModelSynth(sampleRate=params['sampleRate'], fftSize=synFFTSize, hopSize=params['hopSize'], stocf=params['stocf'])
 
     # add half window of zeros to input signal to reach same ooutput length
-    signal = numpy.append(signal, zeros(params['frameSize'] // 2))
-    insignal = VectorInput (signal)
+    signal = numpy.append(signal, essentia.zeros(params['frameSize'] // 2))
+    insignal = VectorInput(signal)
 
     # analysis
     insignal.data >> fcut.signal
@@ -146,7 +141,6 @@ def analsynthSpsModelStreaming(params, signal):
     smanal.phases >> smsyn.phases
     smanal.stocenv >> smsyn.stocenv
 
-
     smsyn.frame >> (pool, 'frames')
     smsyn.sineframe >> (pool, 'sineframes')
     smsyn.stocframe >> (pool, 'stocframes')
@@ -156,27 +150,23 @@ def analsynthSpsModelStreaming(params, signal):
     outaudio = framesToAudio(pool['frames'])
     outaudio = outaudio [2*params['hopSize']:]
 
-
     return outaudio, pool
 
-
-
-#-------------------------------------
 
 class TestSpsModel(TestCase):
 
     params = { 'frameSize': 2048, 'hopSize': 128, 'startFromZero': False, 'sampleRate': 44100,'maxnSines': 100,'magnitudeThreshold': -74,'minSineDur': 0.02,'freqDevOffset': 10, 'freqDevSlope': 0.001, 'maxFrequency': 550.,'minFrequency': 65., 'stocf':0.2}
-    
+
     precisiondB = -40. # -40dB of allowed noise floor for sinusoidal model
     precisionDigits = int(-numpy.round(precisiondB/20.) -1) # -1 due to the rounding digit comparison.
-    
+
 
     def testZero(self):
-      
+
         # generate test signal
         signalSize = 10 * self.params['frameSize']
-        signal = zeros(signalSize)
-        
+        signal = essentia.zeros(signalSize)
+
         [mags, freqs, phases] = analSpsModelStreaming(self.params, signal)
 
         # compare
@@ -188,19 +178,17 @@ class TestSpsModel(TestCase):
         from random import random
         # generate test signal
         signalSize = 10 * self.params['frameSize']
-        signal = array([2*(random()-0.5)*i for i in ones(signalSize)])
-        
+        signal = array([2*(random()-0.5)*i for i in essentia.ones(signalSize)])
+
         # for white noise test set sine minimum duration to 500ms, and min threshold of -20dB
         self.params['minSineDur'] = 0.5 # limit pitch tracks of a nimumim length of 500ms for the case of white noise input
         self.params['magnitudeThreshold']= -20
-    
+
         [mags, freqs, phases]  = analSpsModelStreaming(self.params, signal)
-        
 
         # compare
         zerofreqs = numpy.zeros(freqs.shape)
         self.assertAlmostEqualMatrix(freqs, zerofreqs)
-
 
 
     def testRegression(self):
@@ -209,29 +197,22 @@ class TestSpsModel(TestCase):
         signalSize = 10 * self.params['frameSize']
         signal = .5 * numpy.sin( (array(range(signalSize))/self.params['sampleRate']) * 110 * 2*math.pi)
 
-        # generate noise components        
-        from random import random            
-        noise = 0.01 * array([2*(random()-0.5)*i for i in ones(signalSize)]) # -40dB
+        # generate noise components
+        from random import random
+        noise = 0.01 * array([2*(random()-0.5)*i for i in essentia.ones(signalSize)]) # -40dB
         signal = signal + noise
-               
-        
-        outsignal,pool = analsynthSpsModelStreaming(self.params, signal)
+
+        outsignal, pool = analsynthSpsModelStreaming(self.params, signal)
 
         outsignal = outsignal[:signalSize] # cut to durations of input and output signal
 
         # compare without half-window bounds to avoid windowing effect
         halfwin = (self.params['frameSize'] // 2)
 
-        
         self.assertAlmostEqualVectorFixedPrecision(outsignal[halfwin:-halfwin], signal[halfwin:-halfwin], self.precisionDigits)
-
-
-
-
 
 
 suite = allTests(TestSpsModel)
 
 if __name__ == '__main__':
     TextTestRunner(verbosity=2).run(suite)
-

--- a/test/src/unittests/tonal/test_pitchsaliencefunctionpeaks.py
+++ b/test/src/unittests/tonal/test_pitchsaliencefunctionpeaks.py
@@ -19,19 +19,19 @@
 
 
 from essentia_test import *
-from numpy import *
+from numpy import sin, pi, concatenate
 
 class TestPitchSalienceFunctionPeaks(TestCase):
-  
+
     def testInvalidParam(self):
         self.assertConfigureFails(PitchSalienceFunctionPeaks(), {'binResolution': -1})
         self.assertConfigureFails(PitchSalienceFunctionPeaks(), {'maxFrequency': -1})
         self.assertConfigureFails(PitchSalienceFunctionPeaks(), {'minFrequency': -1})
-        self.assertConfigureFails(PitchSalienceFunctionPeaks(), {'referenceFrequency': -1})          
+        self.assertConfigureFails(PitchSalienceFunctionPeaks(), {'referenceFrequency': -1})
 
     def testEmpty(self):
         self.assertRaises(RuntimeError, lambda: PitchSalienceFunctionPeaks()([]))
-    
+
     def testSinglePeak(self):
         # Provide a single input peak with a unit magnitude at the reference frequency, and
         # validate that the output salience function has only one non-zero element at the first bin.
@@ -66,10 +66,10 @@ class TestPitchSalienceFunctionPeaks(TestCase):
         # Checks on config. values binResolution being too high for the input in question
         freq_speaks = [55, 100, 340]
         mag_speaks = [1, 1, 1]
-        expectedBins = [ 0., 101.52542, 324.88135, 203.05084, 131.98305,  81.22034,  40.61017] 
+        expectedBins = [ 0., 101.52542, 324.88135, 203.05084, 131.98305,  81.22034,  40.61017]
         expectedValues = [1., 1., 1., 0.8 , 0.64000005, 0.512, 0.40960002]
         calculatedPitchSalience = PitchSalienceFunction(binResolution=100)(freq_speaks,mag_speaks)
-        bins, values = PitchSalienceFunctionPeaks()(calculatedPitchSalience)        
+        bins, values = PitchSalienceFunctionPeaks()(calculatedPitchSalience)
         self.assertAlmostEqualVectorFixedPrecision(bins, expectedBins,3)
         self.assertAlmostEqualVectorFixedPrecision(values, expectedValues, 3)
 
@@ -95,7 +95,7 @@ class TestPitchSalienceFunctionPeaks(TestCase):
         self.assertRaises(RuntimeError, lambda: PitchSalienceFunctionPeaks(referenceFrequency=20000)(calculatedPitchSalience))
 
     def testRegression3PeaksHw0UnharmonicInput(self):
-        # As in testRegression3Peaks but with Harmonic Weight = 0, non multiple freq. inputs        
+        # As in testRegression3Peaks but with Harmonic Weight = 0, non multiple freq. inputs
         freq_speaks = [55, 100, 340]
         mag_speaks = [1, 1, 1]
         expectedBins =  [0., 103., 315.]
@@ -104,9 +104,9 @@ class TestPitchSalienceFunctionPeaks(TestCase):
         bins, values = PitchSalienceFunctionPeaks()(calculatedPitchSalience)
         self.assertEqualVector(bins, expectedBins)
         self.assertAlmostEqualVectorFixedPrecision(values, expectedValues, 6)
-    
+
     def testRegression3PeaksHw0HarmonicInput(self):
-        # As in testRegression3Peaks but with Harmonic Weight = 0, multiple freq. inputs        
+        # As in testRegression3Peaks but with Harmonic Weight = 0, multiple freq. inputs
         freq_speaks = [110, 220]
         mag_speaks = [1, 1]
         expectedBins =  [120., 240.]
@@ -117,14 +117,14 @@ class TestPitchSalienceFunctionPeaks(TestCase):
         self.assertAlmostEqualVectorFixedPrecision(values, expectedValues, 6)
 
     def testRegression3PeaksHw1UnHarmonicInput(self):
-        # As in testRegression3Peaks but with Harmonic Weight = 0,  non multiple freq. inputs        
+        # As in testRegression3Peaks but with Harmonic Weight = 0,  non multiple freq. inputs
         freq_speaks = [55, 100, 340]
         mag_speaks = [1, 1, 1]
         calculatedPitchSalience = PitchSalienceFunction(harmonicWeight=1)(freq_speaks, mag_speaks)
         bins, values = PitchSalienceFunctionPeaks()(calculatedPitchSalience)
         self.assertEqualVector(bins, [2., 37., 75., 103., 125., 195., 315.])
         self.assertAlmostEqualVectorFixedPrecision(values, [1.6984011, 1., 1., 1., 1., 1., 1.], 6)
-    
+
     def testRegression3PeaksHw1HarmonicInput(self):
         # As in testRegression3Peaks but with Harmonic Weight = 1, multiple freq. inputs
         freq_speaks = [110, 220]
@@ -177,15 +177,15 @@ class TestPitchSalienceFunctionPeaks(TestCase):
 
         signalSize = frameSize * 10
         # Here are generated sine waves for each note of the scale, e.g. C3 is 130.81 Hz, etc
-        c3 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 130.81 * 2*math.pi)
-        d3 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 146.83 * 2*math.pi)
-        e3 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 164.81 * 2*math.pi)
-        f3 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 174.61 * 2*math.pi)
-        g3 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 196.00 * 2*math.pi)
-        a3 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 220.00 * 2*math.pi)
-        b3 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 246.94 * 2*math.pi)
-        c4 = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 261.63 * 2*math.pi)
-    
+        c3 = 0.5 * sin((array(range(signalSize))/44100.) * 130.81 * 2*pi)
+        d3 = 0.5 * sin((array(range(signalSize))/44100.) * 146.83 * 2*pi)
+        e3 = 0.5 * sin((array(range(signalSize))/44100.) * 164.81 * 2*pi)
+        f3 = 0.5 * sin((array(range(signalSize))/44100.) * 174.61 * 2*pi)
+        g3 = 0.5 * sin((array(range(signalSize))/44100.) * 196.00 * 2*pi)
+        a3 = 0.5 * sin((array(range(signalSize))/44100.) * 220.00 * 2*pi)
+        b3 = 0.5 * sin((array(range(signalSize))/44100.) * 246.94 * 2*pi)
+        c4 = 0.5 * sin((array(range(signalSize))/44100.) * 261.63 * 2*pi)
+
         # This signal is a "major scale ladder"
         scale = concatenate([c3, d3, e3, f3, g3, a3, b3, c4])
 
@@ -198,9 +198,9 @@ class TestPitchSalienceFunctionPeaks(TestCase):
 
         # Do some spot checks on selected frequemtly occuring peaks in selected bin ranges.
         expectedBins1 = [170.,  50.,  98., 222.,  32.] # 168 to 313
-        expectedBins2 = [220., 100.,  30., 167., 260.,  47., 140.,  70.] # 649 to 794   
-        expectedBins3 = [240., 120.,  50.,   0., 276., 194., 156.,  74.,  86.,  36.] # 807 bins 953 
-        expectedBins4 = [260., 140.,  70.,  20., 101., 293., 220., 173.,  53.] # 968 to 1112        
+        expectedBins2 = [220., 100.,  30., 167., 260.,  47., 140.,  70.] # 649 to 794
+        expectedBins3 = [240., 120.,  50.,   0., 276., 194., 156.,  74.,  86.,  36.] # 807 bins 953
+        expectedBins4 = [260., 140.,  70.,  20., 101., 293., 220., 173.,  53.] # 968 to 1112
 
         index = 0
         for frame in FrameGenerator(audio, frameSize=frameSize, hopSize=hopSize):
@@ -211,13 +211,13 @@ class TestPitchSalienceFunctionPeaks(TestCase):
             salience_peaks_bins, _ = run_pitch_salience_function_peaks(salience)
 
             if (index >= 168 ) and index < 313:
-                self.assertEqualVector(expectedBins1, salience_peaks_bins)                                                                                  
+                self.assertEqualVector(expectedBins1, salience_peaks_bins)
             elif (index >= 649 ) and index < 794:
-                self.assertEqualVector(expectedBins2, salience_peaks_bins)                                     
+                self.assertEqualVector(expectedBins2, salience_peaks_bins)
             elif (index >= 807 ) and index < 953:
-                self.assertEqualVector(expectedBins3, salience_peaks_bins)                                     
-            elif (index >= 968)  and index < 1112:             
-                self.assertEqualVector(expectedBins4, salience_peaks_bins)                                                                                                                                                    
+                self.assertEqualVector(expectedBins3, salience_peaks_bins)
+            elif (index >= 968)  and index < 1112:
+                self.assertEqualVector(expectedBins4, salience_peaks_bins)
             index+=1
 
 suite = allTests(TestPitchSalienceFunctionPeaks)

--- a/test/src/unittests/tonal/test_tonicindianartmusic.py
+++ b/test/src/unittests/tonal/test_tonicindianartmusic.py
@@ -19,7 +19,7 @@
 
 
 from essentia_test import *
-from numpy import sin, float32, pi, arange, mean, log2, floor, ceil, math, concatenate
+from numpy import sin, float32, pi, arange, mean, log2, floor, ceil, concatenate
 import numpy as np
 
 class TestTonicIndianArtMusic(TestCase):
@@ -99,13 +99,13 @@ class TestTonicIndianArtMusic(TestCase):
     def testBelowMinimumTonic(self):
         signalSize = 15 * 2048
         # generate test signal 99 Hz, and put minTonicFreq as 100 Hz in the TonicIndianArtMusic
-        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 99* 2*math.pi)
+        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 99* 2*pi)
         self.assertRaises(EssentiaException, lambda: TonicIndianArtMusic(minTonicFrequency=100,maxTonicFrequency=375)(x))
 
     def testAboveMaxTonic(self):
         signalSize = 15 * 2048
         # generate test signal 101 Hz, and put maxTonicFreq as 100 Hz in the TonicIndianArtMusic
-        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 101* 2*math.pi)
+        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 101* 2*pi)
         self.assertRaises(RuntimeError, lambda: TonicIndianArtMusic(minTonicFrequency=99,maxTonicFrequency=100)(x))
 
     def testRegressionSyntheticSignal(self):
@@ -113,9 +113,9 @@ class TestTonicIndianArtMusic(TestCase):
         signalSize = 15 * 2048
 
         # Concat 3 sine waves together of different frequencies
-        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 124 * 2*math.pi)
-        y = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 100 * 2*math.pi)
-        z = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 80 * 2*math.pi)
+        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 124 * 2*pi)
+        y = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 100 * 2*pi)
+        z = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 80 * 2*pi)
         mix = concatenate([x, y, z])
 
         # tiam = acronym for "Tonic Indian Art Music"
@@ -127,9 +127,9 @@ class TestTonicIndianArtMusic(TestCase):
         self.assertGreater(124, tonic)
 
         ### Make a (unharmonic) chord
-        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 124 * 2*math.pi)
-        y = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 100 * 2*math.pi)
-        z = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 80 * 2*math.pi)
+        x = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 124 * 2*pi)
+        y = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 100 * 2*pi)
+        z = 0.5 * numpy.sin((array(range(signalSize))/44100.) * 80 * 2*pi)
         chord = x+y+z
 
         tiam = TonicIndianArtMusic(minTonicFrequency=50, maxTonicFrequency=111)


### PR DESCRIPTION
- Updates Python bindings to NumPy v2 C-API.
- Drops support for Python wheels < 3.9.
- Fixes in unit tests. Remove deprecated NumPy submodule.

Very similar changes were proposed in PR #1470 in 7636b9949330d496d6a999cd91fa4b481c24c2b1.
