### PR TITLE
AudioLoader: fix swresample init for unspecified channel layouts

### DIFF
--- a/src/algorithms/io/audioloader.cpp
+++ b/src/algorithms/io/audioloader.cpp
@@ -122,17 +122,26 @@ void AudioLoader::openAudioFile(const string& filename) {
   
     // Configure format conversion (no samplerate conversion yet)
     // Use modern channel layout API
+    // Containers such as WAV commonly leave the layout unspecified (order
+    // AV_CHANNEL_ORDER_UNSPEC); swr_init() rejects that, so derive the default
+    // layout for the channel count instead.
     AVChannelLayout layout;
-    if (_audioCtx->ch_layout.nb_channels > 0) {
-        layout = _audioCtx->ch_layout;
-    } else {
-        // Fallback for older codecs that might not have channel layout set
+    av_channel_layout_uninit(&layout);
+
+    if (_audioCtx->ch_layout.nb_channels <= 0) {
+        throw EssentiaException("AudioLoader: Stream reports no audio channels");
+    }
+
+    if (_audioCtx->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC ||
+        !av_channel_layout_check(&_audioCtx->ch_layout)) {
         av_channel_layout_default(&layout, _audioCtx->ch_layout.nb_channels);
+    } else if (av_channel_layout_copy(&layout, &_audioCtx->ch_layout) < 0) {
+        throw EssentiaException("AudioLoader: Could not copy channel layout");
     }
 
     E_DEBUG(EAlgorithm, "AudioLoader: using sample format conversion from libswresample");
     _convertCtxAv = swr_alloc();
-        
+
     // Use modern channel layout API for swresample configuration
     av_opt_set_chlayout(_convertCtxAv, "in_chlayout", &layout, 0);
     av_opt_set_chlayout(_convertCtxAv, "out_chlayout", &layout, 0);
@@ -141,8 +150,20 @@ void AudioLoader::openAudioFile(const string& filename) {
     av_opt_set_int(_convertCtxAv, "in_sample_fmt", _audioCtx->sample_fmt, 0);
     av_opt_set_int(_convertCtxAv, "out_sample_fmt", AV_SAMPLE_FMT_FLT, 0);
 
-    if (swr_init(_convertCtxAv) < 0) {
-        throw EssentiaException("AudioLoader: Could not initialize swresample context");
+    // av_opt_set_chlayout() copies the layout, so our local copy can go now.
+    const int swrStatus = swr_init(_convertCtxAv);
+    av_channel_layout_uninit(&layout);
+
+    if (swrStatus < 0) {
+        char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+        av_strerror(swrStatus, errbuf, sizeof(errbuf));
+        ostringstream msg;
+        msg << "AudioLoader: Could not initialize swresample context: " << errbuf
+            << " (channels: " << _audioCtx->ch_layout.nb_channels
+            << ", layout order: " << (int)_audioCtx->ch_layout.order
+            << ", sample_rate: " << _audioCtx->sample_rate
+            << ", sample_fmt: " << (int)_audioCtx->sample_fmt << ")";
+        throw EssentiaException(msg.str());
     }
 
     av_init_packet(&_packet);


### PR DESCRIPTION
# AudioLoader: fix swresample init for unspecified channel layouts

## Problem

On current `master` (`b9fa6cb`), `MonoLoader` / `AudioLoader` fail on any file whose
container does not declare a channel layout — which includes ordinary WAV:

```
RuntimeError: Error while configuring MonoLoader:
AudioLoader: Could not initialize swresample context
```

followed by a segfault during teardown.

Reproduces with any plain PCM WAV. `ffprobe` shows the relevant part:

```
codec_name=pcm_s16le  sample_fmt=s16  sample_rate=48000  channels=2  channel_layout=unknown
```

## Cause

`AudioLoader::openAudioFile()` passes the decoder's channel layout straight to
libswresample:

```cpp
AVChannelLayout layout;
if (_audioCtx->ch_layout.nb_channels > 0) {
    layout = _audioCtx->ch_layout;
} else {
    av_channel_layout_default(&layout, _audioCtx->ch_layout.nb_channels);
}
...
av_opt_set_chlayout(_convertCtxAv, "in_chlayout",  &layout, 0);
av_opt_set_chlayout(_convertCtxAv, "out_chlayout", &layout, 0);
```

For WAV, `ch_layout.order` is `AV_CHANNEL_ORDER_UNSPEC`. `nb_channels` is 2, so the
first branch is taken and the unspecified layout is handed to swresample, which
rejects it — `swr_init()` returns `EINVAL`. The `else` branch cannot help either: it
is only reachable when `nb_channels <= 0`, and it then calls
`av_channel_layout_default()` with that same non-positive count.

Two smaller problems in the same block:

- `layout = _audioCtx->ch_layout` is a shallow struct copy. For a custom
  (`AV_CHANNEL_ORDER_CUSTOM`) layout this aliases the decoder's heap-allocated `u.map`
  rather than taking ownership of a copy; `av_channel_layout_copy()` is the supported way.
- `layout` is never uninitialised, so the copy leaks for custom layouts.

This code path arrived with the FFmpeg 7.x compatibility work in #1494; it appears the
`ch_layout` migration was only exercised against containers that declare a layout.

## Fix

- Derive the default layout for the channel count whenever the reported layout is
  `AV_CHANNEL_ORDER_UNSPEC` or fails `av_channel_layout_check()`, rather than only when
  the channel count is non-positive.
- Use `av_channel_layout_copy()` instead of a shallow assignment, and
  `av_channel_layout_uninit()` once `av_opt_set_chlayout()` has taken its own copy.
- Raise an explicit error when the stream reports no channels.
- Include `av_strerror()` text and the stream parameters in the exception message.

That last point is what actually identified the bug: the original bare message is
indistinguishable from the *other* way this fails, which is building against one FFmpeg
major and linking another. With the parameters printed, a mismatched build shows up
immediately as nonsense field values (`ch_layout.order` reading back as the sample rate),
whereas the real layout bug shows `Invalid argument` with correct-looking values.

## Testing

Built with `--lightweight=fftw,libsamplerate,libav --fft=FFTW --with-python` against
system FFmpeg 6.1.1 on Ubuntu, Python 3.12.

- `MonoLoader` on 48 kHz stereo PCM WAV: previously raised + segfaulted, now loads.
  Output matches `librosa.load(..., sr=16000, mono=True)` at r = 0.99997 over a 120 s file.
- `AudioLoader` returns the expected `(n, 2)` array, 48000 Hz, `pcm_s16le`, 1536 kb/s.
- `EqloudLoader`, `EasyLoader`, `Resample` all exercised on the same file.
- Files that *do* declare a layout are unaffected: the copy branch is taken as before.

I do not have an FFmpeg 7.x/8.x build to hand to confirm there, but the APIs used
(`av_channel_layout_check` / `_copy` / `_default` / `_uninit`) are all present from 5.1
onward, so the change should be version-neutral across the range this file already targets.
