### PR TITLE
Fix Trimmer sample-position drift past 2^24 samples (#1529)

### DIFF
--- a/src/algorithms/standard/trimmer.cpp
+++ b/src/algorithms/standard/trimmer.cpp
@@ -31,9 +31,17 @@ const char* Trimmer::description = DOC("This algorithm extracts a segment of an 
 "Giving \"startTime\" greater than \"endTime\" will raise an exception.");
 
 void Trimmer::configure() {
-  Real sampleRate = parameter("sampleRate").toReal();
-  _startIndex = (long long)(parameter("startTime").toReal() * sampleRate);
-  _endIndex = (long long)(parameter("endTime").toReal() * sampleRate);
+  // Convert seconds to samples in double precision: a float32 product drifts
+  // off the sample grid past 2^24 samples (~380 s at 44.1 kHz). The parameter
+  // values themselves are stored as Real (float32), so we widen them once and
+  // round once to the nearest sample (llrint, ties-to-even in the default
+  // rounding mode) so that a seconds value carrying float32 representation
+  // error still lands on the intended sample; truncation would fall one
+  // sample short whenever float32 stores the seconds value slightly below
+  // the intended instant.
+  double sampleRate = (double)parameter("sampleRate").toReal();
+  _startIndex = llrint((double)parameter("startTime").toReal() * sampleRate);
+  _endIndex = llrint((double)parameter("endTime").toReal() * sampleRate);
   if (_startIndex > _endIndex) {
     throw EssentiaException("Trimmer: startTime cannot be larger than endTime.");
   }
@@ -72,9 +80,12 @@ const char* Trimmer::category = essentia::standard::Trimmer::category;
 const char* Trimmer::description = essentia::standard::Trimmer::description;
 
 void Trimmer::configure() {
-  Real sampleRate = parameter("sampleRate").toReal();
-  _startIndex = (long long)(parameter("startTime").toReal() * sampleRate);
-  _endIndex = (long long)(parameter("endTime").toReal() * sampleRate);
+  // See standard::Trimmer::configure(): seconds->samples in double, rounded
+  // once to the nearest sample (llrint), to stay on the sample grid past
+  // 2^24 samples.
+  double sampleRate = (double)parameter("sampleRate").toReal();
+  _startIndex = llrint((double)parameter("startTime").toReal() * sampleRate);
+  _endIndex = llrint((double)parameter("endTime").toReal() * sampleRate);
   if (_startIndex > _endIndex) {
     throw EssentiaException("Trimmer: startTime cannot be larger than endTime.");
   }

--- a/test/src/unittests/standard/test_trimmer_streaming.py
+++ b/test/src/unittests/standard/test_trimmer_streaming.py
@@ -21,6 +21,7 @@
 
 from essentia_test import *
 from essentia.streaming import Trimmer
+import essentia.standard
 
 class TestTrimmer_Streaming(TestCase):
 
@@ -66,6 +67,70 @@ class TestTrimmer_Streaming(TestCase):
         self.assertConfigureFails(Trimmer(), {'endTime' : -1.0})
         self.assertConfigureFails(Trimmer(), {'startTime' : 1.0,
                                               'endTime' : 0})
+
+    # --- sample-precision regression tests (upstream issue 1529 on MTG/essentia) ---
+    #
+    # Trimmer used to compute startTime*sampleRate in Real (float32). Past
+    # 2^24 samples (~380.4 s at 44.1 kHz) the float32 grid spacing exceeds one
+    # sample, so cut points drifted: at 3090 s the float32 product is
+    # 136268992 instead of 136269000 (-8 samples). The conversion must be done
+    # in double and rounded once to the nearest sample.
+    #
+    # The test signal is a ramp where sample i has value i % MOD, so the value
+    # of the first/last output sample encodes its absolute position exactly
+    # (MOD is far below 2^24, so every value is exact in float32, unlike a
+    # plain ramp whose values would themselves collapse onto the float32 grid
+    # at these positions and mask the error being tested).
+
+    MOD = 1 << 20
+
+    def _rampSignal(self, size):
+        # built in bounded chunks to avoid a second full-size int64 array
+        sig = numpy.empty(size, dtype=numpy.float32)
+        chunk = 1 << 22
+        for offset in range(0, size, chunk):
+            n = min(chunk, size - offset)
+            idx = numpy.arange(offset, offset + n, dtype=numpy.int64)
+            sig[offset:offset+n] = (idx % self.MOD).astype(numpy.float32)
+        return sig
+
+    def _assertExactSlice(self, found, startSample, numSamples):
+        found = numpy.asarray(found)
+        self.assertEqual(len(found), numSamples)
+        expectedFirst = startSample % self.MOD
+        expectedLast = (startSample + numSamples - 1) % self.MOD
+        self.assertEqual(found[0], expectedFirst)
+        self.assertEqual(found[-1], expectedLast)
+        idx = numpy.arange(startSample, startSample + numSamples, dtype=numpy.int64)
+        expected = (idx % self.MOD).astype(numpy.float32)
+        self.assertTrue(numpy.array_equal(found, expected))
+
+    def testLongOffsetSamplePrecisionStreaming(self):
+        # trimming a 30 s window at 3090 s must start at exactly sample
+        # 136269000 and produce exactly 1323000 samples
+        sr = 44100
+        startSample = 3090 * sr    # 136269000
+        numSamples = 30 * sr       # 1323000
+        signal = self._rampSignal(startSample + numSamples + sr)
+
+        gen = VectorInput(signal)
+        pool = Pool()
+        trim = Trimmer(startTime=3090.0, endTime=3120.0, sampleRate=sr)
+        gen.data >> trim.signal
+        trim.signal >> (pool, 'slice')
+        run(gen)
+
+        self._assertExactSlice(pool['slice'], startSample, numSamples)
+
+    def testLongOffsetSamplePrecisionStandard(self):
+        sr = 44100
+        startSample = 3090 * sr    # 136269000
+        numSamples = 30 * sr       # 1323000
+        signal = self._rampSignal(startSample + numSamples + sr)
+
+        trim = essentia.standard.Trimmer(startTime=3090.0, endTime=3120.0,
+                                         sampleRate=sr)
+        self._assertExactSlice(trim(signal), startSample, numSamples)
 
     def testEmpty(self):
         gen = VectorInput([])


### PR DESCRIPTION
Fixes #1529.

## Summary

`Trimmer` converts `startTime`/`endTime` to sample positions by multiplying in `Real` (float32). Past 2^24 samples (380.4 s at 44.1 kHz) the float32 grid spacing exceeds one sample, so cut points drift off the requested sample grid — measured −8 samples at 3,090 s and −40 samples at 12 h, with grid spacing reaching 128 samples. Both `configure()` methods (standard + streaming) now widen the stored parameter values to `double` before multiplying by `sampleRate` and round once with `llrint`; the internal indices were already `long long`.

## Why llrint (ties-to-even), not llround

A first attempt with `llround` broke the existing `testDecimalSlice`: `endTime=25.25` at sampleRate 10 is an exact .5 tie (252.5) that historical truncation resolved to 252. `llrint` preserves that boundary while fixing the drift, and also repairs a latent truncation off-by-one for float32-stored seconds slightly below the intended instant (0.7 s × 44100 → 30870, not 30869).

## Precision boundary (stated, not hidden)

Parameters are stored as `Real`, so seconds values that are not float32-representable remain quantized at parameter storage (up to ~11 samples at 3,090 s at 44.1 kHz). Float32-representable inputs — integer seconds, the practical case — are now sample-exact. A double-precision parameter path would be a separate, larger change.

## Tests & verification

Two regression tests (standard + streaming) trim [3090 s, 3120 s] at 44.1 kHz from a ramp whose sample i encodes i mod 2^20 (a plain ramp's values would themselves collapse onto the float32 grid and mask the drift). Pre-fix: slice starts at sample 136,268,992 (−8) with length 1,323,008 (+8). Post-fix: starts at exactly 136,269,000 with exactly 1,323,000 samples. Full trimmer suite passes; the affected loader suites pass.

## Same pattern elsewhere (follow-up candidates, unchanged here)

StereoTrimmer (identical conversion), Slicer (`int(t*sr+0.5)` in Real, plus an int overflow hazard), StartStopCut, GapsDetector, Chromaprinter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYAJgSs6cBVq9JntGUHu8
