### PR TITLE
New upgrade: taglib v1.13.1

### DIFF
--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -2,14 +2,9 @@
 
 HOST=i686-w64-mingw32
 if [ -z "${PREFIX}" ]; then
-  PREFIX=$(pwd)
+  PREFIX=`pwd`
 fi
 echo Installing to: $PREFIX
-
-#SHARED_OR_STATIC="
-#--enable-shared \
-#--disable-static
-#"
 
 SHARED_OR_STATIC="
 --disable-shared \

--- a/packaging/build_config.sh
+++ b/packaging/build_config.sh
@@ -2,7 +2,7 @@
 
 HOST=i686-w64-mingw32
 if [ -z "${PREFIX}" ]; then
-    PREFIX=`pwd`
+  PREFIX=$(pwd)
 fi
 echo Installing to: $PREFIX
 
@@ -19,7 +19,7 @@ SHARED_OR_STATIC="
 EIGEN_VERSION=3.3.7
 FFMPEG_VERSION=ffmpeg-2.8.12
 LAME_VERSION=3.100
-TAGLIB_VERSION=taglib-1.11.1
+TAGLIB_VERSION=taglib-1.13.1
 ZLIB_VERSION=zlib-1.2.12
 FFTW_VERSION=fftw-3.3.2
 LIBSAMPLERATE_VERSION=libsamplerate-0.1.8
@@ -28,7 +28,6 @@ CHROMAPRINT_VERSION=1.4.3
 QT_SOURCE_URL=https://download.qt.io/archive/qt/4.8/4.8.4/qt-everywhere-opensource-src-4.8.4.tar.gz
 GAIA_VERSION=2.4.6-86-ged433ed
 TENSORFLOW_VERSION=2.5.0
-
 
 FFMPEG_AUDIO_FLAGS="
     --disable-programs

--- a/packaging/debian_3rdparty/build_taglib.sh
+++ b/packaging/debian_3rdparty/build_taglib.sh
@@ -13,17 +13,18 @@ tar -xf $TAGLIB_VERSION.tar.gz
 cd $TAGLIB_VERSION/
 
 cmake \
-    -D CMAKE_CXX_FLAGS="-fPIC" \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DZLIB_ROOT=$PREFIX \
-	.
+  -D CMAKE_CXX_FLAGS="-fPIC" \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DZLIB_ROOT=$PREFIX \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+  .
 make
-# patch taglib.cp (missing -lz flag)
+
+# Patch taglib.cp (missing -lz flag)
 sed -i 's/-ltag/-ltag -lz/g' taglib.pc
 make install
 
 cd ../..
 rm -r tmp
-

--- a/test/src/unittests/io/test_metadatareader.py
+++ b/test/src/unittests/io/test_metadatareader.py
@@ -39,9 +39,9 @@ class TestMetadataReader(TestCase):
         result = MetadataReader(filename = join(self.audioDir, 'test.flac'))()
         tagsPool = result[7]
         tags = tagsPool.descriptorNames() + [tagsPool[t][0] for t in tagsPool.descriptorNames()]
-        
+
         self.assertEqualVector(result[:7], ('test flac', 'mtg', 'essentia', '', 'Thrash Metal', '01', '2009'))
-        
+
         # FIXME: Taglib 1.11.0 on OSX outputs bitrate inconsistent with 1.9.1 on Linux for FLAC and OGG
         # It might be due to different versions of Taglib or due to different platforms (we have not tested)
         # Therefore accept both bitrates as correct
@@ -50,11 +50,11 @@ class TestMetadataReader(TestCase):
         self.assertTrue(result[9] == 2201 or result[9] == 2202)
 
         self.assertEqualVector(
-                tags, 
-                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.composer', 'metadata.tags.copyright', 
-                 'metadata.tags.date', 'metadata.tags.description', 'metadata.tags.discnumber', 'metadata.tags.genre', 
-                 'metadata.tags.performer', 'metadata.tags.title', 'metadata.tags.tracknumber', 'metadata.tags.tracktotal', 
-                 'essentia', 'mtg', 'roberto.toscano', 'mtg.upf.edu', '2009', 'This is not thrash metal', '01', 'Thrash Metal', 
+                tags,
+                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.composer', 'metadata.tags.copyright',
+                 'metadata.tags.date', 'metadata.tags.description', 'metadata.tags.discnumber', 'metadata.tags.genre',
+                 'metadata.tags.performer', 'metadata.tags.title', 'metadata.tags.tracknumber', 'metadata.tags.tracktotal',
+                 'essentia', 'mtg', 'roberto.toscano', 'mtg.upf.edu', '2009', 'This is not thrash metal', '01', 'Thrash Metal',
                  'roberto.toscano', 'test flac', '01', '01']
             )
 
@@ -62,7 +62,6 @@ class TestMetadataReader(TestCase):
         result = MetadataReader(filename = join(self.audioDir, 'test.ogg'))()
         tagsPool = result[7]
         tags = tagsPool.descriptorNames() + [tagsPool[t][0] for t in tagsPool.descriptorNames()]
