### PR TITLE
Make RhythmExtractor2013 and MusicExtractor deterministic (#1097, #1006)

### DIFF
--- a/src/algorithms/rhythm/tempotapdegara.cpp
+++ b/src/algorithms/rhythm/tempotapdegara.cpp
@@ -20,6 +20,7 @@
 #include "tempotapdegara.h"
 #include "essentiamath.h"
 #include <limits>
+#include <random>
 
 using namespace std;
 
@@ -427,10 +428,20 @@ void TempoTapDegara::computeBeatPeriodsDavies(vector<Real> detections,
   _frameCutter->reset();  // TODO reset here for consequent signal inputs, or should the user do it always?
 
   _numberFramesODF = observations.size();
-  // Add noise
+  // Add low-amplitude noise to break ties in the Viterbi path search.
+  // Use a fixed-seed PRNG, re-seeded on every compute, so that repeated
+  // analyses of the same audio produce bitwise-identical results
+  // (https://github.com/MTG/essentia/issues/1097). The previous
+  // implementation used the process-global rand(), whose state advances
+  // across calls, making the output depend on how many times the algorithm
+  // (or anything else using rand()) had run before in the same process.
+  // std::mt19937 with a fixed seed is fully specified by the C++ standard,
+  // so the generated noise is also identical across platforms.
+  std::mt19937 rng(83);
   for (size_t t=0; t<_numberFramesODF; ++t) {
     for (int i=0; i<_hopSizeODF; ++i) {
-      observations[t][i] += 0.0001 * observationsMax * (Real) rand() / RAND_MAX;
+      observations[t][i] += 0.0001 * observationsMax *
+          (Real) rng() / (Real) std::mt19937::max();
     }
   }
 

--- a/src/algorithms/standard/framecutter.cpp
+++ b/src/algorithms/standard/framecutter.cpp
@@ -158,6 +158,9 @@ const char* FrameCutter::description = DOC("This algorithm slices the input stre
 
 void FrameCutter::reset() {
   Algorithm::reset();
+  // Re-seed the internal noise generator so that a reused (reset) instance
+  // produces the same frames as a fresh one (determinism across resets).
+  _noiseAdder->reset();
   //_reschedule = false;
   _streamIndex = 0;
   if (_startFromZero) _startIndex = 0;
@@ -201,8 +204,12 @@ void FrameCutter::configure() {
   // Adding noise to avoid divisions by zero (in case the user chooses to do so
   // by setting the silentFrames parameter to ADD_NOISE).  The level of such noise
   // is chosen to be -100dB because it will still be detected as a silent frame
-  // by essentia::isSilent() and is unhearable by humans
-  _noiseAdder->configure("fixSeed", false, "level", -100);
+  // by essentia::isSilent() and is unhearable by humans.
+  // Use a fixed seed so that analysis results are reproducible across runs
+  // (https://github.com/MTG/essentia/issues/1006): with a time-based seed,
+  // any extractor relying on silentFrames="noise" (e.g. MusicExtractor)
+  // returned different values on every execution.
+  _noiseAdder->configure("fixSeed", true, "level", -100);
   reset();
 }
 

--- a/src/algorithms/standard/noiseadder.cpp
+++ b/src/algorithms/standard/noiseadder.cpp
@@ -36,11 +36,22 @@ const char* NoiseAdder::description = DOC("This algorithm adds noise to an input
 
 void NoiseAdder::configure() {
   _level = db2pow(parameter("level").toReal());
-  if (parameter("fixSeed").toBool()) {
+  _fixSeed = parameter("fixSeed").toBool();
+  if (_fixSeed) {
     unsigned long seed = 0;
     _mtrand.seed(seed);
   }
 
+}
+
+void NoiseAdder::reset() {
+  Algorithm::reset();
+  // Re-seed on reset when a fixed seed is requested, so that a reused
+  // (reset) instance generates the same noise sequence as a fresh one.
+  if (_fixSeed) {
+    unsigned long seed = 0;
+    _mtrand.seed(seed);
+  }
 }
 
 void NoiseAdder::compute() {

--- a/src/algorithms/standard/noiseadder.h
+++ b/src/algorithms/standard/noiseadder.h
@@ -48,11 +48,14 @@ class NoiseAdder : public Algorithm {
 #endif
 
   Real _level;
+  bool _fixSeed;
 
  public:
   NoiseAdder()
 #ifdef CPP_11
-      : _mtrand(time(NULL) ^ clock())
+      : _mtrand(time(NULL) ^ clock()), _fixSeed(false)
+#else
+      : _fixSeed(false)
 #endif
   {
     declareInput(_signal, "signal", "the input signal");
@@ -66,6 +69,7 @@ class NoiseAdder : public Algorithm {
 
   void configure();
   void compute();
+  void reset();
 
   static const char* name;
   static const char* category;

--- a/test/src/unittests/rhythm/test_rhythmextractor2013.py
+++ b/test/src/unittests/rhythm/test_rhythmextractor2013.py
@@ -173,6 +173,59 @@ class TestRhythmExtractor2013(TestCase):
         for i in range(len(estimates)):
             self.assertAlmostEqual(estimates[i], expectedBpm, 5.0)
 
+    def _createClickTrack(self, dur=20.0, bpm=120.0, sr=44100):
+        # A music-like synthetic signal: short decaying 1 kHz clicks every
+        # 60/bpm seconds plus a low-level fixed-seed noise floor, so that
+        # onset detection gets realistic input. Fully deterministic
+        # (fixed-seed numpy generator, no audio files needed).
+        rng = numpy.random.RandomState(42)
+        signal = ((rng.rand(int(sr*dur)) * 2 - 1) * 1e-4).astype(numpy.float32)
+        clickDur = int(0.03*sr)
+        t = numpy.arange(clickDur, dtype=numpy.float32) / sr
+        click = (numpy.sin(2*numpy.pi*1000.*t) * numpy.exp(-t/0.005)).astype(numpy.float32)
+        period = int(sr*60./bpm)
+        for start in range(0, len(signal) - clickDur, period):
+            signal[start:start+clickDur] += 0.9*click
+        return signal
+
+    def _assertBitwiseEqualResults(self, result, expected):
+        # exact equality, no tolerance
+        self.assertEqual(result[0], expected[0])                     # bpm
+        self.assertTrue(numpy.array_equal(result[1], expected[1]))   # ticks
+        self.assertEqual(result[2], expected[2])                     # confidence
+        self.assertTrue(numpy.array_equal(result[3], expected[3]))   # estimates
+        self.assertTrue(numpy.array_equal(result[4], expected[4]))   # bpmIntervals
+
+    def _assertDeterministic(self, method, numFreshRuns, numReusedRuns):
+        # Regression test for https://github.com/MTG/essentia/issues/1097:
+        # TempoTapDegara used to draw its Viterbi tie-breaking noise from the
+        # process-global, never-seeded rand(), so repeated analyses of the
+        # same audio within one process could return different
+        # bpm/ticks/confidence. All outputs must now be bitwise identical
+        # across repeated computes, both with fresh instances and when
+        # reusing one instance.
+        audio = self._createClickTrack()
+
+        results = []
+        for _ in range(numFreshRuns):
+            results.append(RhythmExtractor2013(method=method)(audio))
+
+        extractor = RhythmExtractor2013(method=method)
+        for _ in range(numReusedRuns):
+            results.append(extractor(audio))
+
+        # sanity check: the click track is correctly detected at 120 bpm
+        self.assertTrue(abs(results[0][0] - 120.) < 2.)
+
+        for result in results[1:]:
+            self._assertBitwiseEqualResults(result, results[0])
+
+    def testDeterministicMultifeature(self):
+        self._assertDeterministic("multifeature", numFreshRuns=5, numReusedRuns=5)
+
+    def testDeterministicDegara(self):
+        self._assertDeterministic("degara", numFreshRuns=3, numReusedRuns=3)
+
 
 suite = allTests(TestRhythmExtractor2013)
 

--- a/test/src/unittests/standard/test_framecutter_streaming.py
+++ b/test/src/unittests/standard/test_framecutter_streaming.py
@@ -501,6 +501,65 @@ class TestFrameCutter_Streaming(TestCase):
         run(gen)
         self.assertTrue(len(pool.descriptorNames())==0)
 
+    def _cutSilentFramesWithNoise(self, input):
+        # Runs a fresh streaming FrameCutter with silentFrames="noise" over
+        # the given input and returns the resulting frames as a numpy matrix.
+        gen = VectorInput(input)
+        pool = Pool()
+        frameCutter = es.FrameCutter(frameSize = 1024,
+                                     hopSize = 512,
+                                     startFromZero = True,
+                                     silentFrames = "noise")
+        gen.data >> frameCutter.signal
+        frameCutter.frame >> (pool, 'frames')
+        run(gen)
+        return numpy.array(pool['frames'])
+
+    def testSilentFramesNoiseDeterministic(self):
+        # Regression test for https://github.com/MTG/essentia/issues/1006:
+        # the noise injected into silent frames (silentFrames="noise", the
+        # default) used to be seeded from time(NULL) ^ clock(), so every run
+        # produced different frames and every descriptor computed over
+        # silence was irreproducible. The noise must now be a fixed
+        # pseudorandom sequence: two identical runs must produce bitwise
+        # identical frames.
+        input = [0.]*44100  # 1 second of silence
+
+        frames1 = self._cutSilentFramesWithNoise(input)
+        frames2 = self._cutSilentFramesWithNoise(input)
+
+        self.assertEqual(frames1.shape, frames2.shape)
+        # bitwise identity, no tolerance
+        self.assertTrue(numpy.array_equal(frames1, frames2))
+        # sanity check: the frames do contain noise (not silence)
+        self.assertTrue((frames1 != 0).any())
+
+    def testSilentFramesNoiseDeterministicAfterReset(self):
+        # A reused (reset) FrameCutter must produce the same frames as a
+        # fresh one: FrameCutter::reset() re-seeds its internal NoiseAdder.
+        input = [0.]*44100  # 1 second of silence
+        gen = VectorInput(input)
+        pool = Pool()
+        frameCutter = es.FrameCutter(frameSize = 1024,
+                                     hopSize = 512,
+                                     startFromZero = True,
+                                     silentFrames = "noise")
+        gen.data >> frameCutter.signal
+        frameCutter.frame >> (pool, 'frames')
+
+        run(gen)
+        frames1 = numpy.array(pool['frames'])
+
+        pool.remove('frames')
+        reset(gen)
+
+        run(gen)
+        frames2 = numpy.array(pool['frames'])
+
+        self.assertEqual(frames1.shape, frames2.shape)
+        # bitwise identity, no tolerance
+        self.assertTrue(numpy.array_equal(frames1, frames2))
+        self.assertTrue((frames1 != 0).any())
 
 
 suite = allTests(TestFrameCutter_Streaming)

--- a/test/src/unittests/standard/test_noiseadder.py
+++ b/test/src/unittests/standard/test_noiseadder.py
@@ -60,6 +60,27 @@ class TestNoiseAdder(TestCase):
         for i in range(10):
             self.assertNotEqual(a[i], b[i])
 
+    def testFixSeedDefault(self):
+        # The documented default of the public algorithm is fixSeed=false
+        # (time-based seed); only FrameCutter's internal instance uses
+        # fixSeed=true. Make sure the default was not changed by accident.
+        self.assertEqual(NoiseAdder().paramValue('fixSeed'), False)
+
+    def testFixSeedReset(self):
+        # With fixSeed=true, reset() must re-seed the generator so that a
+        # reused (reset) instance produces exactly the same noise sequence
+        # as a fresh one.
+        ng = NoiseAdder(fixSeed=True)
+        a = ng(zeros(1000))
+        ng.reset()
+        b = ng(zeros(1000))
+        self.assertEqualVector(a, b)
+
+        # Without a reset the generator keeps advancing: the next compute
+        # must continue the sequence, not restart it.
+        c = ng(zeros(1000))
+        self.assertTrue(any(b[i] != c[i] for i in range(1000)))
+
 
 
 suite = allTests(TestNoiseAdder)


### PR DESCRIPTION
Fixes #1097. Also addresses the within-platform component of #1006 (cross-platform float variation from FFT backends/libm remains out of scope).

## Root causes (two independent unseeded RNGs)

1. `TempoTapDegara` adds tie-breaking noise to its Viterbi observation matrix drawn from the process-global, never-seeded `rand()` (`tempotapdegara.cpp`). Reproduced: 2 of 25 corpus files gave 2 distinct bitwise outputs across repeated in-process runs (12/175 runs mismatched), with both fresh and reused instances — `reset()` is irrelevant. Affects both `multifeature` (5 instances) and `degara`.
2. Streaming `FrameCutter` hardcodes its internal NoiseAdder to `fixSeed=false`, seeded with `time(NULL) ^ clock()`. With `silentFrames="noise"` (the default in MusicExtractor's lowlevel/tonal chains), 19/19 runs on 1 s of silence differed; 4 end-to-end MusicExtractor runs gave 4 different pool digests — matching the diagnosis already suggested in the #1006 thread.

Ruled out: FFTW planning (all plans use deterministic `FFTW_ESTIMATE`), other `rand()`/unordered-container use in these chains.

## Changes

- TempoTapDegara: noise drawn from a fixed-seed `std::mt19937` constructed anew each compute (bit-portable per the C++ standard; tie-breaking preserved).
- FrameCutter: internal NoiseAdder configured with `fixSeed=true`; NoiseAdder gains a `reset()` that re-seeds under `fixSeed`, called from `FrameCutter::reset()` so reused instances match fresh ones. The standalone NoiseAdder default is unchanged.
- Tests: 6 new determinism tests (FrameCutter silent-noise bitwise-identical across instances and across `reset()`; NoiseAdder re-seed; RhythmExtractor2013 bitwise-identical over repeated multifeature/degara runs on a synthetic click track). The FrameCutter/NoiseAdder tests fail before the fix; the rhythm tests pin the fixed behavior (the old noise only flipped near-tie Viterbi states on real music, which a clean click track does not trigger — stated in the commit body).

## Verification

After the fix: 25 files × 8 runs, 0 mismatches; 60 runs on each previously-failing file collapse to 1 unique output; 3 separate processes bitwise-identical. 23/25 corpus files match the pre-fix output exactly; the 2 that differ are precisely the previously unstable ones. Audio with silent frames differs from the previously randomly-varying results by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYAJgSs6cBVq9JntGUHu8
