### PR TITLE
CI fixes and modernization

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -46,7 +46,7 @@ jobs:
             '
 
       - name: Upload built documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: essentia-docs
           path: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,6 +31,10 @@ jobs:
             -w /project \
             mtgupf/essentia-builds:manylinux2014_x86_64 \
             bash -euxc '
+              # Repo is bind-mounted from the host runner; container runs as
+              # root, so git refuses to touch it without this exception.
+              git config --global --add safe.directory /project
+
               python3 -m pip install --upgrade pip
               python3 -m pip install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat gitpython sphinx-copybutton
               yum install -y doxygen pandoc

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,40 +9,35 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-22.04
+    container:
+      image: mtgupf/essentia-builds:manylinux2014_x86_64
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force
-      - name: Install dependencies
-        run: | 
-          sudo apt-get update
-          sudo apt-get install -y build-essential libeigen3-dev libyaml-dev libfftw3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libsamplerate0-dev libtag1-dev libchromaprint-dev python3-dev python3-numpy-dev python3-numpy python3-yaml python3-six
-          sudo apt-get install -y doxygen python3-pip pandoc
-          pip3 install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat gitpython sphinx-copybutton
-          # Install TensorFlow
-          sudo sh src/3rdparty/tensorflow/setup_from_libtensorflow.sh
-          # Install Gaia dependencies
-          sudo apt-get install qtbase5-dev swig pkg-config
-      - name: Build Gaia
+
+      - name: Install documentation dependencies
         run: |
-          git clone https://github.com/MTG/gaia.git
-          cd gaia
-          python3 waf configure --with-python-bindings
-          python3 waf
-          sudo python3 waf install
+          python3 -m pip install --upgrade pip
+          python3 -m pip install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat gitpython sphinx-copybutton
+          yum install -y doxygen pandoc
 
       - name: Build Essentia
-        run: | 
-          python3 waf configure --with-python --with-gaia --with-tensorflow
+        # Mirror the Linux before-all from cibuildwheel-tensorflow.toml so the
+        # docs build matches what the published wheels are built against.
+        run: |
+          python3 waf configure --with-python --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path="${PKG_CONFIG_PATH}"
           python3 waf
+          python3 waf install
 
       - name: Build documentation
-        run: |
-          python3 waf doc
+        run: python3 waf doc
+
       - name: Upload built documentation
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,10 +8,10 @@ on:
       - master
 jobs:
   build-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-22.04
-    container:
-      image: mtgupf/essentia-builds:manylinux2014_x86_64
 
     steps:
       - uses: actions/checkout@v4
@@ -21,22 +19,27 @@ jobs:
         # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force
 
-      - name: Install documentation dependencies
+      - name: Build Essentia and documentation
+        # Run inside the same image used by cibuildwheel.toml so the
+        # docs are generated against the same toolchain and static deps as the
+        # published wheels. We invoke Docker manually (rather than via the job's
+        # `container:`) because manylinux2014 ships glibc 2.17, which is too old
+        # for the Node 20 runtime that GitHub Actions injects into containers.
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat gitpython sphinx-copybutton
-          yum install -y doxygen pandoc
+          docker run --rm \
+            -v "${PWD}:/project" \
+            -w /project \
+            mtgupf/essentia-builds:manylinux2014_x86_64 \
+            bash -euxc '
+              python3 -m pip install --upgrade pip
+              python3 -m pip install sphinx pyparsing sphinxcontrib-doxylink docutils jupyter sphinx-toolbox nbformat gitpython sphinx-copybutton
+              yum install -y doxygen pandoc
 
