### PR TITLE
Fix 'cannot seek vector iterator after end' debug assertion failure

### DIFF
--- a/src/algorithms/tonal/key.cpp
+++ b/src/algorithms/tonal/key.cpp
@@ -716,7 +716,7 @@ void Key::shiftPcp(vector<Real>& pcp) {
 
   vector<Real>::iterator newBegin;
   if (maxValIndex > (tuningResolution / 2)) {
-    newBegin = pcp.end() + maxValIndex - tuningResolution;
+    newBegin = pcp.end() + (maxValIndex - tuningResolution);
   }
   else {
     newBegin = pcp.begin() + maxValIndex;


### PR DESCRIPTION
This pull request fixes a small issue with the order of operations in the `Key::shiftPcp()` method.

The issue occurs on Windows with MSVC compiler and leads to a 'cannot seek vector iterator after end' debug assertion failure at runtime.

The problem was reported on my fork https://github.com/wo80/essentia/issues/7

