### PR TITLE
Reorganize interactive demos section and improve demo links

### DIFF
--- a/doc/sphinxdoc/demos.rst
+++ b/doc/sphinxdoc/demos.rst
@@ -1,45 +1,14 @@
 Interactive demos
 =================
 
-Music audio descriptors in the browser
---------------------------------------
+Essentia.js browser demos — (real-time) analysis in the browser (tagging, genre, mood, key, BPM, onset detection, audio metering, chroma, pitch, mel-spectrogram)
+https://mtg.github.io/essentia.js/examples/#/demos/
 
-Examples of music audio analysis with Essentia algorithms using Essentia.js
+Replicate demos — cloud-hosted inference demos (tagging, genre, mood, arousal/valence, approachability, engagement, BPM)
+https://replicate.com/mtg/
 
-https://mtg.github.io/essentia.js/examples/
+AcousticBrainz — large-scale music analysis database with descriptors for millions of tracks
+https://acousticbrainz.org
 
-
-Tempo estimation
-----------------
-
-Tempo BPM estimation with Essentia: https://replicate.com/mtg/essentia-bpm
-
-
-Essentia TensorFlow models
---------------------------
-
-Examples of inference with the pre-trained TensorFlow models for music auto-tagging and classification tasks:
-
-- Music classification by genre, mood, danceability, instrumentation: https://replicate.com/mtg/music-classifiers
-- Music style classification with the Discogs taxonomy (400 styles, MAEST model). Overall track-level predictions: https://replicate.com/mtg/maest
-- Music style classification with the Discogs taxonomy (400 styles, Effnet-Discogs model). Overall track-level predictions: https://replicate.com/mtg/effnet-discogs
-- Music style classification with the Discogs taxonomy (400 styles, Effnet-Discogs model). Segment-level real-time predictions with Essentia.js: https://essentia.upf.edu/essentiajs-discogs
-- Real-time music autotagging (50 tags) in the browser with Essentia.js: https://mtg.github.io/essentia.js/examples/demos/autotagging-rt/
-- Mood classification in the browser with Essentia.js: https://mtg.github.io/essentia.js/examples/demos/mood-classifiers/
-- Music emotion arousal/valence regression: https://replicate.com/mtg/music-arousal-valence
-- Music approachability and engagement: https://replicate.com/mtg/music-approachability-engagement
-- Jupyter notebook for real-time music `auto-tagging <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_auto-tagging.ipynb>`_ and `classification <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_simultaneous_classifiers.ipynb>`_.
-
-    .. raw:: html
-
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/xMUcY7_n4kQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/yssBE6oafLs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-Essentia SVM models
--------------------
-
-Examples of inference with older SVM models for music classification tasks:
-
-- `AcousticBrainz <https://acousticbrainz.org>`_ is using our pre-trained SVM classifiers for large-scale music analysis on millions of tracks.
-- `AcousticBrainz Moods Playlist Generator <http://mtg.upf.edu/demos/acousticbrainz/moods>`_  is using SVM mood classifiers.
+Cosine.club — interactive music similarity exploration
+https://cosine.club/

--- a/doc/sphinxdoc/python_examples.rst
+++ b/doc/sphinxdoc/python_examples.rst
@@ -48,6 +48,8 @@ Deep embeddings, music classification and auto-tagging
 * `Music auto-tagging, classification, and embedding extraction <tutorial_tensorflow_auto-tagging_classification_embeddings.html>`_
 * `Real-time music auto-tagging <tutorial_tensorflow_real-time_auto-tagging.html>`_
 * `Simultaneous real-time inference with multiple classifiers <tutorial_tensorflow_real-time_simultaneous_classifiers.html>`_
+* `Music auto-tagging <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_auto-tagging.ipynb>`_
+* `Music classification <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_simultaneous_classifiers.ipynb>`_
 
 
 Fingerprinting & similarity
@@ -67,9 +69,3 @@ Audio problems
 * `Signal-to-noise ratio estimation <tutorial_audioproblems_snr.html>`_
 * `Start/stop cuts detection <tutorial_audioproblems_startstopcut.html>`_
 * `True-peak detection <tutorial_audioproblems_truepeakdetector.html>`_
-
-
-Jupyter notebook real-time
---------------------------
-* `Music auto-tagging <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_auto-tagging.ipynb>`_
-* `Music classification <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_simultaneous_classifiers.ipynb>`_

--- a/doc/sphinxdoc/python_examples.rst
+++ b/doc/sphinxdoc/python_examples.rst
@@ -68,3 +68,8 @@ Audio problems
 * `Start/stop cuts detection <tutorial_audioproblems_startstopcut.html>`_
 * `True-peak detection <tutorial_audioproblems_truepeakdetector.html>`_
 
+
+Jupyter notebook real-time
+--------------------------
+* `Music auto-tagging <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_auto-tagging.ipynb>`_
+* `Music classification <https://github.com/MTG/essentia/blob/master/src/examples/python/tutorial_tensorflow_real-time_simultaneous_classifiers.ipynb>`_


### PR DESCRIPTION
# Reorganize interactive demos section and improve demo links

## Description

This PR reorganizes the interactive demos section of the Essentia webpage.

## Main changes

- Redesigned and simplified links for:
  - Essentia JS demos
  - Replicate demos
  - application examples (AcousticBrainz, cosine.club, etc.)
- Improved demo organization and reduced redundancy.
- Moved Jupyter Notebook real-time demos to the Python Examples section for better documentation consistency.

These changes aim to improve navigation, clarity, and overall usability of the demos page.