### PR TITLE
New feature: OnnxPredict algorithm

### DIFF
--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -28,6 +28,7 @@ CHROMAPRINT_VERSION=1.4.3
 QT_SOURCE_URL=https://download.qt.io/archive/qt/4.8/4.8.4/qt-everywhere-opensource-src-4.8.4.tar.gz
 GAIA_VERSION=2.4.6-86-ged433ed
 TENSORFLOW_VERSION=2.5.0
+LIBONNXRUNTIME_VERSION=1.21.1
 
 
 FFMPEG_AUDIO_FLAGS="

--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -2,7 +2,7 @@
 
 HOST=i686-w64-mingw32
 if [ -z "${PREFIX}" ]; then
-    PREFIX=`pwd`
+  PREFIX=$(pwd)
 fi
 echo Installing to: $PREFIX
 
@@ -28,8 +28,7 @@ CHROMAPRINT_VERSION=1.4.3
 QT_SOURCE_URL=https://download.qt.io/archive/qt/4.8/4.8.4/qt-everywhere-opensource-src-4.8.4.tar.gz
 GAIA_VERSION=2.4.6-86-ged433ed
 TENSORFLOW_VERSION=2.5.0
-LIBONNXRUNTIME_VERSION=1.21.1
-
+LIBONNXRUNTIME_VERSION=1.22.1
 
 FFMPEG_AUDIO_FLAGS="
     --disable-programs

--- a/packaging/debian_3rdparty/build_onnx.sh
+++ b/packaging/debian_3rdparty/build_onnx.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+. ../build_config.sh
+
+# rm -rf tmp
+# mkdir tmp
+cd tmp
+
+# Prerequisites:        python>=3.10
+#                       cmake>=3.28
+
+echo "Building onnxruntime $LIBONNXRUNTIME_VERSION"
+
+#curl -SLO "https://github.com/microsoft/onnxruntime/archive/refs/tags/v$LIBONNXRUNTIME_VERSION.tar.gz"
+#! this file has an issue https://github.com/microsoft/onnxruntime/issues/24861
+#! it is fixed manually for testing https://github.com/microsoft/onnxruntime/commit/f57db79743c4d1a3553aa05cf95bcd10966030e6
+#! should be done in three-steps: first, downloading the package, editing the deps.txt file and running the script
+#! in the main branch it is fixed, it should be replaced when a release is available.
+
+#tar -xf v$LIBONNXRUNTIME_VERSION.tar.gz
+cd onnxruntime-$LIBONNXRUNTIME_VERSION
+
+python3 -m pip install cmake
+
+# compile library with cmake
+./build.sh \
+  --config RelWithDebInfo \
+  --build_shared_lib \
+  --parallel \
+  --compile_no_warning_as_error \
+  --skip_submodule_sync
+
+cd ../..
+# rm -fr tmp

