### PR TITLE
Fix Python streaming-mode memory leak: recursive deleteNetwork + disconnectNetwork API (#405)

### DIFF
--- a/src/essentia/scheduler/network.cpp
+++ b/src/essentia/scheduler/network.cpp
@@ -60,12 +60,39 @@ set<Algorithm*> visibleDependencies(const Algorithm* algo, bool logWarnings=true
 }
 
 void deleteNetwork(const streaming::Algorithm* algo) {
-  set<Algorithm*> dependencies = visibleDependencies(algo, false);
+  if (!algo) return;
 
-  for (set<Algorithm*>::iterator it = dependencies.begin(); it != dependencies.end(); ++it) {
+  // Collect the whole visible network reachable downstream of this algorithm,
+  // not only its first-level dependencies. Anything deeper (e.g. the second
+  // and further levels of a processing chain, or the PoolStorage/DevNull sink
+  // algorithms created by connecting a source to a Pool or to NOWHERE) would
+  // otherwise be leaked, which is what its documentation ("the algorithm
+  // together with all its visible dependencies") and its callers expect this
+  // function to delete.
+  set<const Algorithm*> visited;
+  stack<const Algorithm*> toVisit;
+  toVisit.push(algo);
+
+  while (!toVisit.empty()) {
+    const Algorithm* current = toVisit.top();
+    toVisit.pop();
+
+    if (visited.find(current) != visited.end()) continue;
+    visited.insert(current);
+
+    set<Algorithm*> dependencies = visibleDependencies(current, false);
+    for (set<Algorithm*>::iterator it = dependencies.begin(); it != dependencies.end(); ++it) {
+      if (visited.find(*it) == visited.end()) toVisit.push(*it);
+    }
+  }
+
+  // Deleting an algorithm automatically severs its remaining connections on
+  // both ends (Sources and Sinks disconnect themselves on destruction), so
+  // every algorithm is visited and deleted exactly once, in any order, even
+  // when the traversal contains diamond shapes.
+  for (set<const Algorithm*>::iterator it = visited.begin(); it != visited.end(); ++it) {
     delete *it;
   }
-  delete algo;
 }
 
 /**

--- a/src/python/essentia/streaming.py
+++ b/src/python/essentia/streaming.py
@@ -62,6 +62,13 @@ class _StreamConnector:
             # update connections
             left.output_algo.connections[left].append(right)
 
+            # also keep a back-reference on the sink algorithm: connections
+            # are C++-side, so a connected network must only ever be reclaimed
+            # as a whole. Without this, dropping all references to a source
+            # algorithm would let the garbage collector delete the underlying
+            # C++ network while sink algorithms are still referenced.
+            right.input_algo._upstream.append(left)
+
             return right
 
 
@@ -70,6 +77,12 @@ class _StreamConnector:
 
             # update connections
             left.output_algo.connections[left].append(right)
+
+            # back-reference, see above (a raw _essentia.StreamingAlgorithm
+            # has no instance dictionary, hence the getattr)
+            upstream = getattr(right, '_upstream', None)
+            if upstream is not None:
+                upstream.append(left)
 
             return right
 
@@ -114,6 +127,11 @@ class _StreamConnector:
 
         # call internal disconnect based on connector type
         if isinstance(connector, _StreamConnector):
+            # drop the back-reference that kept the source algorithm alive
+            upstream = getattr(connector.input_algo, '_upstream', None)
+            if upstream is not None and self in upstream:
+                upstream.remove(self)
+
             return _essentia.disconnect(self.output_algo, self.name, connector.input_algo, connector.name)
 
         elif isinstance(connector, tuple):
@@ -156,6 +174,13 @@ def _create_streaming_algo(givenname):
             # keys should be StreamConnectors (outputs) and values should be lists
             # of StreamConnectors/pool tuples/None (inputs)
             self.connections = {}
+
+            # _StreamConnectors of the sources that are connected to this
+            # algorithm's sinks (the reverse direction of 'connections'),
+            # appended to by _StreamConnector.__rshift__. This keeps every
+            # upstream algorithm alive for as long as this algorithm is, so
+            # that a connected network is only ever reclaimed as a whole.
+            self._upstream = []
 
             # populate instance members from sources and sinks
             # we don't descriminate b/w inputs and outputs at this point, put
@@ -314,3 +339,56 @@ class CompositeBase(object):
         elif self.hasInput(name):  return self.inputs[name]
         elif self.hasOutput(name): return self.outputs[name]
         raise NameError('The '+self.name()+ ' CompositeBase algorithm does not have a connector named \''+name+'\'')
+
+
+def disconnectNetwork(*algos):
+    '''Disconnect every connection of the streaming network(s) that contain the
+    given algorithm(s).
+
+    The network is walked in both directions (from sources down to sinks and
+    back up), so passing any single algorithm of a network -- for instance its
+    generator -- is enough to tear the whole network down. Severing a
+    connection immediately releases the C++ resources held by that connection
+    (among others, the internal PoolStorage algorithm that is created when a
+    source is connected to a Pool). Each algorithm then releases its own
+    resources (e.g. its output buffers) as soon as its Python object is
+    reclaimed.
+
+    Note that dropping all references to a network without calling this
+    function also releases all of its C++ resources, but only once the cyclic
+    garbage collector has run: streaming algorithm objects live in reference
+    cycles, so they are not reclaimed by reference counting alone. Call
+    gc.collect() to force immediate reclamation in either case.
+
+    This function accepts partially built networks and algorithms whose
+    connections were already severed; disconnecting is idempotent.
+    '''
+    toVisit = [algo for algo in algos if algo is not None]
+    # keep a strong reference to every visited algorithm so that ids stay
+    # unambiguous while we are still walking
+    visited = {}
+
+    while toVisit:
+        algo = toVisit.pop()
+        if id(algo) in visited: continue
+        visited[id(algo)] = algo
+
+        # walk upstream, so that the whole network is covered no matter which
+        # of its algorithms we were given
+        for source in list(getattr(algo, '_upstream', ())):
+            toVisit.append(source.output_algo)
+
+        # walk downstream, severing every connection on the way
+        connections = getattr(algo, 'connections', None)
+        if not connections: continue
+        for connector, targets in list(connections.items()):
+            for target in list(targets):
+                if isinstance(target, _StreamConnector):
+                    toVisit.append(target.input_algo)
+                    connector.disconnect(target)
+                elif isinstance(target, tuple) or target is None:
+                    connector.disconnect(target)
+                else:
+                    # a FileOutput algorithm: no disconnect is exposed for it,
+                    # it is reclaimed together with the rest of the network
+                    toVisit.append(target)

--- a/src/python/globalfuncs.cpp
+++ b/src/python/globalfuncs.cpp
@@ -799,6 +799,11 @@ static PyObject* fileOutputConnect(PyObject* notUsed, PyObject* args) {
 
   try {
     streaming::connect(sourceAlg->algo->output(sourceName), *fileout);
+
+    // the FileOutput is now connected to a network: it is not a generator
+    // anymore and will be deleted by the deleteNetwork call of its
+    // generator(s), exactly as in connect() above
+    sinkAlg->isGenerator = false;
   }
   catch (const exception& e) {
     PyErr_SetString(PyExc_TypeError, e.what());

--- a/src/python/pystreamingalgorithm.cpp
+++ b/src/python/pystreamingalgorithm.cpp
@@ -104,29 +104,25 @@ int PyStreamingAlgorithm::tp_init(PyStreamingAlgorithm *self, PyObject *args, Py
 
 // Deleting a streaming algorithm is not as simple as deleting the pointer. If
 // the algorithm is configured to be a generator algorithm (has only its
-// sources connected), then we need to call deleteNetwork on that algorithm.
-// If the algorithm is not connected to anything, we can safely delete it (we
-// can also call deleteNetwork on it). If
+// sources connected), then we need to call deleteNetwork on that algorithm,
+// which deletes the whole network reachable downstream of it (including the
+// PoolStorage/DevNull instances created when connecting a source to a Pool or
+// to NOWHERE, which have no Python proxy of their own). If
 // the algorithm has either both its sources and sinks connected, or just its
 // sinks, do not delete it, because it is connected to a network and will be
-// eventually deleted with the deleteNetwork function.
+// eventually deleted by the deleteNetwork call of its generator(s). The
+// Python layer (essentia/streaming.py) guarantees that a connected network is
+// only ever reclaimed as a whole: every connection also stores a
+// back-reference from the sink algorithm to the source connector, so no
+// algorithm of a network can be garbage-collected while any other part of the
+// network is still referenced.
 void PyStreamingAlgorithm::tp_dealloc (PyObject* obj) {
   PyStreamingAlgorithm* self = reinterpret_cast<PyStreamingAlgorithm*>(obj);
-  // FIXME: need to deallocate something here I guess...
-  
-  if (self->isGenerator) {
+
+  // self->algo can be NULL for a VectorInput whose inner C++ algorithm was
+  // never initialized (it is only created at connection time)
+  if (self->isGenerator && self->algo) {
     scheduler::deleteNetwork(self->algo);
-    
-    // Another way to do that is by creating a network and running its clear() method
-    /*    
-    try {
-      scheduler::Network(self->algo).clear();
-    }
-    catch (const exception& e) {
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      return;
-    }
-    */
   }
 
   Py_TYPE(self)->tp_free(obj);

--- a/src/python/pyvectorinput.cpp
+++ b/src/python/pyvectorinput.cpp
@@ -51,6 +51,11 @@ static int vectorinput_init(PyStreamingAlgorithm* self, PyObject *args, PyObject
   }
   Edt tp = stringToEdt( PyString_AS_STRING(argsV[1]) );
 
+  // A VectorInput has no sinks, so it is always a generator. Without this
+  // flag, tp_dealloc (shared with PyStreamingAlgorithm) never deletes the
+  // underlying C++ algorithm and every VectorInput leaks its data.
+  self->isGenerator = true;
+
   // NOTE:
   // Everywhere we use fromPythonCopy, we need to give ownership of that newly created variable to the
   // VectorInput instance, so that it knows it has to delete it later. This is done by using own=true in

--- a/test/src/unittests/streaming/test_network_teardown.py
+++ b/test/src/unittests/streaming/test_network_teardown.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2006-2021  Music Technology Group - Universitat Pompeu Fabra
+#
+# This file is part of Essentia
+#
+# Essentia is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the Affero GNU General Public License
+# version 3 along with this program. If not, see http://www.gnu.org/licenses/
+
+
+# Regression tests for https://github.com/MTG/essentia/issues/405 (memory leak
+# in streaming mode in python): dropping the Python proxies of a streaming
+# network must release the C++ side of the network as well -- the connection
+# ring buffers, the algorithms themselves, and the internal PoolStorage
+# algorithms created when connecting a source to a Pool.
+
+import gc
+import resource
+import sys
+
+from essentia_test import *
+from essentia.streaming import _StreamConnector, disconnectNetwork
+import essentia.streaming as es
+import numpy
+
+
+# ru_maxrss is expressed in kilobytes on Linux and in bytes on macOS/BSD
+_MAXRSS_TO_MB = 1024.0 if sys.platform.startswith('linux') else (1024.0 * 1024.0)
+
+
+def _highWaterMB():
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / _MAXRSS_TO_MB
+
+
+class TestNetworkTeardown(TestCase):
+
+    def _buildFanoutNetwork(self, pool, nbranches=8):
+        # A fan-out network with algorithms more than one connection away from
+        # the generator. The streaming Scale allocates a
+        # BufferUsage::forLargeAudioStream output buffer (4MB), so every
+        # branch that outlives its Python proxies is clearly visible in RSS.
+        gen = VectorInput(essentia.array(numpy.zeros(1024, dtype='float32')))
+        head = es.Scale(factor=1.0)
+        gen.data >> head.signal
+
+        branches = []
+        for i in range(nbranches):
+            scale = es.Scale(factor=1.0)
+            head.signal >> scale.signal
+            scale.signal >> (pool, 'branch_%d' % i)
+            branches.append(scale)
+
+        return gen, head, branches
+
+    def testRepeatedBuildAndDropDoesNotGrowRss(self):
+        # each dropped round used to retain ~4MB per branch (the C++ side of
+        # everything further than one connection from the generator was never
+        # deleted), so 10 rounds x 8 branches would grow the high-water mark
+        # by roughly 300MB. With the leak fixed the growth after the first
+        # round is zero; the assertion budget is kept deliberately generous so
+        # that unrelated allocator noise cannot make this test flaky.
+        rounds = 10
+        baseline = None
+        for i in range(rounds):
+            pool = Pool()
+            gen, head, branches = self._buildFanoutNetwork(pool)
+            del gen, head, branches, pool
+            # the proxies live in reference cycles, so they are reclaimed by
+            # the cyclic garbage collector, not by reference counting
+            gc.collect()
+            # take the baseline after the second round: the first rounds can
+            # bump the high-water mark once as the allocator warms up, and the
+            # high-water mark never comes back down
+            if i < 2:
+                baseline = _highWaterMB()
+
+        growth = _highWaterMB() - baseline
+        self.assertTrue(
+            growth < 40.0,
+            'high-water RSS grew by %.1f MB across %d build+drop rounds' % (growth, rounds))
+
+    def testRepeatedRunAndDropDoesNotGrowRss(self):
+        rounds = 10
+        baseline = None
+        expected = None
+        for i in range(rounds):
+            pool = Pool()
+            gen, head, branches = self._buildFanoutNetwork(pool)
+            run(gen)
+            result = pool['branch_0']
+            # teardown must not perturb the computed results
+            if expected is None:
+                expected = result
+            else:
+                self.assertEqualVector(result, expected)
+            del gen, head, branches, pool
+            gc.collect()
+            if i < 2:
+                baseline = _highWaterMB()
+
+        growth = _highWaterMB() - baseline
+        self.assertTrue(
+            growth < 40.0,
+            'high-water RSS grew by %.1f MB across %d run+drop rounds' % (growth, rounds))
+
+    def testRepeatedAlgorithmCreationDoesNotGrowRss(self):
+        # the original reproducer of MTG/essentia#405: unconnected streaming
+        # algorithms created in a loop
+        rounds = 300
+        baseline = None
+        for i in range(rounds):
+            algo = es.MFCC()
+            del algo
+            gc.collect()
+            if i < 2:
+                baseline = _highWaterMB()
+
+        growth = _highWaterMB() - baseline
+        self.assertTrue(
+            growth < 20.0,
+            'high-water RSS grew by %.1f MB across %d algorithm create+drop rounds' % (growth, rounds))
+
+    def testDisconnectNetworkSeversAllConnections(self):
+        pool = Pool()
+        gen, head, branches = self._buildFanoutNetwork(pool)
+
+        # passing any single algorithm of the network is enough
+        disconnectNetwork(branches[0])
+
+        for algo in [gen, head] + branches:
+            for connector, targets in algo.connections.items():
+                self.assertEqualVector(targets, [])
+            self.assertEqualVector(getattr(algo, '_upstream', []), [])
+
+    def testDisconnectNetworkIsIdempotentAndTolerant(self):
+        pool = Pool()
+        gen, head, branches = self._buildFanoutNetwork(pool)
+
+        # a partially severed network must not raise
+        head.signal.disconnect(branches[0].signal)
+        disconnectNetwork(gen)
+        disconnectNetwork(gen, head, None, *branches)
+
+        # unconnected and None algorithms must not raise either
+        disconnectNetwork(None)
+        disconnectNetwork(es.Scale())
+
+    def testNetworkStaysRunnableWhileAnyProxyIsReferenced(self):
+        # the sink side keeps the source side alive: dropping the explicit
+        # references to the upstream algorithms must not break the network as
+        # long as part of it is still referenced
+        pool = Pool()
+        gen, head, branches = self._buildFanoutNetwork(pool)
+        del head
+        gc.collect()
+
+        run(gen)
+        self.assertTrue(len(pool.descriptorNames()) == len(branches))
+
+    def testResultsUnchangedAfterExplicitTeardown(self):
+        data = essentia.array(numpy.arange(1024, dtype='float32'))
+
+        def computeOnce():
+            pool = Pool()
+            gen = VectorInput(data)
+            scale = es.Scale(factor=0.5)
+            gen.data >> scale.signal
+            scale.signal >> (pool, 'scaled')
+            run(gen)
+            result = pool['scaled']
+            disconnectNetwork(gen)
+            del gen, scale, pool
+            gc.collect()
+            return result
+
+        first = computeOnce()
+        second = computeOnce()
+        self.assertEqualVector(second, first)
+
+
+suite = allTests(TestNetworkTeardown)
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Fixes #405.

## Summary

Streaming networks built from Python leak all C++-side allocations that sit two or more connections downstream of the generator — algorithms, their `BufferUsage::forLargeAudioStream` ring buffers (~4 MB per source), and the `PoolStorage`/`DevNull` sink algorithms created by `poolConnect`/`nowhereConnect`, which have no Python proxy at all. A downstream production pipeline measured ~5 MiB leaked per connected branch at network-construction time (the leak exists for networks that are built and never run), growing linearly at +0.31 GiB per analysis chunk (R² = 0.99959). #405 was closed as not reproducible in 2018; a standalone reproducer is included in the test added here.

## Root cause

1. **`scheduler::deleteNetwork()` was not recursive** (`src/essentia/scheduler/network.cpp`): it deleted the algorithm plus its first-level dependencies only, while its doc comment, the Python bindings' `tp_dealloc`, and the C++ examples all assume whole-network deletion.
2. **`PyVectorInput` never set `isGenerator`**, so a VectorInput's C++ algorithm was never freed.
3. **`fileOutputConnect` didn't clear the sink's `isGenerator`** — a use-after-free trap once deleteNetwork walks the whole network.
4. **No Python-side upstream retention**: dropping a generator proxy while sink proxies were still alive could free C++ algorithms other proxies still pointed to.

## Changes

- `network.cpp`: `deleteNetwork()` now walks the entire visible network (deduplicated; Sources/Sinks unlink themselves on destruction, so shared nodes in multi-generator networks are deleted exactly once).
- `pyvectorinput.cpp`: sets `isGenerator = true`.
- `globalfuncs.cpp`: `fileOutputConnect` clears the sink's `isGenerator`.
- `pystreamingalgorithm.cpp`: `tp_dealloc` NULL-guard and corrected comments.
- `essentia/streaming.py`: `_upstream` back-references on connect/disconnect so a network is reclaimed only as a whole, plus a new public `essentia.streaming.disconnectNetwork(*algos)` — walks the network bidirectionally, severs every edge, idempotent, tolerant of partially-built networks.

## Measurements (A/B, identical build flags)

- Gated 20-branch MonoLoader fan-out reproducer, 5 build+drop rounds: **before +274.4 MiB (unbounded, ~3.4 MiB/branch/round) → after +0.1 MiB, flat**.
- 8-branch Scale fan-out build+drop probe, 10 rounds: **before +45.2 MiB/round → after +0.2 MiB total across rounds 2–10**.

## Tests

Adds `test/src/unittests/streaming/test_network_teardown.py` (7 tests): RSS-flatness for build+drop, run+drop, and an algorithm-churn loop matching the #405 report (via `resource.getrusage`, generous CI-stable thresholds, warm-up baseline); `disconnectNetwork` severs every edge and is idempotent; a network stays runnable while any of its proxies is referenced; results are byte-identical across teardown cycles. Existing streaming and base suites pass.

## Behavior notes for review

- Recursive `deleteNetwork` also changes behavior for C++ callers — in the direction the function's documentation and all in-tree callers already assume; the C++ examples calling it were leaking identically.
- With `_upstream` back-references, a network is retained while *any* of its proxies is referenced — deliberate, and strictly safer than the previous dangling-pointer behavior.
- Python proxies still live in reference cycles (the self-connector keys in `connections`), so reclamation is GC-driven rather than refcount-prompt. Breaking the cycle with weakrefs would break the legitimate `return loader.audio` pattern, so the cycle is left in place and `disconnectNetwork` documents the explicit-teardown option.
- FileOutput edges have no disconnect binding (pre-existing FIXME); they are reclaimed via the GC path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYAJgSs6cBVq9JntGUHu8
