### PR TITLE
fix(audioloader): set pkt_timebase so decoded frame timestamps are correct

### DIFF
--- a/src/algorithms/io/audioloader.cpp
+++ b/src/algorithms/io/audioloader.cpp
@@ -115,6 +115,13 @@ void AudioLoader::openAudioFile(const string& filename) {
         throw EssentiaException("AudioLoader: Could not copy codec parameters");
     }
 
+    // Tell the decoder what time base the packets we feed it are in. libavcodec needs this to
+    // report frame timestamps correctly -- in particular it advances frame->pts by however many
+    // samples it skipped (codec delay / pre-skip), and that adjustment is expressed in
+    // pkt_timebase. Left unset the adjustment is computed against an invalid time base, so
+    // frame->pts is wrong for every format that carries an encoder delay.
+    _audioCtx->pkt_timebase = _demuxCtx->streams[_streamIdx]->time_base;
+
     if (avcodec_open2(_audioCtx, _audioCodec, NULL) < 0) {
         avcodec_free_context(&_audioCtx);
         throw EssentiaException("AudioLoader: Unable to instantiate codec...");


### PR DESCRIPTION
`AVCodecContext::pkt_timebase` tells libavcodec the time base of the packets it is being fed. `AudioLoader` never sets it, so it stays at its `0/1` default.

libavcodec uses it whenever it has to move a timestamp by a sample count — most importantly when it discards a codec's initial padding (Opus pre-skip, AAC/MP3 encoder delay) and then advances `frame->pts` by the number of samples skipped. With an invalid `pkt_timebase` that adjustment is meaningless, so `frame->pts` does not correspond to the samples actually returned.

Nothing in `AudioLoader` consumed `frame->pts` before, which is why this has been invisible. It becomes load-bearing as soon as timestamps are used to locate the decoder in the stream — e.g. any seeking implementation (#771), which is how I found it.

**Measured:** on an Ogg Opus file the error is exactly the 312-sample (6.5 ms) Opus pre-skip. With this fix, decoded frame timestamps line up with the samples returned, and a seek-and-trim path becomes bit-identical to decode-and-discard on Ogg/Opus; without it, it is off by exactly the pre-skip.

Six lines added, none removed. Signed off per the DCO in the contribution guide; under the 20-line CLA threshold.
