### PR TITLE
fix(setup): do not crash reading the dev version when no git tag is reachable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,13 @@ def get_version():
         # Development version. Get the number of commits after the last release
         git_version = get_git_version()
         print('git describe:', git_version)
-        dev_commits = git_version.split('-')[-2] if git_version else ''
+        # `git describe --always --tags` only yields '<tag>-<commits>-g<sha>' when a tag is
+        # REACHABLE. With no tags in the clone -- the normal case for a fork, since GitHub does
+        # not copy tags, and for any shallow checkout -- `--always` falls back to a bare sha,
+        # which has no '-' to split on and made the [-2] index raise IndexError instead of
+        # reaching the graceful fallback immediately below.
+        describe_parts = git_version.split('-') if git_version else []
+        dev_commits = describe_parts[-2] if len(describe_parts) >= 2 else ''
         if not dev_commits.isdigit():
             print('Error parsing the number of dev commits: %s', dev_commits)
             dev_commits = '0'


### PR DESCRIPTION
`get_version()` in `setup.py` parses `git describe --always --tags` as `<tag>-<commits>-g<sha>` and takes `split('-')[-2]` as the commit count. That form only appears when a tag is **reachable from HEAD**.

When none is — the normal state of **a fork**, since GitHub does not copy tags, and of any shallow checkout — `--always` falls back to emitting a bare abbreviated sha, which contains no `-` at all, so the `[-2]` index raises:

```
git describe: 0b674bb1
  File "<string>", line 80, in get_version
IndexError: list index out of range
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

The wheel build fails during dependency resolution, before any compilation — so `cibuildwheel` is red on every job for anyone building from a fork.

The intent to degrade gracefully is already in the code: the very next lines fall back to `'0'` when the parsed value is not a digit. This patch only adds the length guard that lets that fallback actually be reached.

| `git describe` output | before | after |
| --- | --- | --- |
| `v2.1_beta5-1234-g0b674bb1` | `1234` | `1234` (unchanged) |
| `0b674bb1` (no tag reachable) | **IndexError** | `0` |
| empty / unavailable | `0` | `0` (unchanged) |

Behaviour with a tag reachable is identical; only the crash path changes.

Seven lines added, one removed. Signed off per the DCO in the contribution guide; under the 20-line CLA threshold.