-
         self.assertEqualVector(result[:7], ('test ogg', 'mtg', 'essentia', 'this is not psychadelic', 'Psychadelic', '01', '2009'))
 
         # see the FIXME note above
@@ -70,11 +69,11 @@ class TestMetadataReader(TestCase):
         self.assertTrue(result[9] == 96 or result[9] == 20)
 
         self.assertEqualVector(
-                tags, 
-                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.comment', 'metadata.tags.composer', 
-                 'metadata.tags.copyright', 'metadata.tags.date', 'metadata.tags.description', 'metadata.tags.discnumber', 
-                 'metadata.tags.genre', 'metadata.tags.performer', 'metadata.tags.title', 'metadata.tags.tracknumber', 
-                 'metadata.tags.tracktotal', 'essentia', 'mtg', 'this is not psychadelic', 'roberto.toscano', 'mtg.upf.edu', 
+                tags,
+                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.comment', 'metadata.tags.composer',
+                 'metadata.tags.copyright', 'metadata.tags.date', 'metadata.tags.description', 'metadata.tags.discnumber',
+                 'metadata.tags.genre', 'metadata.tags.performer', 'metadata.tags.title', 'metadata.tags.tracknumber',
+                 'metadata.tags.tracktotal', 'essentia', 'mtg', 'this is not psychadelic', 'roberto.toscano', 'mtg.upf.edu',
                  '2009', 'this is not psychadelic', '1', 'Psychadelic', 'roberto.toscano', 'test ogg', '01', '01']
             )
 
@@ -86,9 +85,9 @@ class TestMetadataReader(TestCase):
         self.assertEqualVector(result[:7], ('test sound', 'mtg', 'essentia', 'this is not reggae', 'Reggae', '01', '2009'))
         self.assertEqualVector(result[8:], (5, 128, 44100, 1))
         self.assertEqualVector(
-                tags, 
-                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.comment', 'metadata.tags.date', 
-                 'metadata.tags.genre', 'metadata.tags.title', 'metadata.tags.tracknumber', 'essentia', 'mtg', 
+                tags,
+                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.comment', 'metadata.tags.date',
+                 'metadata.tags.genre', 'metadata.tags.title', 'metadata.tags.tracknumber', 'essentia', 'mtg',
                  'this is not reggae', '2009', 'Reggae', 'test sound', '01']
             )
 
@@ -100,16 +99,16 @@ class TestMetadataReader(TestCase):
         self.assertEqualVector(result[:7], ('ape test file', 'mtg', 'essentia', 'this is not porn', 'Porn Groove', "01/01", "2009"))
         self.assertEqualVector(result[8:], (5, 722, 44100, 1))
         self.assertEqualVector(
-                tags, 
-                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.comment', 'metadata.tags.composer', 
-                 'metadata.tags.copyright', 'metadata.tags.date', 'metadata.tags.genre', 'metadata.tags.original artist', 
-                 'metadata.tags.part', 'metadata.tags.title', 'metadata.tags.tracknumber', 'essentia', 'mtg', 'this is not porn', 
+                tags,
+                ['metadata.tags.album', 'metadata.tags.artist', 'metadata.tags.comment', 'metadata.tags.composer',
+                 'metadata.tags.copyright', 'metadata.tags.date', 'metadata.tags.genre', 'metadata.tags.original artist',
+                 'metadata.tags.part', 'metadata.tags.title', 'metadata.tags.tracknumber', 'essentia', 'mtg', 'this is not porn',
                  'roberto.toscano', 'mtg.upf.edu', '2009', 'Porn Groove', 'roberto.toscano', '1', 'ape test file', '01/01']
             )
 
     def testPCM(self):
         result = MetadataReader(filename = join(testdata.audio_dir, 'recorded', 'musicbox.wav'), failOnError=True)()
-        
+
         self.assertTrue(not len(result[7].descriptorNames()))
         self.assertEqualVector(result[:7], ('', '', '', '', '', '', ''))
         self.assertEqualVector(result[8:], (45, 1444, 44100, 2))
@@ -117,7 +116,7 @@ class TestMetadataReader(TestCase):
     def testFailOnError(self):
         self.assertComputeFails(
             MetadataReader(filename = join(self.audioDir, 'random_file_that_doesnt_exist.ape'), failOnError=True))
-        
+
         result = MetadataReader(filename = join(self.audioDir, 'random_file_that_doesnt_exist.ape'), failOnError=False)()
 
         self.assertTrue(result[7].descriptorNames() == [])


### PR DESCRIPTION
# New upgrade: taglib v1.13.1
## Upgrade
Upgrade Taglib library version to 1.13.1

## Details

* Modify building script using cmake 3 in `packaging/debian_3rdparty/build_taglib.sh`
* Modify taglib version in `packaging/build_config.sh`

## Prerequisites

`cmake>=3.28`

## Testing 
- [x] Build succesfully in x86_64 GNU/Linux machine
- [ ] Build succesfully in a OSX machine

## How to test
Tested in Ubuntu 24.02.1

```bash
cd packaging/debian_3rdpart/
bash build_taglib.sh
```
