### PR TITLE
build: use sysconfig instead of the removed distutils in the python bindings

### DIFF
--- a/src/python/wscript
+++ b/src/python/wscript
@@ -3,8 +3,8 @@
 
 from __future__ import print_function
 
-import distutils.sysconfig
 import os
+import sysconfig
 
 
 def options(ctx):
@@ -39,7 +39,7 @@ def build(ctx):
     print('→ building from ' + ctx.path.abspath())
 
     # gets the path from the active virtualenv
-    PYLIB = distutils.sysconfig.get_python_lib()
+    PYLIB = sysconfig.get_paths()['purelib']
 
     NUMPY_INCPATH = [ # importable numpy path
                       __import__('numpy').get_include(),


### PR DESCRIPTION
`distutils` was deprecated by [PEP 632](https://peps.python.org/pep-0632/) and **removed from the standard library in Python 3.12**, so `python waf configure --with-python` fails outright on any modern interpreter:

```
File "src/python/wscript", line 6, in <module>
    import distutils.sysconfig
ModuleNotFoundError: No module named 'distutils'
```

Both uses are `distutils.sysconfig.get_python_lib()`, whose documented replacement is `sysconfig.get_paths()['purelib']`. `sysconfig` has been in the standard library since Python 3.2, so this raises no minimum version for anyone still on older interpreters.

Tested by building the bindings from source on Python 3.14.

Two lines changed. Signed off per the DCO in the contribution guide; under the 20-line CLA threshold.