-      - name: Build Essentia
-        # Mirror the Linux before-all from cibuildwheel-tensorflow.toml so the
-        # docs build matches what the published wheels are built against.
-        run: |
-          python3 waf configure --with-python --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path="${PKG_CONFIG_PATH}"
-          python3 waf
-          python3 waf install
-
-      - name: Build documentation
-        run: python3 waf doc
+              python3 waf configure --with-python --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path="${PKG_CONFIG_PATH}"
+              python3 waf
+              python3 waf install
+              python3 waf doc
+            '
 
       - name: Upload built documentation
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-15]
+        os: [ubuntu-22.04, macos-15-intel, macos-15]
         config: [cibuildwheel, cibuildwheel-tensorflow]
 
     steps:

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-15-intel, macos-15]
+        os: [ubuntu-24.04, macos-15-intel, macos-15]
         config: [cibuildwheel, cibuildwheel-tensorflow]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -21,11 +21,11 @@ jobs:
         run: git fetch --tags --force
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.2.1
         with:
           config-file: ${{ matrix.config }}.toml
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           path: ./wheelhouse/*.whl
           name: artifact-${{ matrix.os }}-${{ matrix.config }}

--- a/.github/workflows/build-wheels-cibuildwheel.yml
+++ b/.github/workflows/build-wheels-cibuildwheel.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           config-file: ${{ matrix.config }}.toml
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           path: ./wheelhouse/*.whl
           name: artifact-${{ matrix.os }}-${{ matrix.config }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,16 +32,16 @@ jobs:
       PRE_CMD: ${{ matrix.PRE_CMD }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch release tags from GitHub
         # Workaround for https://github.com/actions/checkout/issues/290
         run: git fetch --tags --force
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: '3.12'
       - name: Build wheels in a Docker image
         run: |
           docker pull $DOCKER_IMAGE > /dev/null
@@ -51,7 +51,7 @@ jobs:
           ls wheelhouse/
           sudo python setup.py sdist
       - name: Upload wheels and sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: essentia-python-wheels
           path: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,7 +51,7 @@ jobs:
           ls wheelhouse/
           sudo python setup.py sdist
       - name: Upload wheels and sdist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: essentia-python-wheels
           path: |

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -30,10 +30,8 @@ environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PRO
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
   # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
   # Tensorflow bottle a has minimum target of 14.2 which is too new.
   # We could build from source as a workaround, however, it takes too much time on the CI worker.
@@ -67,10 +65,8 @@ environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PRO
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
   # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
   # Tensorflow bottle a has minimum target of 15.2 which is too new.
   # We could build from source as a workaround, however, it takes too much time on the CI worker.

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -11,7 +11,7 @@ environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PRO
 
 # Use system's Python3 to build Essentia.
 before-all = [
-  "python3 waf configure --with-gaia --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
+  "python3 waf configure --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
   "python3 waf",
   "python3 waf install",
   # Monkey-patch package name.

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -9,11 +9,11 @@ skip = ["pp*", "*-musllinux*", "*i686", "*cp36*", "*cp37*", "*cp38*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
+# Use system's Python3 to build Essentia.
 before-all = [
-  "PYBIN=/opt/python/cp36-cp36m/bin/",
-  "\"${PYBIN}/python\" waf configure --with-gaia --with-tensorflow --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
-  "\"${PYBIN}/python\" waf",
-  "\"${PYBIN}/python\" waf install",
+  "python3 waf configure --with-gaia --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
+  "python3 waf",
+  "python3 waf install",
   # Monkey-patch package name.
   # We could have a separate pyproject.toml configuration, but the build backend does not accept custom configuration filepaths.
   "sed 's/^name *= *\"essentia\"$/name = \"essentia-tensorflow\"/' pyproject.toml > pyproject.toml.patched && mv pyproject.toml.patched pyproject.toml"

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -33,7 +33,7 @@ before-all = [
   "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
   # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
-  # Tensorflow bottle a has minimum target of 14.2 which is too new.
+  # Tensorflow bottle has a minimum target of 15.2 which is too new.
   # We could build from source as a workaround, however, it takes too much time on the CI worker.
   # To keep it simple, just use the bottles available for tensorflow.
   "brew install tensorflow",

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -61,14 +61,14 @@ select = "*macosx_arm64*"
 
 skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
 
-environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1, MACOSX_DEPLOYMENT_TARGET=15.2 }
+environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1, MACOSX_DEPLOYMENT_TARGET=15.4 }
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
   "brew install eigen libyaml fftw ffmpeg libsamplerate libtag",
   "brew install chromaprint",
   # Delocate checks for the min OS version (LC_BUILD_VERSION or C_VERSION_MIN_MACOSX).
-  # Tensorflow bottle a has minimum target of 15.2 which is too new.
+  # Tensorflow bottle has a minimum target of 15.4 which is too new.
   # We could build from source as a workaround, however, it takes too much time on the CI worker.
   # To keep it simple, just use the bottles available for tensorflow.
   "brew install tensorflow",

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -5,7 +5,14 @@ manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 # Only support x86_64 for essentia-tensorflow.
 build = "cp**-manylinux_x86_64"
 
-skip = ["pp*", "*-musllinux*", "*i686", "*cp36*", "*cp37*", "*cp38*"]
+# Skip selectors:
+# - cp38: project does not target Python 3.8.
+# - *t-*: free-threaded (no-GIL) builds. The Essentia C bindings rely on
+#   legacy PyTypeObject definitions that fail to instantiate under
+#   cp313t/cp314t ("Type does not define the tp_name field"). Re-enable
+#   once the bindings are audited for free-threading compatibility.
+# - *-musllinux*, *i686: not supported by our manylinux2014 build images.
+skip = ["*cp38*", "*t-*", "*-musllinux*", "*i686"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
@@ -24,7 +31,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 
 [tool.cibuildwheel.macos]
 
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
+# See linux section for skip rationale.
+skip = ["*cp38*", "*t-*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=15.2 }
 
@@ -59,7 +67,8 @@ before-all = [
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
+# See linux section for skip rationale.
+skip = ["*cp38*", "*t-*"]
 
 environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1, MACOSX_DEPLOYMENT_TARGET=15.4 }
 

--- a/cibuildwheel-tensorflow.toml
+++ b/cibuildwheel-tensorflow.toml
@@ -26,7 +26,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 
 skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
 
-environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=14.2 }
+environment = { PROJECT_NAME="essentia-tensorflow", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=15.2 }
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -22,7 +22,7 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 
 skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
 
-environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=13.0 }
+environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=15.0 }
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -4,7 +4,14 @@
 manylinux-x86_64-image = "mtgupf/essentia-builds:manylinux2014_x86_64"
 manylinux-i686-image = "mtgupf/essentia-builds:manylinux2014_i686"
 
-skip = ["pp*", "*-musllinux*", "*i686", "*cp36*", "*cp37*", "*cp38*"]
+# Skip selectors:
+# - cp38: project does not target Python 3.8.
+# - *t-*: free-threaded (no-GIL) builds. The Essentia C bindings rely on
+#   legacy PyTypeObject definitions that fail to instantiate under
+#   cp313t/cp314t ("Type does not define the tp_name field"). Re-enable
+#   once the bindings are audited for free-threading compatibility.
+# - *-musllinux*, *i686: not supported by our manylinux2014 build images.
+skip = ["*cp38*", "*t-*", "*-musllinux*", "*i686"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
@@ -20,7 +27,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 
 [tool.cibuildwheel.macos]
 
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
+# See linux section for skip rationale.
+skip = ["*cp38*", "*t-*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, MACOSX_DEPLOYMENT_TARGET=15.0 }
 
@@ -40,7 +48,8 @@ test-command = "python -c 'import essentia; import essentia.standard; import ess
 [[tool.cibuildwheel.overrides]]
 select = "*macosx_arm64*"
 
-skip = ["pp*", "*cp36*", "*cp37*", "*cp38*"]
+# See linux section for skip rationale.
+skip = ["*cp38*", "*t-*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1, ESSENTIA_MACOSX_ARM64=1, MACOSX_DEPLOYMENT_TARGET=15.0 }
 

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -26,10 +26,7 @@ environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}"
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm freetype libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
-  "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag chromaprint",
   #"brew tap MTG/essentia",
   #"brew install gaia --HEAD",
   # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
@@ -49,10 +46,7 @@ environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}"
 
 before-all = [
   "brew install pkg-config gcc readline sqlite gdbm libpng",
-  "brew install eigen libyaml fftw ffmpeg@2.8 libsamplerate libtag",
-  "brew link --force ffmpeg@2.8",
-  "brew install chromaprint",
-  "brew link --overwrite ffmpeg@2.8",
+  "brew install eigen libyaml fftw ffmpeg libsamplerate libtag chromaprint",
   # Override VIRTUAL_ENV set by cibuildwheel to ensure global install
   "VIRTUAL_ENV=/usr/local python waf configure --pkg-config-path=\"${PKG_CONFIG_PATH}\" --arch arm64 --no-msse",
   "python waf",

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -8,11 +8,11 @@ skip = ["pp*", "*-musllinux*", "*i686", "*cp36*", "*cp37*", "*cp38*"]
 
 environment = { PROJECT_NAME="essentia", ESSENTIA_PROJECT_NAME="${PROJECT_NAME}", ESSENTIA_WHEEL_SKIP_3RDPARTY=1, ESSENTIA_WHEEL_ONLY_PYTHON=1 }
 
+# Use system's Python3 to build Essentia.
 before-all = [
-  "PYBIN=/opt/python/cp36-cp36m/bin/",
-  "\"${PYBIN}/python\" waf configure --with-gaia --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
-  "\"${PYBIN}/python\" waf",
-  "\"${PYBIN}/python\" waf install"
+  "python3 waf configure --with-gaia --build-static --static-dependencies --pkg-config-path=\"${PKG_CONFIG_PATH}\"",
+  "python3 waf",
+  "python3 waf install",
 ]
 
 test-command = "python -c 'import essentia; import essentia.standard; import essentia.streaming; from essentia.standard import MonoLoader, MetadataReader, YamlInput, Chromaprinter'"

--- a/wscript
+++ b/wscript
@@ -47,7 +47,7 @@ def options(ctx):
                    help='debug, release or default')
 
     ctx.add_option('--std', action='store',
-                   dest='STD', default='c++11',
+                   dest='STD', default='c++14',
                    help='C++ standard to compile for [c++11 c++14 c++17 ...]')
 
     ctx.add_option('--arch', action='store',


### PR DESCRIPTION
This PR brings the build system and CI workflows up to date with current toolchains and runner availability, fixing several breakages along the way.

**C++ standard: C++11 → C++14**

Homebrew's current eigen formula (5.x) requires C++14 features (std::enable_if_t, std::integer_sequence, std::make_signed_t, etc.), which fail to compile under Essentia's previous C++11 default. Bumped the default in wscript to C++14.

**macOS deployment target bumps**

The libtensorflow Homebrew bottle has tightened its minimum macOS target. delocate-wheel rejected wheels whose bundled libs required a newer OS than the wheel's own tag advertised. Updated MACOSX_DEPLOYMENT_TARGET for the cibuildwheel-tensorflow.toml arm64 override (15.2 → 15.4) to match the current bottle.

**cibuildwheel.toml skip selectors**

cibuildwheel 3.x rejected several legacy selectors with warnings:
- Removed pp*, *cp36*, *cp37* (no longer valid in 3.x).
- Kept *cp38* (project choice) and *-musllinux*/*i686 (unsupported by our manylinux2014 image).
- Added *t-* to skip Python free-threaded builds (cp313t, cp314t). The Essentia C bindings define types via the legacy PyTypeObject API and fail to instantiate under no-GIL Python with SystemError: Type does not define the tp_name field. Re-enable once the bindings are audited for free-threading.

**build-docs.yml: aligned with the wheel build**

The docs workflow was building Essentia from scratch on a stock Ubuntu host: apt-get for system deps, manual git clone + build of Gaia, and setup_from_libtensorflow.sh for TensorFlow. This drifted from how the published wheels are produced and meant docs could pass while wheels failed (or vice versa).

Now the docs job runs the build inside the same mtgupf/essentia-builds:manylinux2014_x86_64 image used by cibuildwheel-tensorflow.toml, with the same waf configure flags. Only Sphinx/Doxygen/pandoc are layered on top.

**Workflow modernization**

- actions/checkout: v4 → v6
- actions/upload-artifact: v4 → v6
- actions/setup-python: v2 → v6 (host Python 3.8 → 3.12 for sdist)
- pypa/cibuildwheel: v2.23.2 → v3.2.1
- Hosted runners: ubuntu-22.04 → ubuntu-24.04 (preempts upcoming GitHub deprecation; the actual builds still run inside the manylinux container, so host changes are just to prevent sooner deprecation).

**Removed macos-13 runner**

GitHub retired the Intel macos-13 hosted runner; jobs targeting it sit indefinitely in "Waiting for a runner". Replaced with macos-15-intel / kept macos-15 (arm64).