### PR TITLE
Fix OnsetDetectionGlobal output buffer overflow on long audio — RhythmExtractor2013 fails past ~63 min (#1528)

### DIFF
--- a/src/algorithms/rhythm/onsetdetectionglobal.cpp
+++ b/src/algorithms/rhythm/onsetdetectionglobal.cpp
@@ -470,8 +470,9 @@ OnsetDetectionGlobal::OnsetDetectionGlobal() : AlgorithmComposite() {
   //_onsetDetections.setBufferType(BufferUsage::forMultipleFrames); // too small
   
   // estimation for required buffer size: 1sec = 44100 samples ~ 87 frames
-  // we want to cover recordings up to 60 min = 3600secs = 310078 frames
-   _onsetDetections.setBufferInfo(BufferInfo(327680, 163840)); // too large?
+  // the default size covers recordings up to ~60 min (at the default hopSize
+  // of 512); process() grows the buffer on the fly for longer inputs
+  _onsetDetections.setBufferInfo(BufferInfo(327680, 163840));
 
   _signal >> _poolStorage->input("data"); // attach input proxy
 }
@@ -495,6 +496,20 @@ AlgorithmStatus OnsetDetectionGlobal::process() {
   _onsetDetectionGlobal->input("signal").set(_pool.value<vector<Real> >("internal.signal"));
   _onsetDetectionGlobal->output("onsetDetections").set(detections);
   _onsetDetectionGlobal->compute();
+
+  // All detection values are pushed to the output at once, while consumers
+  // can only run after this process() returns. Therefore, the output buffer
+  // must be able to hold the entire detection function. The default buffer
+  // size (see the constructor) only covers ~60 minutes of audio at the
+  // default hopSize of 512, and longer inputs used to abort with a "buffer
+  // is full" exception. Grow the buffer to fit the actual number of values.
+  // Resizing is safe at this point because nothing has been pushed to this
+  // source yet, so the buffer is empty.
+  BufferInfo info = _onsetDetections.bufferInfo();
+  if ((int)detections.size() > info.size) {
+    info.size = detections.size();
+    _onsetDetections.setBufferInfo(info);
+  }
 
   for (size_t i=0; i<detections.size(); ++i) {
     _onsetDetections.push(detections[i]);

--- a/test/src/unittests/rhythm/test_onsetdetectionglobal.py
+++ b/test/src/unittests/rhythm/test_onsetdetectionglobal.py
@@ -64,6 +64,39 @@ class TestOnsetDetectionGlobal(TestCase):
         self.assertAlmostEqualVectorFixedPrecision(calculated_beat_emphasis, expected_beat_emphasis,2)
         self.assertAlmostEqualVectorFixedPrecision(calculated_infogain, expected_infogain,2)
 
+    def testLongInputStreamingBufferResize(self):
+        # Regression test for the output buffer overflow on long audio inputs
+        # (RhythmExtractor2013/BeatTrackerMultiFeature failing with
+        # "OnsetDetectionGlobal::onsetDetections: Could not push 1 value,
+        # output buffer is full"). The streaming OnsetDetectionGlobal pushes
+        # the whole detection function at once, and its output buffer used to
+        # have a fixed capacity of 327680 values (~63 min of audio at the
+        # default hopSize of 512). Use a small hopSize so that the number of
+        # ODF frames exceeds the old capacity with a moderately-sized input
+        # instead of an hour-long one (the buffer capacity is defined in
+        # frames, independently of hopSize).
+        from essentia.streaming import OnsetDetectionGlobal as strOnsetDetectionGlobal
+
+        hopSize = 128
+        frameSize = 256
+        # yields 327690 ODF frames, just above the old capacity of 327680
+        # (note: not 327681, as a number of frames equal to 1 modulo the
+        # buffer's maxContiguousElements of 163840 triggers an unrelated
+        # pre-existing PoolStorage issue mixing Pool::append and Pool::set)
+        nSamples = 327691 * hopSize
+
+        gen = VectorInput(zeros(nSamples))
+        odg = strOnsetDetectionGlobal(method='infogain', frameSize=frameSize, hopSize=hopSize)
+        p = Pool()
+
+        gen.data >> odg.signal
+        odg.onsetDetections >> (p, 'odf')
+
+        # this used to raise RuntimeError: output buffer is full
+        run(gen)
+
+        self.assertTrue(len(p['odf']) > 327680)
+
 
 suite=allTests(TestOnsetDetectionGlobal)
 


### PR DESCRIPTION
Fixes #1528.

## Root cause

`streaming::OnsetDetectionGlobal` accumulates the whole signal, computes the entire onset detection function at end-of-stream, and pushes every value in a single `process()` call — before any consumer can run. Its output buffer is hard-coded in the constructor at `BufferInfo(327680, 163840)`: a fixed 327,680-token capacity ≈ **63.4 minutes** at the default hopSize 512. Anything longer throws `OnsetDetectionGlobal::onsetDetections: Could not push 1 value, output buffer is full`, killing `RhythmExtractor2013(method="multifeature")` (which uses this algorithm twice via `BeatTrackerMultiFeature`). `BeatTrackerDegara` is unaffected.

The measured threshold is exact: 327,680 ODF frames succeed, 327,681 overflow — 3804.39 s OK vs 3804.40 s RuntimeError at defaults, verified at hop 128 and hop 512.

## Fix

In `process()`, after computing the ODF and before pushing, grow the output buffer to `detections.size()` when it exceeds the current capacity — safe at that point (the buffer is empty), and the same information-driven sizing approach as `Resample::configure()`. Same class of fix as the old ChordsDetection buffer issues (#24, #99, #161). Defaults are unchanged, so short inputs are untouched.

## Verification

- A 3810 s synthetic 120 BPM click track that fails with the issue's exact error on master returns bpm=120.01, confidence 3.85, 7,619 ticks with the fix; verified up to 700,000 frames (2.1× the old cap).
- A/B byte-identity: multifeature outputs (bpm/ticks/confidence/estimates/intervals) on 60 s and 600 s inputs are bit-identical between unfixed and fixed builds — the change affects capacity only.
- Regression test added (`testLongInputStreamingBufferResize`, ~40 s runtime via hopSize 128): fails with the exact error on master, passes with the fix. Full rhythm suites otherwise identical to master.

## Incidental finding (documented, not fixed here)

A pre-existing `PoolStorage` quirk: a source with `releaseSize==0` connected directly to a Pool mixes `Pool::append` with `Pool::set`, throwing a "different data type" error whenever the total token count ≡ 1 mod 163,840 — reproducible on master below the old capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWYAJgSs6cBVq9JntGUHu8