--- a/src/algorithms/machinelearning/onnxpredict.cpp
+++ b/src/algorithms/machinelearning/onnxpredict.cpp
@@ -1,0 +1,419 @@
+/*
+ * Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#include "onnxpredict.h"
+
+using namespace std;
+using namespace essentia;
+using namespace standard;
+
+const char* OnnxPredict::name = "OnnxPredict";
+const char* OnnxPredict::category = "Machine Learning";
+const char* OnnxPredict::description = DOC("This algorithm runs a Tensorflow graph and stores the desired output tensors in a pool.\n"
+"The Tensorflow graph should be stored in Protocol Buffer (.pb) binary format [1] or as a SavedModel [2], and should contain both the architecture and the weights of the model.\n"
+"The parameter `inputs` should contain a list with the names of the input nodes that feed the model. The input Pool should contain the tensors corresponding to each input node stored using Essetia tensors. "
+"The pool namespace for each input tensor has to match the input node's name.\n"
+"In the same way, the `outputs` parameter should contain the names of the tensors to save. These tensors will be stored inside the output pool under a namespace that matches the tensor's name. "
+"TensorFlow nodes return tensors identified as `nodeName:n`, where `n` goes from 0 to the number of outputs of the node - 1. "
+"The first output tensor of a node can be referred implicitly (e.g., `nodeName`) or explicitly (e.g., `nodeName:0`), and the subsequent tensors require the specific index (e.g., nodeName:1, nodeName:2). "
+"In TensorFlow 2 SavedModels all the outputs of the model are contained in the `PartitionedCall` node (e.g., `PartitionedCall:0`, `PartitionedCall:1`). "
+"You can use TenorFlow's `saved_model_cli` to find the relation of outputs and `PartitionedCall` indices, for example:\n"
+"\n"
+">>>    saved_model_cli show --dir SavedModel/ --all\n"
+">>>    ...\n"
+">>>    The given SavedModel SignatureDef contains the following output(s):\n"
+">>>      outputs['activations'] tensor_info:\n"
+">>>          dtype: DT_FLOAT\n"
+">>>          shape: (1, 400)\n"
+">>>          name: PartitionedCall:0\n"
+">>>      outputs['embeddings'] tensor_info:\n"
+">>>          dtype: DT_FLOAT\n"
+">>>          shape: (1, 1280)\n"
+">>>          name: PartitionedCall:1\n"
+">>>    ...\n"
+"\n"
+"To print a list with all the available nodes in the graph set the first element of `outputs` as an empty string (i.e., \"\")."
+"\n"
+"This algorithm is a wrapper for the Tensorflow C API [3]. The first time it is configured with a non-empty `graphFilename` it will try to load the contained graph and to attach a Tensorflow session to it. "
+"The reset method deletes the current session (and the resources attached to it) and creates a new one relying on the available graph. "
+"By reconfiguring the algorithm the graph is reloaded and the reset method is called.\n"
+"\n"
+"References:\n"
+"  [1] TensorFlow - An open source machine learning library for research and production.\n"
+"  https://www.tensorflow.org/extend/tool_developers/#protocol_buffers\n\n"
+"  [2] TensorFlow - An open source machine learning library for research and production.\n"
+"  https://www.tensorflow.org/guide/saved_model\n\n"
+"  [3] TensorFlow - An open source machine learning library for research and production.\n"
+"  https://www.tensorflow.org/api_docs/cc/");
+
+
+static void DeallocateBuffer(void* data, size_t) {
+  free(data);
+}
+
+
+void OnnxPredict::configure() {
+  _savedModel = parameter("savedModel").toString();
+  _graphFilename = parameter("graphFilename").toString();
+
+  if ((_savedModel.empty()) and (_graphFilename.empty()) and (_isConfigured)) {
+    E_WARNING("OnnxPredict: You are trying to update a valid configuration with invalid parameters. "
+              "If you want to update the configuration specify a valid `graphFilename` or `savedModel` parameter.");
+  };
+
+  // Do not do anything if we did not get a non-empty model name.
+  if ((_savedModel.empty()) and (_graphFilename.empty())) return;
+
+  _tags = parameter("tags").toVectorString();
+
+  _inputNames = parameter("inputs").toVectorString();
+  _outputNames = parameter("outputs").toVectorString();
+  _isTraining = parameter("isTraining").toBool();
+  _isTrainingName = parameter("isTrainingName").toString();
+  _squeeze = parameter("squeeze").toBool();
+
+  (_isTrainingName == "") ? _isTrainingSet = false : _isTrainingSet = true;
+
+  _nInputs = _inputNames.size();
+  _nOutputs = _outputNames.size();
+
+  // Allocate input and output tensors.
+  _inputTensors.resize(_nInputs + int(_isTrainingSet));
+  _inputNodes.resize(_nInputs + int(_isTrainingSet));
+
+  _outputTensors.resize(_nOutputs);
+  _outputNodes.resize(_nOutputs);
+
+  TF_DeleteGraph(_graph);
+  _graph = TF_NewGraph();
+
+  openGraph();
+
+  _isConfigured = true;
+  reset();
+
+  // If the first output name is empty just print out the list of nodes and return.
+  if (_outputNames[0] == "") {
+    E_INFO(availableNodesInfo());
+
+    return;
+  }
+
+  // Initialize the list of input and output node names.
+  for (size_t i = 0; i < _nInputs; i++) {
+    _inputNodes[i] = graphOperationByName(_inputNames[i]);
+  }
+
+  for (size_t i = 0; i < _nOutputs; i++) {
+    _outputNodes[i] = graphOperationByName(_outputNames[i]);
+  }
+
+  // Add isTraining flag if needed.
+  if (_isTrainingSet) {
+    const int64_t dims[1] = {};
+    TF_Tensor *isTraining = TF_AllocateTensor(TF_BOOL, dims, 0, 1);
+    void* isTrainingValue = TF_TensorData(isTraining);
+
+    if (isTrainingValue == NULL) {
+      TF_DeleteTensor(isTraining);
+      throw EssentiaException("OnnxPredict: Error generating training phase flag");
+    }
+
+    memcpy(isTrainingValue, &_isTraining, sizeof(bool));
+
+    _inputTensors[_nInputs] = isTraining;
+    _inputNodes[_nInputs] = graphOperationByName(_isTrainingName);
+  }
+}
+
+
+void OnnxPredict::openGraph() {
+  // Prioritize savedModel when both are specified.
+  if (!_savedModel.empty()) {
+    std::vector<char*> tags_c;
+    tags_c.reserve(_tags.size());
+    for (size_t i = 0; i < _tags.size(); i++) {
+      tags_c.push_back(const_cast<char*>(_tags[i].c_str()));
+    }
+
+    TF_LoadSessionFromSavedModel(_sessionOptions, _runOptions,
+      _savedModel.c_str(), &tags_c[0], (int)tags_c.size(),
+      _graph, NULL, _status);
+
+    if (TF_GetCode(_status) != TF_OK) {
+      throw EssentiaException("OnnxPredict: Error importing SavedModel specified in the `savedModel` parameter. ", TF_Message(_status));
+    }
+
+    E_INFO("OnnxPredict: Successfully loaded SavedModel: `" << _savedModel << "`");
+
+    return;
+  }
+
+  if (!_graphFilename.empty()) {
+    // First we load and initialize the model.
+    const auto f = fopen(_graphFilename.c_str(), "rb");
+    if (f == NULL) {
+      throw EssentiaException(
+          "OnnxPredict: could not open the Tensorflow graph file.");
+    }
+
+    fseek(f, 0, SEEK_END);
+    const auto fsize = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    // Graph size sanity check.
+    if (fsize < 1) {
+      fclose(f);
+      throw(EssentiaException("OnnxPredict: Graph file is empty."));
+    }
+
+    // Reserve memory and read the graph.
+    const auto data = malloc(fsize);
+    fread(data, fsize, 1, f);
+    fclose(f);
+
+    TF_Buffer* buffer = TF_NewBuffer();
+    buffer->data = data;
+    buffer->length = fsize;
+    buffer->data_deallocator = DeallocateBuffer;
+
+    TF_GraphImportGraphDef(_graph, buffer, _options, _status);
+
+    TF_DeleteBuffer(buffer);
+
+    if (TF_GetCode(_status) != TF_OK) {
+      throw EssentiaException("OnnxPredict: Error importing graph. ", TF_Message(_status));
+    }
+
+    E_INFO("OnnxPredict: Successfully loaded graph file: `" << _graphFilename << "`");
+  }
+}
+
+
+void OnnxPredict::reset() {
+  if (!_isConfigured) return;
+
+  TF_CloseSession(_session, _status);
+  if (TF_GetCode(_status) != TF_OK) {
+    throw EssentiaException("OnnxPredict: Error closing session. ", TF_Message(_status));
+  }
+
+  TF_DeleteSession(_session, _status);
+  if (TF_GetCode(_status) != TF_OK) {
+    throw EssentiaException("OnnxPredict: Error deleting session. ", TF_Message(_status));
+  }
+
+  _session = TF_NewSession(_graph, _sessionOptions, _status);
+  if (TF_GetCode(_status) != TF_OK) {
+    throw EssentiaException("OnnxPredict: Error creating new session after reset. ", TF_Message(_status));
+  }
+}
+
+
+void OnnxPredict::compute() {
+  if (!_isConfigured) {
+    throw EssentiaException("OnnxPredict: This algorithm is not configured. To configure this algorithm you "
+                            "should specify a valid `graphFilename` or `savedModel` as input parameter.");
+  }
+
+  const Pool& poolIn = _poolIn.get();
+  Pool& poolOut = _poolOut.get();
+
+  // Parse the input tensors from the pool into Tensorflow tensors.
+  for (size_t i = 0; i < _nInputs; i++) {
+    const Tensor<Real>& inputData =
+        poolIn.value<Tensor<Real> >(_inputNames[i]);
+    _inputTensors[i] = TensorToTF(inputData);
+  }
+
+  // Initialize output tensors.
+  for (size_t i = 0; i < _nOutputs; i++) {
+    _outputTensors[i] = NULL;
+  }
+
+  // Run the Tensorflow session.
+  TF_SessionRun(_session,
+                NULL,                            // Run options.
+                &_inputNodes[0],                 // Input node names.
+                &_inputTensors[0],               // input tensor values.
+                _nInputs + (int)_isTrainingSet,  // Number of inputs.
+                &_outputNodes[0],                // Output node names.
+                &_outputTensors[0],              // Output tensor values.
+                _nOutputs,                       // Number of outputs.
+                NULL, 0,                         // Target operations, number of targets.
+                NULL,                            // Run metadata.
+                _status                          // Output status.
+               );
+
+  if (TF_GetCode(_status) != TF_OK) {
+    throw EssentiaException("OnnxPredict: Error running the Tensorflow session. ", TF_Message(_status));
+  }
+
+  // Copy the desired tensors into the output pool.
+  for (size_t i = 0; i < _nOutputs; i++) {
+    poolOut.set(_outputNames[i], TFToTensor(_outputTensors[i], _outputNodes[i]));
+  }
+
+  // Deallocate tensors.
+  for (size_t i = 0; i < _nInputs; i++) {
+    TF_DeleteTensor(_inputTensors[i]);
+  }
+
+  for (size_t i = 0; i < _nOutputs; i++) {
+    TF_DeleteTensor(_outputTensors[i]);
+  }
+}
+
+
+TF_Tensor* OnnxPredict::TensorToTF(
+    const Tensor<Real>& tensorIn) {
+  int dims = 1;
+  vector<int64_t> shape;
+
+  // With squeeze, the Batch dimension is the only one allowed to be singleton
+  shape.push_back((int64_t)tensorIn.dimension(0));
+
+  if (_squeeze) {
+    for(int i = 1; i < tensorIn.rank(); i++) {
+      if (tensorIn.dimension(i) > 1) {
+        shape.push_back((int64_t)tensorIn.dimension(i));
+        dims++;
+      }
+    }
+
+    // There should be at least 2 dimensions (batch, data)
+    if (dims == 1) {
+      shape.push_back((int64_t) 1);
+      dims++;
+    }
+
+  } else {
+    dims = tensorIn.rank();
+    for(int i = 1; i < dims; i++) {
+        shape.push_back((int64_t)tensorIn.dimension(i));
+      }
+  }
+
+  TF_Tensor* tensorOut = TF_AllocateTensor(
+      TF_FLOAT, &shape[0], dims,
+      (size_t)tensorIn.size() * sizeof(Real));
+
+  if (tensorOut == NULL) {
+    throw EssentiaException("OnnxPredict: Error generating input tensor.");
+  }
+
+  // Get a pointer to the data and fill the tensor.
+  void* tensorData = TF_TensorData(tensorOut);
+
+  if (tensorData == NULL) {
+    TF_DeleteTensor(tensorOut);
+    throw EssentiaException("OnnxPredict: Error generating input tensors data.");
+  }
+
+  memcpy(tensorData, tensorIn.data(),
+         std::min(tensorIn.size() * sizeof(Real),
+                  TF_TensorByteSize(tensorOut)));
+
+  return tensorOut;
+}
+
+
+const Tensor<Real> OnnxPredict::TFToTensor(
+    const TF_Tensor* tensor, TF_Output node) {
+  const Real* outputData = static_cast<Real*>(TF_TensorData(tensor));
+
+  // Get the output tensor's shape.
+  size_t outNDims = TF_GraphGetTensorNumDims(_graph, node, _status);
+
+  if (TF_GetCode(_status) != TF_OK) {
+    throw EssentiaException("OnnxPredict: Error getting the output tensor's shape. ", TF_Message(_status));
+  }
+
+  // Create and array to store the shape of the tensor.
+  array<long int, 4> shape {1, 1, 1, 1};
+  shape[0] = (int)TF_Dim(tensor, 0);
+
+  // We are assuming one of the following cases:
+  //       1 - outNDims = 2 -> Batch + Feats
+  //       2 - outNDims = 3 -> Batch + Timestamps + Feats
+  //       3 - outNDims = 4 -> Batch + Channels + Timestamps + Feats
+  size_t idx = 1;
+  for (size_t i = shape.size() - outNDims + 1; i < shape.size(); i++, idx++) {
+    shape[i] = (int)TF_Dim(tensor, idx);
+  }
+
+  // Return a const reference to the data in Eigen format.
+  return TensorMap<const Real>(outputData, shape);
+}
+
+
+TF_Output OnnxPredict::graphOperationByName(const string nodeName) {
+  int index = 0;
+  const char* name = nodeName.c_str();
+  string newNodeName;
+
+  // TensorFlow operations (or nodes from the graph perspective) return tensors named <nodeName:n>, where n goes
+  // from 0 to the number of outputs. The first output tensor of a node can be extracted implicitly (nodeName)
+  // or explicitly (nodeName:0). To extract the subsequent tensors, the index has to be specified (nodeName:1,
+  // nodeName:2, ...).
+  string::size_type n = nodeName.find(':');
+  if (n != string::npos) {
+    try {
+      newNodeName = nodeName.substr(0, n);
+      name = newNodeName.c_str();
+      index = stoi(nodeName.substr(n + 1, nodeName.size()));
+
+    } catch (const invalid_argument& ) {
+      throw EssentiaException("OnnxPredict: `" + nodeName + "` is not a valid node name. Make sure that all "
+                              "your inputs and outputs follow the pattern `nodeName:n`, where `n` in an integer that "
+                              "goes from 0 to the number of outputs of the node - 1.");
+    }
+
+  }
+
+  TF_Operation* oper = TF_GraphOperationByName(_graph, name);
+
+  TF_Output output = {oper, index};
+
+  if (output.oper == NULL) {
+    throw EssentiaException("OnnxPredict: '" + string(nodeName) +
+                            "' is not a valid node name of this graph.\n" +
+                            availableNodesInfo());
+  }
+
+  int n_outputs = TF_OperationNumOutputs(oper);
+  if (index > n_outputs - 1) {
+    throw EssentiaException("OnnxPredict: Asked for the output with index `" + to_string(index) +
+                            "`, but the node `" + name + "` only has `" + to_string(n_outputs) + "` outputs.");
+  }
+
+  return output;
+}
+
+vector<string> OnnxPredict::nodeNames() {
+  size_t pos = 0;
+  TF_Operation *oper;
+  vector<string> nodeNames;
+
+  while ((oper = TF_GraphNextOperation(_graph, &pos)) != NULL) {
+    nodeNames.push_back(string(TF_OperationName(oper)));
+  }
+
+  return nodeNames;
+}

--- a/src/algorithms/machinelearning/onnxpredict.cpp
+++ b/src/algorithms/machinelearning/onnxpredict.cpp
@@ -116,7 +116,6 @@ void OnnxPredict::configure() {
     
     
   _env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "default");
-  //_session = Ort::Session{env, _graphFilename.c_str(), options_ort};
     
   try{
     _session = Ort::Session(_env, _graphFilename.c_str(), _sessionOptions);
@@ -273,18 +272,18 @@ void OnnxPredict::reset() {
   // Ort::ReleaseSession(_session); // error: no type named 'ReleaseSession' in namespace 'Ort'
 
     
-  if (Ort::Status::GetErrorCode(_status) != Ort::Status::IsOK()) {
-    throw EssentiaException("OnnxPredict: Error closing session. ",  Ort::Status::GetErrorMessage(_status));
+  if (_status->GetErrorCode() != _status->IsOK()) {
+    throw EssentiaException("OnnxPredict: Error closing session. ",  _status->GetErrorMessage());
   }
 
   //TF_DeleteSession(_session, _status);
-  if (Ort::Status::GetErrorCode(_status) != Ort::Status::IsOK) {
-    throw EssentiaException("OnnxPredict: Error deleting session. ", Ort::Status::GetErrorMessage(_status));
+  if (_status->GetErrorCode() != _status->IsOK()) {
+    throw EssentiaException("OnnxPredict: Error deleting session. ", _status->GetErrorMessage());
   }
 
   // TODO: do we need this for ORT?
   /*_session = TF_NewSession(_graph, _sessionOptions, _status);
-  if (Ort::Status::GetErrorCode(_status) != Ort::Status::IsOK) {
+  if (Ort::Status::GetErrorCode(_status) != Ort::Status::IsOK(_status)) {
     throw EssentiaException("OnnxPredict: Error creating new session after reset. ", Ort::Status::GetErrorMessage(_status));
   }*/
 }
