### PR TITLE
Fix: Build FFmpeg as a dynamic library to link with Essentia

### DIFF
--- a/packaging/debian_3rdparty/build_ffmpeg.sh
+++ b/packaging/debian_3rdparty/build_ffmpeg.sh
@@ -20,12 +20,13 @@ cd $FFMPEG_VERSION
 
 ./configure \
   --enable-pic \
+  --disable-static \
+  --enable-shared \
   $FFMPEG_AUDIO_FLAGS \
   $FFMPEG_AUDIO_FLAGS_MUXERS \
   --prefix=$PREFIX \
   --extra-ldflags="-L$PREFIX/lib" \
-  --extra-cflags="-I$PREFIX/include" \
-  $SHARED_OR_STATIC
+  --extra-cflags="-I$PREFIX/include"
 make
 make install
 


### PR DESCRIPTION
# Fix: Build FFmpeg as a dynamic library to link with Essentia

Build `FFmpeg` as a dynamic library and fix errors when `Essentia` builds with `--with-vamp` option.

## Details

- Modify FFmpeg flags in `packaging/debian_3rdparty/build_ffmpeg.sh`

## Solution

- Removes `--disable-shared` and `--enable-static` options.
- Add `--disable-static` and `--enable-shared` options.

## Testing
- [x] Tested in Alma Linux8 Docker image.
- [x] Essentia builds successfully.
- [x] `libvamp_essentia.so` builds successfully.
- [x] `TensorflowPredict` units tests are passed using `MonoLoader`.

## Closes
- Fixes #1504 