@@ -304,6 +303,7 @@ void OnnxPredict::compute() {
   /*input_tensor_ = Ort::Value::CreateTensor<float>(memory_info, input_image_.data(), input_image_.size(), input_shape_.data(), input_shape_.size());
   output_tensor_ = Ort::Value::CreateTensor<float>(memory_info, results_.data(), results_.size(), output_shape_.data(), output_shape_.size());*/
  
+  // TODO: implement TensorToOrt() taht converts Pool tensors into Ort tensors
   // Parse the input tensors from the pool into Tensorflow tensors.
   for (size_t i = 0; i < _nInputs; i++) {
     const Tensor<Real>& inputData =
@@ -344,8 +344,8 @@ void OnnxPredict::compute() {
                 _status                          // Output status.
                );*/
 
-  if (Ort::Status::GetErrorCode(_status) != Ort::Status::IsOK()) {
-    throw EssentiaException("OnnxPredict: Error running the OnnxRuntime session. ", Ort::Status::GetErrorMessage(_status));
+  if (_status->GetErrorCode() != _status->IsOK()) {
+    throw EssentiaException("OnnxPredict: Error running the OnnxRuntime session. ", _status->GetErrorMessage());
   }
     
   // Copy the desired tensors into the output pool.

--- a/src/algorithms/machinelearning/onnxpredict.h
+++ b/src/algorithms/machinelearning/onnxpredict.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
+ *
+ * This file is part of Essentia
+ *
+ * Essentia is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation (FSF), either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the Affero GNU General Public License
+ * version 3 along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+#ifndef ESSENTIA_ONNXPREDICT_H
+#define ESSENTIA_ONNXPREDICT_H
+
+#include "algorithm.h"
+#include "pool.h"
+#include <tensorflow/c/c_api.h>
+
+
+namespace essentia {
+namespace standard {
+
+class OnnxPredict : public Algorithm {
+
+ protected:
+  Input<Pool> _poolIn;
+  Output<Pool> _poolOut;
+
+  std::string _graphFilename;
+  std::vector<std::string> _inputNames;
+  std::vector<std::string> _outputNames;
+
+  std::vector<TF_Tensor*> _inputTensors;
+  std::vector<TF_Tensor*> _outputTensors;
+
+  std::vector<TF_Output> _inputNodes;
+  std::vector<TF_Output> _outputNodes;
+
+  size_t _nInputs;
+  size_t _nOutputs;
+
+  TF_Graph* _graph;
+  TF_Status* _status;
+  TF_ImportGraphDefOptions* _options;
+  TF_SessionOptions* _sessionOptions;
+  TF_Session* _session;
+
+  std::string _savedModel;
+  std::vector<std::string> _tags;
+  TF_Buffer* _runOptions;
+
+  bool _isTraining;
+  bool _isTrainingSet;
+  std::string _isTrainingName;
+
+  bool _squeeze;
+
+  bool _isConfigured;
+
+  void openGraph();
+  TF_Tensor* TensorToTF(const Tensor<Real>& tensorIn);
+  const Tensor<Real> TFToTensor(const TF_Tensor* tensor, TF_Output node);
+  TF_Output graphOperationByName(const std::string nodeName);
+  std::vector<std::string> nodeNames();
+
+  inline std::string availableNodesInfo() {
+    std::vector<std::string> nodes = nodeNames();
+    std::string info = "OnnxPredict: Available node names are:\n";
+    for (std::vector<std::string>::const_iterator i = nodes.begin(); i != nodes.end() - 1; ++i) info += *i + ", ";
+    return info + nodes.back() + ".\n\nReconfigure this algorithm with valid node names as inputs and outputs before starting the processing.";
+  }
+
+ public:
+  OnnxPredict() : _graph(TF_NewGraph()), _status(TF_NewStatus()),
+      _options(TF_NewImportGraphDefOptions()), _sessionOptions(TF_NewSessionOptions()),
+      _session(TF_NewSession(_graph, _sessionOptions, _status)), _runOptions(NULL),
+      _isConfigured(false) {
+    declareInput(_poolIn, "poolIn", "the pool where to get the feature tensors");
+    declareOutput(_poolOut, "poolOut", "the pool where to store the output tensors");
+  }
+
+  ~OnnxPredict(){
+    TF_CloseSession(_session, _status);
+    TF_DeleteSessionOptions(_sessionOptions);
+    TF_DeleteSession(_session, _status);
+    TF_DeleteImportGraphDefOptions(_options);
+    TF_DeleteStatus(_status);
+    TF_DeleteGraph(_graph);
+    TF_DeleteBuffer(_runOptions);
+  }
+
+  void declareParameters() {
+    const char* defaultTagsC[] = { "serve" };
+    std::vector<std::string> defaultTags = arrayToVector<std::string>(defaultTagsC);
+
+    declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
+    declareParameter("savedModel", "the name of the TensorFlow SavedModel. Overrides parameter `graphFilename`", "", "");
+    declareParameter("tags", "the tags of the savedModel", "", defaultTags);
+    declareParameter("inputs", "will look for these namespaces in poolIn. Should match the names of the input nodes in the Tensorflow graph", "", Parameter::VECTOR_STRING);
+    declareParameter("outputs", "will save the tensors on the graph nodes named after `outputs` to the same namespaces in the output pool. Set the first element of this list as an empty array to print all the available nodes in the graph", "", Parameter::VECTOR_STRING);
+    declareParameter("isTraining", "run the model in training mode (normalized with statistics of the current batch) instead of inference mode (normalized with moving statistics). This only applies to some models", "{true,false}", false);
+    declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");
+    declareParameter("squeeze", "remove singleton dimensions of the inputs tensors. Does not apply to the batch dimension", "{true,false}", true);
+  }
+
+  void configure();
+  void compute();
+  void reset();
+
+  static const char* name;
+  static const char* category;
+  static const char* description;
+};
+
+} //namespace standard
+} //namespace essentia
+
+
+#include "streamingalgorithmwrapper.h"
+
+namespace essentia {
+namespace streaming {
+
+class OnnxPredict : public StreamingAlgorithmWrapper {
+
+ protected:
+  Sink<Pool> _poolIn;
+  Source<Pool> _poolOut;
+
+ public:
+  OnnxPredict() {
+    declareAlgorithm("OnnxPredict");
+    declareInput(_poolIn, TOKEN, "poolIn");
+    declareOutput(_poolOut, TOKEN, "poolOut");
+    _poolOut.setBufferType(BufferUsage::forSingleFrames);
+  }
+};
+
+} //namespace standard
+} //namespace essentia
+
+#endif // ESSENTIA_ONNXPREDICT_H

--- a/src/algorithms/machinelearning/onnxpredict.h
+++ b/src/algorithms/machinelearning/onnxpredict.h
@@ -23,118 +23,90 @@
 #include "algorithm.h"
 #include "pool.h"
 
-// DONE: remove TF include and add ONNX includes
-//#include <tensorflow/c/c_api.h>
+#define ORT_ENABLE_EXTENDED_API
 #include <onnxruntime_cxx_api.h>
 
+#include <unordered_set>
 
 namespace essentia {
 namespace standard {
+
+struct TensorInfo {
+    std::string name;
+    ONNXTensorElementDataType type;
+    std::vector<int64_t> shape;
+};
 
 class OnnxPredict : public Algorithm {
 
  protected:
     
-  // DOUBT: do we need Pool for ONNX?
   Input<Pool> _poolIn;
   Output<Pool> _poolOut;
 
   std::string _graphFilename;
   std::vector<std::string> _inputs;
   std::vector<std::string> _outputs;
-    
-  bool _isTraining;
-  bool _isTrainingSet;
-  std::string _isTrainingName;
   
   bool _squeeze;
-
   bool _isConfigured;
 
   size_t _nInputs;
   size_t _nOutputs;
-  
-  /*
-  std::vector<TF_Tensor*> _inputTensors;
-  std::vector<TF_Tensor*> _outputTensors;
 
-  std::vector<TF_Output> _inputNodes;
-  std::vector<TF_Output> _outputNodes;
-
-  TF_Graph* _graph;
-  TF_Status* _status;
-  TF_ImportGraphDefOptions* _options;
-  TF_SessionOptions* _sessionOptions;
-  TF_Session* _session;
-
-  std::string _savedModel;
-  std::vector<std::string> _tags;
-  TF_Buffer* _runOptions;
-  */
+  Ort::Value _inputTensor{nullptr};
+  Ort::Value _outputTensor{nullptr};
     
-  Ort::Value _inputTensors{nullptr};
-  Ort::Value _outputTensors{nullptr};
+  std::vector<Ort::Value> input_tensors;
+  std::vector<const char*> input_names;
+  std::vector<const char*> output_names;
     
-  Ort::Value _inputNodes;
-  Ort::Value _outputNodes;
-
-  // DOUBT: NOT sure if we would need that
-  Ort::Graph* _graph;
-  Ort::Status* _status;
-    
-  Ort::Env _env;
+  Ort::Env _env{nullptr};
   Ort::SessionOptions _sessionOptions{nullptr};
-  Ort::Session _session;
+  Ort::Session _session{nullptr};
     
-  Ort::RunOptions _run_options;
+  Ort::RunOptions _runOptions;
+  Ort::AllocatorWithDefaultOptions _allocator;
+  Ort::MemoryInfo _memoryInfo{ nullptr };     // Used to allocate memory for input
+  Ort::Model _model;
     
-  Ort::MemoryInfo memory_info{ nullptr };     // Used to allocate memory for input
+  std::vector<TensorInfo> all_input_infos;
+  std::vector<TensorInfo> all_output_infos;
+    
+  std::vector<TensorInfo> _inputNodes;
+  std::vector<TensorInfo> _outputNodes;
+    
+  std::vector<std::string> inputNames();
+  std::vector<std::string> outputNames();
+  std::vector<TensorInfo> setTensorInfos(const Ort::Session&, Ort::AllocatorWithDefaultOptions&, bool);
+  void printTensorInfos(const std::vector<TensorInfo>&, const std::string&);
+  std::string getTensorInfos(const std::vector<TensorInfo>&, const std::string&);
+  void checkName(const std::string, std::vector<TensorInfo>);
+  std::string onnxTypeToString(ONNXTensorElementDataType);
 
-  /*void openGraph();
-  TF_Tensor* TensorToTF(const Tensor<Real>& tensorIn);
-  const Tensor<Real> TFToTensor(const TF_Tensor* tensor, TF_Output node);
-  TF_Output graphOperationByName(const std::string nodeName);*/
-  std::vector<std::string> nodeNames();
-
-
-  // TODO: do we need this one?
-  inline std::string availableNodesInfo() {
-    std::vector<std::string> nodes = nodeNames();
-    std::string info = "OnnxPredict: Available node names are:\n";
-    for (std::vector<std::string>::const_iterator i = nodes.begin(); i != nodes.end() - 1; ++i) info += *i + ", ";
-    return info + nodes.back() + ".\n\nReconfigure this algorithm with valid node names as inputs and outputs before starting the processing.";
+  inline std::string availableInputInfo() {
+    std::vector<std::string> inputs = inputNames();
+    std::string info = "OnnxPredict: Available input names are:\n";
+    for (std::vector<std::string>::const_iterator i = inputs.begin(); i != inputs.end() - 1; ++i) info += *i + ", ";
+    return info + inputs.back() + ".\n\nReconfigure this algorithm with valid node names as inputs and outputs before starting the processing.";
   }
 
  public:
-  /*OnnxPredict() : _graph(TF_NewGraph()), _status(TF_NewStatus()),
-      _options(TF_NewImportGraphDefOptions()), _sessionOptions(TF_NewSessionOptions()),
-      _session(TF_NewSession(_graph, _sessionOptions, _status)), _runOptions(NULL),
-      _isConfigured(false) {
-    declareInput(_poolIn, "poolIn", "the pool where to get the feature tensors");
-    declareOutput(_poolOut, "poolOut", "the pool where to store the output tensors");
-  }*/
     
-  OnnxPredict() : _env(Ort::Env(ORT_LOGGING_LEVEL_WARNING, "default")),
-    _sessionOptions(Ort::SessionOptions()), _session(Ort::Session(_env, _graphFilename.c_str(), _sessionOptions)), _isConfigured(false) {
+  OnnxPredict() : _env(Ort::Env(ORT_LOGGING_LEVEL_WARNING, "test")),
+    _sessionOptions(Ort::SessionOptions()), _session(Ort::Session(nullptr)), _runOptions(NULL), _isConfigured(false) , _model(Ort::Model(nullptr)){
     declareInput(_poolIn, "poolIn", "the pool where to get the feature tensors");
     declareOutput(_poolOut, "poolOut", "the pool where to store the output tensors");
   }
 
   ~OnnxPredict(){
-    // TODO: replace with ONNX functionalities
-    //Ort::ReleaseSession(_session);
-    //Ort::ReleaseSessionOptions(_sessionOptions);
-    //Ort::ReleaseGraph(_graph);      // error: no type named 'ReleaseGraph' in namespace 'Ort'
-    //Ort::ReleaseStatus(_status);
-    //Ort::ReleaseRunOptions(_runOptions);
-    
-    /*TF_CloseSession(_session, _status);
-    TF_DeleteSessionOptions(_sessionOptions);
-    TF_DeleteSession(_session, _status);
-    TF_DeleteImportGraphDefOptions(_options);
-    TF_DeleteStatus(_status);
-    TF_DeleteGraph(_graph);
-    TF_DeleteBuffer(_runOptions);*/
+    all_input_infos.clear();
+    all_output_infos.clear();
+    _inputNodes.clear();
+    _outputNodes.clear();
+    input_tensors.clear();
+    input_names.clear();
+    output_names.clear();
   }
 
   void declareParameters() {
@@ -143,9 +115,9 @@ class OnnxPredict : public Algorithm {
 
     declareParameter("graphFilename", "the name of the file from which to load the TensorFlow graph", "", "");
     declareParameter("inputs", "will look for these namespaces in poolIn. Should match the names of the input nodes in the Tensorflow graph", "", Parameter::VECTOR_STRING);
+    // TODO: fix the empty input and output parameters.
     declareParameter("outputs", "will save the tensors on the graph nodes named after `outputs` to the same namespaces in the output pool. Set the first element of this list as an empty array to print all the available nodes in the graph", "", Parameter::VECTOR_STRING);
     declareParameter("isTraining", "run the model in training mode (normalized with statistics of the current batch) instead of inference mode (normalized with moving statistics). This only applies to some models", "{true,false}", false);
-    //declareParameter("isTrainingName", "the name of an additional input node indicating whether the model is to be run in a training mode (for models with a training mode, leave it empty otherwise)", "", "");
     declareParameter("squeeze", "remove singleton dimensions of the inputs tensors. Does not apply to the batch dimension", "{true,false}", true);
   }
 

--- a/src/python/essentia/standard.py
+++ b/src/python/essentia/standard.py
@@ -27,6 +27,7 @@ from copy import copy
 def _create_essentia_class(name, moduleName = __name__):
     essentia.log.debug(essentia.EPython, 'Creating essentia.standard class: %s' % name)
 
+    # print(f"name: {name}")
     _algoInstance = _essentia.Algorithm(name)
     _algoDoc = _algoInstance.getDoc()
     _algoStruct = _algoInstance.getStruct()
@@ -71,7 +72,7 @@ def _create_essentia_class(name, moduleName = __name__):
 
             # we have to make some exceptions for YamlOutput and PoolAggregator
             # because they expect cpp Pools
-            if name in ('YamlOutput', 'PoolAggregator', 'SvmClassifier', 'PCA', 'GaiaTransform', 'TensorflowPredict'):
+            if name in ('YamlOutput', 'PoolAggregator', 'SvmClassifier', 'PCA', 'GaiaTransform', 'TensorflowPredict', 'OnnxPredict'):
                 args = (args[0].cppPool,)
 
             # verify that all types match and do any necessary conversions
@@ -105,7 +106,7 @@ def _create_essentia_class(name, moduleName = __name__):
 
             # we have to make an exceptional case for YamlInput, because we need
             # to wrap the Pool that it outputs w/ our python Pool from common.py
-            if name in ('YamlInput', 'PoolAggregator', 'SvmClassifier', 'PCA', 'GaiaTransform', 'Extractor', 'TensorflowPredict'):
+            if name in ('YamlInput', 'PoolAggregator', 'SvmClassifier', 'PCA', 'GaiaTransform', 'Extractor', 'TensorflowPredict', 'OnnxPredict'):
                 return _c.Pool(results)
 
             # MusicExtractor and FreesoundExtractor output two pools

--- a/src/wscript
+++ b/src/wscript
@@ -21,7 +21,9 @@ lib_map = {
     'FFTW': 'fftw3f',
     'LIBCHROMAPRINT': 'libchromaprint',
     'GAIA2': 'gaia2',
-    'TENSORFLOW': 'tensorflow'}
+    'TENSORFLOW': 'tensorflow',
+    'ONNXRUNTIME': 'onnxruntime',
+    }
 
 
 def options(ctx):
@@ -199,6 +201,10 @@ def configure(ctx):
 
     if 'tensorflow' in ctx.env.CHECK_LIBS:
         ctx.check_cfg(package=lib_map['TENSORFLOW'], uselib_store='TENSORFLOW',
+                      args=check_cfg_args, mandatory=True)
+    
+    if 'onnxruntime' in ctx.env.CHECK_LIBS:
+        ctx.check_cfg(package=lib_map['ONNXRUNTIME'], uselib_store='ONNXRUNTIME',
                       args=check_cfg_args, mandatory=True)
 
     # needed by ffmpeg for the INT64_C macros

--- a/src/wscript
+++ b/src/wscript
@@ -22,7 +22,7 @@ lib_map = {
     'LIBCHROMAPRINT': 'libchromaprint',
     'GAIA2': 'gaia2',
     'TENSORFLOW': 'tensorflow',
-    'ONNXRUNTIME': 'onnxruntime',
+    'ONNXRUNTIME': 'libonnxruntime',
     }
 
 
@@ -211,7 +211,7 @@ def configure(ctx):
 
     if 'onnxruntime' in ctx.env.CHECK_LIBS:
         ctx.check_cfg(package=lib_map['ONNXRUNTIME'], uselib_store='ONNXRUNTIME',
-                      args=check_cfg_args, mandatory=True)
+                      args=['libonnxruntime >= 1.21.1'] + check_cfg_args, mandatory=True)
 
     # needed by ffmpeg for the INT64_C macros
     ctx.env.DEFINES += ['__STDC_CONSTANT_MACROS']

--- a/src/wscript
+++ b/src/wscript
@@ -57,6 +57,9 @@ def options(ctx):
     ctx.add_option('--with-tensorflow', action='store_true',
                    dest='WITH_TENSORFLOW', default=False,
                    help='build with Tensorflow support')
+    ctx.add_option('--with-onnx', action='store_true',
+                   dest='WITH_ONNXRUNTIME', default=False,
+                   help='build with Onnx-Runtime support')
     ctx.add_option('--lightweight', action='store',
                    dest='LIGHTWEIGHT', default=False,
                    help='build lightweight version with specified dependencies (comma separated: =' + ','.join(default_libs) + ')')
@@ -111,6 +114,9 @@ def configure(ctx):
 
     if ctx.env.WITH_TENSORFLOW:
         ctx.env.CHECK_LIBS.append('tensorflow')
+
+    if ctx.env.WITH_ONNXRUNTIME:
+        ctx.env.CHECK_LIBS.append('onnxruntime')
 
     if ctx.env.IGNORE_ALGOS:
         for a in ctx.env.IGNORE_ALGOS.split(","):
@@ -202,7 +208,7 @@ def configure(ctx):
     if 'tensorflow' in ctx.env.CHECK_LIBS:
         ctx.check_cfg(package=lib_map['TENSORFLOW'], uselib_store='TENSORFLOW',
                       args=check_cfg_args, mandatory=True)
-    
+
     if 'onnxruntime' in ctx.env.CHECK_LIBS:
         ctx.check_cfg(package=lib_map['ONNXRUNTIME'], uselib_store='ONNXRUNTIME',
                       args=check_cfg_args, mandatory=True)
@@ -347,6 +353,17 @@ def configure(ctx):
         print('  The following algorithms will be ignored: %s' % algos)
         ctx.env.ALGOIGNORE += algos
 
+
+    algos = [ 'OnnxPredict' ]
+    if has('onnxruntime'):
+        print('- OnnxRuntime detected!')
+        print('  The following algorithms will be included: %s\n' % algos)
+        ctx.env.USE_LIBS += ' ONNXRUNTIME'
+    else:
+        print('- Essentia is configured without Onnx-Runtime.')
+        print('  The following algorithms will be ignored: %s' % algos)
+        ctx.env.ALGOIGNORE += algos
+    
     lel = len(ctx.env.EXAMPLE_LIST)
     if lel:
         print('- Compiling %s example%s' % (lel, "" if lel == 1 else "s"))

--- a/test/src/unittests/machinelearning/test_onnxpredict.py
+++ b/test/src/unittests/machinelearning/test_onnxpredict.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Affero GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+from essentia_test import *
+import sys
+import os
+from pathlib import Path
+import soundfile as sf
+
+
+class TestOnnxPredict(TestCase):
+    # def testIONameParser(self):
+    #     model = join(testdata.models_dir, "discogs-effnet-bsdynamic-1.onnx")
+    #     print(f"\nmodel: {model}")
+    #     configs = [
+    #         {
+    #             "graphFilename": model,
+    #             "inputs": ["model/Placeholder"],
+    #             "outputs": ["model/Softmax:"],
+    #         },  # No index.
+    #         {
+    #             "graphFilename": model,
+    #             "inputs": ["model/Placeholder"],
+    #             "outputs": ["model/Softmax:3"],
+    #         },  # Index out of bounds.
+    #         {
+    #             "graphFilename": model,
+    #             "inputs": ["model/Placeholder"],
+    #             "outputs": ["model/Softmax::0"],
+    #         },  # Double colon.
+    #         {
+    #             "graphFilename": model,
+    #             "inputs": ["model/Placeholder"],
+    #             "outputs": ["model/Softmax:s:0"],
+    #         },  # Several colons.
+    #     ]
+
+    #     for config in configs[1:]:
+    #         with self.subTest(f"{config} failed"):
+    #             self.assertConfigureFails(OnnxPredict(), config)
+
+    def testInference(self,):
+        model = join(testdata.models_dir, "discogs-effnet-bsdynamic-1.onnx")
+        print(f"\nmodel: {model}")
+        output_layer_name0 = "activations"
+        output_layer_name1 = "embeddings"
+        onxx_predict = OnnxPredict(
+            graphFilename= model,
+            inputs=[],
+            outputs=[output_layer_name0, output_layer_name1]
+            )
+
+        stem = "387517__deleted_user_7267864__saxophone-going-up"
+        audio_path = join(testdata.audio_dir, Path("recorded"), f"{stem}.wav")
+
+        audio, sample_rate = sf.read(audio_path, dtype=numpy.float32)
+        print(f"audio.shape: {audio.shape}")
+
+        frame_size = 512
+        hop_size = 256
+        patch_size = 128
+        number_bands = 96
+
+        w = Windowing(type="hann", zeroPadding=frame_size)
+        spectrum = Spectrum(size=frame_size)
+        mels = MelBands(inputSize=frame_size+1,numberBands=number_bands, type="magnitude")
+        logNorm = UnaryOperator(type="log")
+
+        # compute mel bands
+        bands = []
+        for frame in FrameGenerator(audio, frameSize=frame_size, hopSize=hop_size):
+            melFrame = mels(spectrum(w(frame)))
+            bands.append(logNorm(melFrame))
+        bands = array(bands)
+
+        discard = bands.shape[0] % patch_size
+        bands = numpy.reshape(bands[:-discard, :], [-1, patch_size, number_bands])
+        batch = numpy.expand_dims(bands, 1)
+        print(f"bands.shape: {bands.shape}")
+        print(f"batch.shape: {batch.shape}")
+
+        pool = Pool()
+        pool.set("melspectrogram", batch)
+
+        pool_out = onxx_predict(pool)
+
+        # print(f"op: {dir(pool_out)}")
+        print(f"descriptorNames: {pool_out.descriptorNames()}")
+        print(f"result['{output_layer_name0}']: {pool_out[output_layer_name0]}")
+        print(f"result['{output_layer_name0}'].shape(): {pool_out[output_layer_name0].shape}")
+
+        print(f"result['{output_layer_name1}']: {pool_out[output_layer_name1]}")
+        print(f"result['{output_layer_name0}'].shape(): {pool_out[output_layer_name1].shape}")
+
+        AssertionError()
+
+    """
+    def regression(self, parameters):
+        # Test a simple tensorflow model trained on Essentia features.
+        # The ground true values were obtained with the following script:
+        expectedValues = [9.9997020e-01, 5.3647455e-14, 2.9801236e-05, 4.9495230e-12]
+
+        patchSize = 128
+        numberBands = 128
+        frameSize = 1024
+        hopSize = frameSize
+
+        filename = join(testdata.audio_dir, "recorded", "cat_purrrr.wav")
+
+        audio = MonoLoader(filename=filename)()
+
+        w = Windowing(type="hann", zeroPadding=frameSize)
+        spectrum = Spectrum()
+        mels = MelBands(numberBands=numberBands, type="magnitude")
+        logNorm = UnaryOperator(type="log")
+
+        bands = []
+        for frame in FrameGenerator(audio, frameSize=frameSize, hopSize=hopSize):
+            melFrame = mels(spectrum(w(frame)))
+            bands.append(logNorm(melFrame))
+        bands = array(bands)
+
+        discard = bands.shape[0] % patchSize
+        bands = numpy.reshape(bands[:-discard, :], [-1, patchSize, numberBands])
+        batch = numpy.expand_dims(bands, 1)
+
+        pool = Pool()
+        pool.set("model/Placeholder", batch)
+
+        tfp = TensorflowPredict(**parameters)
+        poolOut = tfp(pool)
+
+        foundValues = poolOut["model/Softmax"].mean(axis=0).squeeze()
+
+        self.assertAlmostEqualVector(foundValues, expectedValues, 1e-5)
+
+    def testRegressionFrozenModel(self):
+        parameters = {
+            "graphFilename": join(testdata.models_dir, "vgg", "vgg4.pb"),
+            "inputs": ["model/Placeholder"],
+            "outputs": ["model/Softmax"],
+            "isTraining": False,
+            "isTrainingName": "model/Placeholder_1",
+        }
+
+        self.regression(parameters)
+
+    def testRegressionSavedModel(self):
+        parameters = {
+            "savedModel": join(testdata.models_dir, "vgg", "vgg4"),
+            "inputs": ["model/Placeholder"],
+            "outputs": ["model/Softmax"],
+            "isTraining": False,
+            "isTrainingName": "model/Placeholder_1",
+        }
+
+        self.regression(parameters)
+
+    def testSavedModelOverridesGraphFilename(self):
+        # When both are specified, `savedModel` should be preferred.
+        # Test this by setting an invalid `graphFilename` that should be ignored.
+        parameters = {
+            "graphFilename": "wrong_model",
+            "savedModel": join(testdata.models_dir, "vgg", "vgg4"),
+            "inputs": ["model/Placeholder"],
+            "outputs": ["model/Softmax"],
+            "isTraining": False,
+            "isTrainingName": "model/Placeholder_1",
+        }
+
+        self.regression(parameters)
+
+    def testEmptyModelName(self):
+        # With empty model name the algorithm should skip the configuration without errors.
+        self.assertConfigureSuccess(TensorflowPredict(), {})
+        self.assertConfigureSuccess(TensorflowPredict(), {"graphFilename": ""})
+        self.assertConfigureSuccess(
+            TensorflowPredict(), {"graphFilename": "", "inputs": [""]}
+        )
+        self.assertConfigureSuccess(
+            TensorflowPredict(), {"graphFilename": "", "inputs": ["wrong_input"]}
+        )
+        self.assertConfigureSuccess(TensorflowPredict(), {"savedModel": ""})
+        self.assertConfigureSuccess(
+            TensorflowPredict(), {"savedModel": "", "inputs": [""]}
+        )
+        self.assertConfigureSuccess(
+            TensorflowPredict(), {"savedModel": "", "inputs": ["wrong_input"]}
+        )
+        self.assertConfigureSuccess(
+            TensorflowPredict(), {"graphFilename": "", "savedModel": ""}
+        )
+        self.assertConfigureSuccess(
+            TensorflowPredict(), {"graphFilename": "", "savedModel": "", "inputs": [""]}
+        )
+        self.assertConfigureSuccess(
+            TensorflowPredict(),
+            {"graphFilename": "", "savedModel": "", "inputs": ["wrong_input"]},
+        )
+
+    def testInvalidParam(self):
+        model = join(testdata.models_dir, "vgg", "vgg4.pb")
+        self.assertConfigureFails(
+            TensorflowPredict(), {"graphFilename": model}
+        )  # inputs and outputs are not defined
+        self.assertConfigureFails(
+            TensorflowPredict(),
+            {
+                "graphFilename": model,
+                "inputs": ["model/Placeholder"],
+            },
+        )  # outputs are not defined
+        self.assertConfigureFails(
+            TensorflowPredict(),
+            {
+                "graphFilename": model,
+                "inputs": ["wrong_input_name"],
+                "outputs": ["model/Softmax"],
+            },
+        )  # input does not exist in the model
+        self.assertConfigureFails(
+            TensorflowPredict(),
+            {
+                "graphFilename": "wrong_model_name",
+                "inputs": ["model/Placeholder"],
+                "outputs": ["model/Softmax"],
+            },
+        )  # the model does not exist
+
+        # Repeat tests for savedModel format.
+        model = join(testdata.models_dir, "vgg", "vgg4/")
+        self.assertConfigureFails(
+            TensorflowPredict(), {"savedModel": model}
+        )  # inputs and outputs are not defined
+        self.assertConfigureFails(
+            TensorflowPredict(),
+            {
+                "savedModel": model,
+                "inputs": ["model/Placeholder"],
+            },
+        )  # outputs are not defined
+        self.assertConfigureFails(
+            TensorflowPredict(),
+            {
+                "savedModel": model,
+                "inputs": ["wrong_input_name"],
+                "outputs": ["model/Softmax"],
+            },
+        )  # input does not exist in the model
+        self.assertConfigureFails(
+            TensorflowPredict(),
+            {
+                "savedModel": "wrong_model_name",
+                "inputs": ["model/Placeholder"],
+                "outputs": ["model/Softmax"],
+            },
+        )  # the model does not exist
+
+    def testIdentityModel(self):
+        # Perform the identity operation in Tensorflow to test if the data is
+        # being copied correctly backwards and fordwards.
+        model = join(filedir(), "tensorflowpredict", "identity.pb")
+        filename = join(testdata.audio_dir, "recorded", "cat_purrrr.wav")
+
+        audio = MonoLoader(filename=filename)()
+        frames = array([frame for frame in FrameGenerator(audio)])
+        batch = frames[numpy.newaxis, numpy.newaxis, :]
+
+        pool = Pool()
+        pool.set("model/Placeholder", batch)
+
+        poolOut = TensorflowPredict(
+            graphFilename=model,
+            inputs=["model/Placeholder"],
+            outputs=["model/Identity"],
+        )(pool)
+
+        foundValues = poolOut["model/Identity"]
+
+        self.assertAlmostEqualMatrix(foundValues, batch)
+
+    def testComputeWithoutConfiguration(self):
+        pool = Pool()
+        pool.set("model/Placeholder", numpy.zeros((1, 1, 1, 1), dtype="float32"))
+
+        self.assertComputeFails(TensorflowPredict(), pool)
+
+    def testIgnoreInvalidReconfiguration(self):
+        pool = Pool()
+        pool.set("model/Placeholder", numpy.ones((1, 1, 1, 1), dtype="float32"))
+
+        model_name = join(filedir(), "tensorflowpredict", "identity.pb")
+        model = TensorflowPredict(
+            graphFilename=model_name,
+            inputs=["model/Placeholder"],
+            outputs=["model/Identity"],
+            squeeze=False,
+        )
+
+        firstResult = model(pool)["model/Identity"]
+
+        # This attempt to reconfigure the algorithm should be ignored and trigger a Warning.
+        model.configure()
+
+        secondResult = model(pool)["model/Identity"]
+
+        self.assertEqualMatrix(firstResult, secondResult)
+
+    def testImplicitOutputTensorIndex(self):
+        model = join(filedir(), "tensorflowpredict", "identity.pb")
+        batch = numpy.reshape(numpy.arange(4, dtype="float32"), (1, 1, 2, 2))
+
+        pool = Pool()
+        pool.set("model/Placeholder", batch)
+
+        implicit_output = "model/Identity"
+        implicit = TensorflowPredict(
+            graphFilename=model,
+            inputs=["model/Placeholder"],
+            outputs=[implicit_output],
+        )(pool)[implicit_output].squeeze()
+
+        explicit_output = "model/Identity:0"
+        explicit = TensorflowPredict(
+            graphFilename=model,
+            inputs=["model/Placeholder"],
+            outputs=[explicit_output],
+        )(pool)[explicit_output].squeeze()
+
+        self.assertAlmostEqualMatrix(implicit, explicit)
+
+    def testNodeNameParser(self):
+        model = join(testdata.models_dir, "vgg", "vgg4.pb")
+
+        configs = [
+            {
+                "graphFilename": model,
+                "inputs": ["model/Placeholder"],
+                "outputs": ["model/Softmax:"],
+            },  # No index.
+            {
+                "graphFilename": model,
+                "inputs": ["model/Placeholder"],
+                "outputs": ["model/Softmax:3"],
+            },  # Index out of bounds.
+            {
+                "graphFilename": model,
+                "inputs": ["model/Placeholder"],
+                "outputs": ["model/Softmax::0"],
+            },  # Double colon.
+            {
+                "graphFilename": model,
+                "inputs": ["model/Placeholder"],
+                "outputs": ["model/Softmax:s:0"],
+            },  # Several colons.
+        ]
+
+        for config in configs[1:]:
+            with self.subTest(f"{config} failed"):
+                self.assertConfigureFails(TensorflowPredict(), config)
+    """
+
+suite = allTests(TestOnnxPredict)
+
+if __name__ == "__main__":
+    TextTestRunner(verbosity=2).run(suite)

--- a/wscript
+++ b/wscript
@@ -92,6 +92,7 @@ def configure(ctx):
     ctx.env.PKG_CONFIG_PATH      = ctx.options.PKG_CONFIG_PATH
     ctx.env.WITH_GAIA            = ctx.options.WITH_GAIA
     ctx.env.WITH_TENSORFLOW      = ctx.options.WITH_TENSORFLOW
+    ctx.env.WITH_ONNXRUNTIME     = ctx.options.WITH_ONNXRUNTIME
     ctx.env.LIGHTWEIGHT          = ctx.options.LIGHTWEIGHT
     ctx.env.EXAMPLES             = ctx.options.EXAMPLES
     ctx.env.EXAMPLE_LIST         = []


### PR DESCRIPTION
This pull request make additional changes in essentia to build ONNX Runtime Inferencing library from the source and to implement a new algorithm (OnnxPredict) to run ONNX models with multiple IO.

## Prerequisites


## Which files have been modified?

* [packaging/build_config.sh](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-c5921fcf673d79cd045f0d088fe6663a79b85c05896d774340535e0e46d356be)
* [src/python/essentia/standard.py](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-5b18c05683ecf643ba4e5cdfb3aaabf3a5d7077e340f8e4dc5b09d0bac968cfe)
* [src/wscript](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-ed85cf00b26b0b15c2763175e40dc4c861c58c7b9f41e4fbca9b1170d6ed9aff)
* [wscript](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-b79856260b3cc9b3e958c83a55bae1e46e31d232125b925c581022786a7bc042)
* [test/src/unittests/machinelearning/test_onnxpredict.py](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-a0964bdeffd10ae8e2337b013bf8373bcb4e9a58544b8196c6b8afcd1d200746)

## Which files have been created?

* [packaging/debian_3rdparty/build_onnx.sh](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-dec14485d3c1b1b7f3a00cb542217a6d77cc852021e36dcd7e094a38c14ffe18)
* [src/algorithms/machinelearning/onnxpredict.cpp](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-9657ef41ce52ea492f2b48d8e01b4b6061cff31f94cda4104d6cd0bd09170014)
* [src/algorithms/machinelearning/onnxpredict.h](https://github.com/MTG/essentia/compare/master...xaviliz:essentia:feat/onnx-predict#diff-8a68b0a03e456d118166e1baf167697518df19db2e7214015bb4464b043ebe8b)

## How to build ONNX Runtime?

`TODO: Provide command for building onnxruntime dynamic library.`

## How to build OnnxPredict in Essentia?

```
source .env/bin/activate
python3 waf configure --fft=KISS --include-algos=OnnxPredict,Windowing,Spectrum,MelBands,UnaryOperator,FrameGenerator,TriangularBands,FFT,Magnitude,NoiseAdder,RealAccumulator,FileOutputProxy,FrameCutter --static-dependencies --pkg-config-path=/packaging/debian_3rdparty/lib/pkgconfig --with-onnx --lightweight= --with-python --pythondir=.env/lib/python3.13/site-packages
python3 waf -v && python3 waf install
```

## How to test it?

`TODO: Provide a command for unittests.`